### PR TITLE
Change test target name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(default_build_type "Debug")
 set(CMAKE_CXX_FLAGS_DEBUG "-g -Wall -Wextra -Werror -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unknown-warning-option")
 set(CMAKE_CXX_FLAGS_RELEASE "-O2")
 
-add_custom_target(test
+add_custom_target(tests
     COMMAND ruby ${CMAKE_SOURCE_DIR}/test/all.rb
     USES_TERMINAL
 )


### PR DESCRIPTION
My CMake raises an error because `test` is a name that is reserved for internal use.