### PR TITLE
Build: General CMake-y improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,45 +2,30 @@ cmake_minimum_required(VERSION 3.10)
 
 project(Natalie)
 
+file(GLOB LIB_SOURCES "src/*.cpp")
+file(GLOB GENERATED_NAMES "src/*.rb")
+
+list(FILTER LIB_SOURCES EXCLUDE REGEX ".*main.cpp$")
+
 add_library(natalie STATIC
-  ${CMAKE_CURRENT_BINARY_DIR}/generated/array.cpp
-  ${CMAKE_CURRENT_BINARY_DIR}/generated/comparable.cpp
-  ${CMAKE_CURRENT_BINARY_DIR}/generated/errno.cpp
-  ${CMAKE_CURRENT_BINARY_DIR}/generated/exception.cpp
-  ${CMAKE_CURRENT_BINARY_DIR}/generated/io.cpp
-  src/array_value.cpp
-  src/bindings.cpp
-  src/block.cpp
-  src/class_value.cpp
-  src/encoding_value.cpp
-  src/env.cpp
-  src/env_value.cpp
-  src/exception_value.cpp
-  src/false_value.cpp
-  src/file_value.cpp
-  src/float_value.cpp
-  src/hash_value.cpp
-  src/integer_value.cpp
-  src/io_value.cpp
-  src/kernel_module.cpp
-  src/match_data_value.cpp
-  src/module_value.cpp
-  src/natalie.cpp
-  src/nil_value.cpp
-  src/proc_value.cpp
-  src/range_value.cpp
-  src/regexp_value.cpp
-  src/string_value.cpp
-  src/symbol_value.cpp
-  src/true_value.cpp
-  src/value.cpp)
+  ${LIB_SOURCES})
+
+foreach(PATH ${GENERATED_NAMES})
+  get_filename_component(FILENAME ${PATH} NAME)
+  string(REGEX REPLACE "[.]rb$" ".cpp" GENERATED_NAME ${FILENAME})
+  set(GENERATED_PATH generated/${GENERATED_NAME})
+  add_custom_command(
+    OUTPUT "${GENERATED_PATH}"
+    DEPENDS "${PATH}"
+    DEPENDS make-generated-directory
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/bin/natalie --write-obj "${GENERATED_PATH}" ${PATH} VERBATIM)
+  target_sources(natalie PRIVATE "${GENERATED_PATH}")
+endforeach()
 
 target_include_directories(natalie PRIVATE
   include
-  ext/bdwgc/include
-  ext/gdtoa
-  ext/hashmap/include
-  ext/onigmo)
+  ${CMAKE_BINARY_DIR}/include
+  ${CMAKE_BINARY_DIR}/include/gdtoa)
 
 set_target_properties(natalie PROPERTIES CXX_STANDARD 17 POSITION_INDEPENDENT_CODE true)
 
@@ -54,26 +39,13 @@ add_custom_target(generate-bindings DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/bind
 add_dependencies(natalie generate-bindings)
 set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/bindings.cpp PROPERTIES GENERATED TRUE)
 
-add_custom_command(OUTPUT generated/array.cpp      DEPENDS src/array.rb      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/bin/natalie --write-obj generated/array.cpp      ${CMAKE_CURRENT_SOURCE_DIR}/src/array.rb VERBATIM)
-add_custom_command(OUTPUT generated/comparable.cpp DEPENDS src/comparable.rb COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/bin/natalie --write-obj generated/comparable.cpp ${CMAKE_CURRENT_SOURCE_DIR}/src/comparable.rb VERBATIM)
-add_custom_command(OUTPUT generated/errno.cpp      DEPENDS src/errno.rb      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/bin/natalie --write-obj generated/errno.cpp      ${CMAKE_CURRENT_SOURCE_DIR}/src/errno.rb VERBATIM)
-add_custom_command(OUTPUT generated/exception.cpp  DEPENDS src/exception.rb  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/bin/natalie --write-obj generated/exception.cpp  ${CMAKE_CURRENT_SOURCE_DIR}/src/exception.rb VERBATIM)
-add_custom_command(OUTPUT generated/io.cpp         DEPENDS src/io.rb         COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/bin/natalie --write-obj generated/io.cpp         ${CMAKE_CURRENT_SOURCE_DIR}/src/io.rb VERBATIM)
-add_custom_target(compile-rb DEPENDS
-  generated/array.cpp
-  generated/comparable.cpp
-  generated/errno.cpp
-  generated/exception.cpp
-  generated/io.cpp)
-add_dependencies(natalie compile-rb)
-
-set_source_files_properties(generated/array.cpp PROPERTIES GENERATED TRUE)
-set_source_files_properties(generated/comparable.cpp PROPERTIES GENERATED TRUE)
-set_source_files_properties(generated/errno.cpp PROPERTIES GENERATED TRUE)
-set_source_files_properties(generated/exception.cpp PROPERTIES GENERATED TRUE)
-set_source_files_properties(generated/io.cpp PROPERTIES GENERATED TRUE)
-
 include(ext/bdwgc.cmake)
 include(ext/gdtoa.cmake)
 include(ext/hashmap.cmake)
 include(ext/onigmo.cmake)
+
+add_dependencies(natalie
+    ${BDWGC_TARGET}
+    ${GDTOA_TARGET}
+    ${HASHMAP_TARGET}
+    ${ONIGMO_TARGET})

--- a/ext/gdtoa.cmake
+++ b/ext/gdtoa.cmake
@@ -1,10 +1,28 @@
 set(GDTOA_SRC "${PROJECT_SOURCE_DIR}/ext/gdtoa")
 
-include(ExternalProject)
+set(GDTOA_LIB "${CMAKE_BINARY_DIR}/libgdtoa.a")
+set(GDTOA_BUILD_DIR "${GDTOA_SRC}/build")
 
-ExternalProject_Add(gdtoa
-  BUILD_IN_SOURCE TRUE
-  SOURCE_DIR ${GDTOA_SRC}
-  CONFIGURE_COMMAND ./autogen.sh
-            COMMAND ./configure --with-pic
-  BUILD_COMMAND $(MAKE) && rm -f compile)
+add_custom_target(make_gdtoa_build_dir
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${GDTOA_BUILD_DIR})
+
+add_custom_command(
+    OUTPUT "${GDTOA_LIB}"
+    BYPRODUCTS "${GDTOA_BUILD_DIR}/libgdtoa.a" "${GDTOA_SRC}/arith.h"
+    DEPENDS make_gdtoa_build_dir
+    WORKING_DIRECTORY ${GDTOA_SRC}
+    COMMAND sh autogen.sh
+    COMMAND mkdir -p build
+    COMMAND ./configure --with-pic --prefix "${GDTOA_BUILD_DIR}"
+    COMMAND make
+    COMMAND make install
+    COMMAND ${CMAKE_COMMAND} -E copy "${GDTOA_BUILD_DIR}/lib/libgdtoa.a" "${GDTOA_LIB}"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${GDTOA_BUILD_DIR}/include" "${CMAKE_BINARY_DIR}/include"
+    COMMAND ${CMAKE_COMMAND} -E copy "${GDTOA_SRC}/*.h" "${CMAKE_BINARY_DIR}/include/gdtoa" # gdtoa does not install all its headers :(
+    COMMAND make clean
+    )
+
+add_custom_target(gdtoa
+    DEPENDS "${GDTOA_LIB}" "${GDTOA_CPPLIB}")
+
+set(GDTOA_TARGET gdtoa)

--- a/ext/hashmap.cmake
+++ b/ext/hashmap.cmake
@@ -1,10 +1,12 @@
 set(HASHMAP_SRC "${PROJECT_SOURCE_DIR}/ext/hashmap")
 
-include(ExternalProject)
+add_subdirectory(${HASHMAP_SRC})
 
-ExternalProject_Add(hashmap
-  BINARY_DIR ${HASHMAP_SRC}/build
-  SOURCE_DIR ${HASHMAP_SRC}
-  BUILD_COMMAND CFLAGS="-fPIC" make
-  BUILD_BYPRODUCTS ${HASHMAP_SRC}/build/libhashmap.a
-  INSTALL_COMMAND "")
+target_compile_options(hashmap PRIVATE "-fPIC")
+
+add_custom_target(hashmap_dep
+    COMMAND ${CMAKE_COMMAND} -E copy "ext/hashmap/libhashmap.a" "libhashmap.a"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${HASHMAP_SRC}/include" "include"
+    DEPENDS hashmap)
+
+set(HASHMAP_TARGET hashmap_dep)

--- a/ext/onigmo.cmake
+++ b/ext/onigmo.cmake
@@ -1,9 +1,26 @@
 set(ONIGMO_SRC "${PROJECT_SOURCE_DIR}/ext/onigmo")
 
-include(ExternalProject)
+set(ONIGMO_LIB "${CMAKE_BINARY_DIR}/libonigmo.a")
+set(ONIGMO_BUILD_DIR "${ONIGMO_SRC}/build")
 
-ExternalProject_Add(onigmo
-  BUILD_IN_SOURCE TRUE
-  SOURCE_DIR ${ONIGMO_SRC}
-  CONFIGURE_COMMAND ./configure --with-pic --disable-shared --enable-static
-  BUILD_COMMAND $(MAKE))
+add_custom_target(make_onigmo_build_dir
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${ONIGMO_BUILD_DIR})
+
+add_custom_command(
+    OUTPUT "${ONIGMO_LIB}"
+    BYPRODUCTS "${ONIGMO_BUILD_DIR}/libonigmo.a"
+    DEPENDS make_onigmo_build_dir
+    WORKING_DIRECTORY ${ONIGMO_SRC}
+    COMMAND sh autogen.sh
+    COMMAND mkdir -p build
+    COMMAND ./configure --with-pic --prefix "${ONIGMO_BUILD_DIR}"
+    COMMAND make
+    COMMAND make install
+    COMMAND make clean
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${ONIGMO_BUILD_DIR}/include" "${CMAKE_BINARY_DIR}/include"
+    COMMAND ${CMAKE_COMMAND} -E copy "${ONIGMO_BUILD_DIR}/lib/libonigmo.a" "${ONIGMO_LIB}")
+
+add_custom_target(onigmo
+    DEPENDS "${ONIGMO_LIB}")
+
+set(ONIGMO_TARGET onigmo)

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -12,20 +12,20 @@ module Natalie
     SRC_PATH = File.join(ROOT_DIR, 'src')
     INC_PATHS = [
       File.join(ROOT_DIR, 'include'),
-      File.join(ROOT_DIR, 'ext/bdwgc/include'),
-      File.join(ROOT_DIR, 'ext/gdtoa'),
-      File.join(ROOT_DIR, 'ext/onigmo'),
-      File.join(ROOT_DIR, 'ext/hashmap/include'),
+      File.join(BUILD_DIR, 'include'),
+      File.join(BUILD_DIR, 'include/gdtoa'),
     ]
-    GC_LIB_PATHS = ENV['NAT_CFLAGS'] =~ /NAT_GC_DISABLE/ ? [] : [
-      File.join(ROOT_DIR, 'ext/bdwgc/.libs/libgc.a'),
-      File.join(ROOT_DIR, 'ext/bdwgc/.libs/libgccpp.a'),
+    GC_LIBS = ENV['NAT_CFLAGS'] =~ /NAT_GC_DISABLE/ ? [] : [
+      'libgc.a',
+      'libgccpp.a',
     ]
-    LIB_PATHS = GC_LIB_PATHS + [
-      File.join(ROOT_DIR, 'ext/gdtoa/.libs/libgdtoa.a'),
-      File.join(ROOT_DIR, 'ext/hashmap/build/libhashmap.a'),
-      File.join(ROOT_DIR, 'ext/onigmo/.libs/libonigmo.a'),
+    LIBS = GC_LIBS + [
+      'libgdtoa.a',
+      'libhashmap.a',
+      'libonigmo.a',
     ]
+    LIB_NAMES = LIBS.map { |lib| "-l:#{lib}" }
+    LIB_PATH = BUILD_DIR
     OBJ_PATH = File.expand_path('../../obj', __dir__)
 
     RB_LIB_PATH = File.expand_path('..', __dir__)
@@ -146,7 +146,7 @@ module Natalie
     end
 
     def compiler_command
-      "#{cc} #{build_flags} #{extra_cflags} #{shared? ? '-fPIC -shared' : ''} #{inc_paths} -o #{out_path} #{BUILD_DIR}/libnatalie.a #{LIB_PATHS.join(' ')} -x c++ -std=c++17 #{@c_path || 'code.cpp'} -lm"
+      "#{cc} #{build_flags} #{extra_cflags} #{shared? ? '-fPIC -shared' : ''} #{inc_paths} -x c++ -std=c++17 #{@c_path || 'code.cpp'} -o #{out_path} -L #{LIB_PATH} -Wl,-Bstatic -l:libnatalie.a #{LIB_NAMES.join(' ')} -Wl,-Bdynamic -lm"
     end
 
     private


### PR DESCRIPTION
Heya!
I'm not much of a CMake expert, but I figured I might as well help towards #7.
As it stands, my additions are based off the `Makefile` in the master branch, so the intermediate external library builds spew out a lot of logs, this is not immediately fixable without cmake hacks, so I left that out.

Here's an overview of what this PR changes:
- Move all (needed) built external libraries and includes to build dir
- Make root CMakeFiles less verbose ('fancy')
- 'Fix' `compiler_command` to be explicit about library dependencies
- Swap out LIB_PATHS to LIB_NAMES for the compiler invocation

Also, might I interest you in `cmake .. -GNinja` for faster and more reliably incremental builds?