### PR TITLE
Make <=> work as expected with strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ obj/**/*.o
 .build
 test/tmp
 coverage-report
+
+# Editor tools
+.ccls
+compile_commands.json
+tags

--- a/lib/natalie/repl.rb
+++ b/lib/natalie/repl.rb
@@ -14,32 +14,52 @@ end
 
 module Natalie
   class Repl
+    def initialize
+      @to_clean_up = []
+      @var_decls = {}
+      # Readline.completion_proc = self.method(:completion)
+    end
+
     def go
-      to_clean_up = []
       env = nil
-      vars = {}
       loop do
-        break unless (line = get_line)
-        ast = Natalie::Parser.new(line, '(repl)').ast
-        last_node = ast.pop
-        ast << last_node.new(:call, nil, 'puts', s(:call, s(:lasgn, :_, last_node), 'inspect'))
-        out = Tempfile.create('natalie.so')
-        to_clean_up << out
-        compiler = Compiler.new(ast, '(repl)')
-        compiler.repl = true
-        compiler.vars = vars
-        compiler.out_path = out.path
-        compiler.compile
-        vars = compiler.context[:vars]
-        lib = Fiddle.dlopen(out.path)
-        env ||= Fiddle::Function.new(lib['build_top_env'], [], Fiddle::TYPE_VOIDP).call
-        eval_func = Fiddle::Function.new(lib['EVAL'], [Fiddle::TYPE_VOIDP], Fiddle::TYPE_VOIDP)
-        eval_func.call(env)
+
+          break unless (line = get_line)
+          out = Tempfile.create('natalie.so')
+          do_compile(line, out) 
+          lib = Fiddle.dlopen(out.path)
+          env ||= Fiddle::Function.new(lib['build_top_env'], [], Fiddle::TYPE_VOIDP).call
+          eval_func = Fiddle::Function.new(lib['EVAL'], [Fiddle::TYPE_VOIDP], Fiddle::TYPE_VOIDP)
+          eval_func.call(env)
       end
-      to_clean_up.each { |f| File.unlink(f.path) }
+    rescue Interrupt => e
+      system('stty', `stty -g`.chomp)
+      exit
+    ensure
+      @to_clean_up.each { |f| File.unlink(f.path) }
     end
 
     private
+
+    def do_compile(line, outfile)
+      ast = Natalie::Parser.new(line, '(repl)').ast
+      last_node = ast.pop
+      ast << last_node.new(:call, nil, 'puts', s(:call, s(:lasgn, :_, last_node), 'inspect'))
+      
+      @to_clean_up << outfile
+      
+      compiler = Compiler.new(ast, '(repl)')
+      compiler.repl = true
+      compiler.vars = @var_decls
+      compiler.out_path = outfile.path
+      compiler.compile
+      
+      @var_decls = compiler.context[:vars]
+    end
+
+    def completion(str)
+      # TODO
+    end
 
     def get_line
       line = Readline.readline('nat> ', true)

--- a/src/string.c
+++ b/src/string.c
@@ -101,7 +101,16 @@ NatObject *String_cmp(NatEnv *env, NatObject *self, size_t argc, NatObject **arg
     NAT_ASSERT_ARGC(1);
     NatObject* arg = args[0];
     if (NAT_TYPE(arg) != NAT_VALUE_STRING) return NAT_NIL;
-    return nat_integer(env, strcmp(self->str, arg->str));
+    int diff = strcmp(self->str, arg->str);
+    int result;
+    if (diff < 0) {
+        result = -1;
+    } else if (diff > 0) {
+        result = 1;
+    } else {
+        result = 0;
+    }
+    return nat_integer(env, result);
 }
 
 NatObject *String_eqtilde(NatEnv *env, NatObject *self, size_t argc, NatObject **args, struct hashmap *kwargs, NatBlock *block) {

--- a/test/natalie/string_test.nat
+++ b/test/natalie/string_test.nat
@@ -3,6 +3,20 @@
 require_relative '../spec_helper'
 
 describe 'string' do
+  describe "#<=>" do
+    it "should return -1 if lhs is less than rhs" do
+      ('a' <=> 'b').should == -1
+    end
+
+    it "should return 1 if lhs is greater than rhs" do
+      ('b' <=> 'a').should == 1
+    end
+
+    it "should return 0 if both sides are equal" do
+      ('a' <=> 'a').should == 0
+    end
+  end
+
   describe '#succ' do
     context 'given a single character' do
       it 'returns the next character' do

--- a/test/natalie/string_test.nat
+++ b/test/natalie/string_test.nat
@@ -6,14 +6,17 @@ describe 'string' do
   describe "#<=>" do
     it "should return -1 if lhs is less than rhs" do
       ('a' <=> 'b').should == -1
+      ('a' <=> 'z').should == -1
     end
 
     it "should return 1 if lhs is greater than rhs" do
       ('b' <=> 'a').should == 1
+      ('z' <=> 'a').should == 1
     end
 
     it "should return 0 if both sides are equal" do
       ('a' <=> 'a').should == 0
+      ('z' <=> 'z').should == 0
     end
   end
 


### PR DESCRIPTION
Currently the spaceship operator with strings just returns the result of running `strcmp`. In reality the spaceship operator is supposed to return -1 if the left side is less than the right side, 1 if the left side is greater than the right side, and 0 if the two sides are equal.