### PR TITLE
Add Enumerable::chain

### DIFF
--- a/spec/core/enumerable/chain_spec.rb
+++ b/spec/core/enumerable/chain_spec.rb
@@ -1,5 +1,3 @@
-# skip-test
-
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 

--- a/src/enumerable.rb
+++ b/src/enumerable.rb
@@ -176,4 +176,12 @@ module Enumerable
     end
     result
   end
+
+  def chain(*args)
+    args.each do |arg|
+      arg.each do |val|
+        yield val
+      end
+    end
+  end
 end


### PR DESCRIPTION
I can't get it building locally, but CI appears to pass. Is `spec_chain.rb` auto-enabled?