### PR TITLE
Kernel: Add 'loop'

### DIFF
--- a/include/natalie/kernel_module.hpp
+++ b/include/natalie/kernel_module.hpp
@@ -6,6 +6,8 @@
 
 #include "natalie/forward.hpp"
 #include "natalie/value.hpp"
+#include "natalie/integer_value.hpp"
+#include "natalie/nil_value.hpp"
 
 namespace Natalie {
 
@@ -47,6 +49,7 @@ struct KernelModule : Value {
     Value *instance_variable_get(Env *env, Value *name_val);
     Value *instance_variable_set(Env *env, Value *name_val, Value *value);
     Value *lambda(Env *env, Block *block);
+    Value *loop(Env *env, Block *block);
     Value *methods(Env *env);
     Value *p(Env *env, ssize_t argc, Value **args);
     Value *print(Env *env, ssize_t argc, Value **args);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -384,6 +384,7 @@ gen.binding('Kernel', 'instance_variables', 'KernelModule', 'ivars', argc: 0, pa
 gen.binding('Kernel', 'is_a?', 'KernelModule', 'is_a', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('Kernel', 'nil?', 'KernelModule', 'is_nil', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
 gen.binding('Kernel', 'lambda', 'KernelModule', 'lambda', argc: 0, pass_env: true, pass_block: true, return_type: :Value)
+gen.binding('Kernel', 'loop', 'KernelModule', 'loop', argc: 0, pass_env: true, pass_block: true, return_type: :Value)
 gen.binding('Kernel', '__method__', 'KernelModule', 'this_method', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Kernel', 'methods', 'KernelModule', 'methods', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Kernel', 'public_methods', 'KernelModule', 'methods', argc: 0, pass_env: true, pass_block: false, return_type: :Value)

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -1107,6 +1107,13 @@ Value *KernelModule_lambda_binding(Env *env, Value *self_value, ssize_t argc, Va
     return return_value;
 }
 
+Value *KernelModule_loop_binding(Env *env, Value *self_value, ssize_t argc, Value **args, Block *block) {
+    NAT_ASSERT_ARGC(0);
+    KernelModule *self = self_value->as_kernel_module_for_method_binding();
+    auto return_value = self->loop(env, block);
+    return return_value;
+}
+
 Value *KernelModule_this_method_binding(Env *env, Value *self_value, ssize_t argc, Value **args, Block *block) {
     NAT_ASSERT_ARGC(0);
     KernelModule *self = self_value->as_kernel_module_for_method_binding();
@@ -1985,6 +1992,7 @@ void init_bindings(Env *env) {
     Kernel->define_method(env, "is_a?", KernelModule_is_a_binding);
     Kernel->define_method(env, "nil?", KernelModule_is_nil_binding);
     Kernel->define_method(env, "lambda", KernelModule_lambda_binding);
+    Kernel->define_method(env, "loop", KernelModule_loop_binding);
     Kernel->define_method(env, "__method__", KernelModule_this_method_binding);
     Kernel->define_method(env, "methods", KernelModule_methods_binding);
     Kernel->define_method(env, "public_methods", KernelModule_methods_binding1);

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -151,6 +151,18 @@ Value *KernelModule::lambda(Env *env, Block *block) {
     }
 }
 
+Value *KernelModule::loop(Env *env, Block *block) {
+    if (block) {
+       for (;;) {
+           NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, 0, nullptr, nullptr);
+       }
+       return env->nil_obj();
+    } else {
+        // TODO: Enumerator?
+        NAT_RAISE(env, "ArgumentError", "loop without block");
+    }
+}
+
 Value *KernelModule::methods(Env *env) {
     ArrayValue *array = new ArrayValue { env };
     if (singleton_class(env)) {

--- a/test/natalie/loop_test.rb
+++ b/test/natalie/loop_test.rb
@@ -33,3 +33,33 @@ describe 'each' do
     x.should == 3
   end
 end
+
+describe 'loop' do
+  it 'can be invoked' do
+    s = false
+    loop do
+      s = true
+      break
+    end
+    s.should == true
+  end
+
+  it 'loops' do
+    x = 0
+    loop do
+      x += 1
+      break if x > 3
+    end
+    x.should == 4
+  end
+
+  it 'can handle break expr' do
+    x = 0
+    s = loop do
+      x += 1
+      break 'hello' if x > 3
+    end
+    s.should == 'hello'
+    x.should == 4
+  end
+end


### PR DESCRIPTION
This closes #4. "good first issue" indeed, made me look around the codebase :D 
Not sure whether the tests are sufficient, but that's all I could think of.

irrelevant idea: could this stuff be generated too? I know some stuff is implemented in ruby (`Array#permutations` for instance), so I'd think something as straightforward as `Kernel#loop` can too be generated?