### PR TITLE
Build on OpenBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,12 @@ cmake_minimum_required(VERSION 3.10)
 project(Natalie)
 
 set(default_build_type "Debug")
-set(CMAKE_CXX_FLAGS_DEBUG "-pthread -ldl -g -Wall -Wextra -Werror -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unknown-warning-option")
-set(CMAKE_CXX_FLAGS_RELEASE "-pthread -ldl -O2")
+set(CMAKE_CXX_FLAGS_DEBUG "-pthread -g -Wall -Wextra -Werror -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unknown-warning-option")
+set(CMAKE_CXX_FLAGS_RELEASE "-pthread -O2")
+if(LINUX)
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -ldl")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -ldl")
+endif()
 
 add_custom_target(tests
     COMMAND ruby ${CMAKE_SOURCE_DIR}/test/all.rb

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GNUMAKEFLAGS := --no-print-directory
 build: build_debug
 
 build_debug:
-	cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -S . -B build -DCMAKE_BUILD_TYPE="Debug"
+	cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -S . -B build -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_MAKE_PROGRAM="${MAKE}"
 	cmake --build build -j 4
 	cp build/compile_commands.json .
 

--- a/ext/bdwgc.cmake
+++ b/ext/bdwgc.cmake
@@ -16,7 +16,7 @@ add_custom_command(
     WORKING_DIRECTORY ${BDWGC_BUILD_DIR}
     COMMAND sh autogen.sh
     COMMAND ./configure --enable-cplusplus --enable-threads=pthreads --enable-static --with-pic
-    COMMAND make
+    COMMAND ${CMAKE_MAKE_PROGRAM}
     COMMAND ${CMAKE_COMMAND} -E copy "${BDWGC_BUILD_DIR}/include/*.h" "${CMAKE_BINARY_DIR}/include/bdwgc"
     COMMAND ${CMAKE_COMMAND} -E copy "${BDWGC_BUILD_DIR}/.libs/libgc.a" "${BDWGC_LIB}"
     COMMAND ${CMAKE_COMMAND} -E copy "${BDWGC_BUILD_DIR}/.libs/libgccpp.a" "${BDWGC_CPPLIB}")

--- a/ext/gdtoa.cmake
+++ b/ext/gdtoa.cmake
@@ -15,7 +15,7 @@ add_custom_command(
     WORKING_DIRECTORY ${GDTOA_BUILD_DIR}
     COMMAND sh autogen.sh
     COMMAND ./configure --with-pic
-    COMMAND make
+    COMMAND ${CMAKE_MAKE_PROGRAM}
     COMMAND ${CMAKE_COMMAND} -E copy "${GDTOA_BUILD_DIR}/*.h" "${CMAKE_BINARY_DIR}/include/gdtoa"
     COMMAND ${CMAKE_COMMAND} -E copy "${GDTOA_BUILD_DIR}/.libs/libgdtoa.a" "${GDTOA_LIB}")
 

--- a/ext/onigmo.cmake
+++ b/ext/onigmo.cmake
@@ -15,8 +15,8 @@ add_custom_command(
     WORKING_DIRECTORY ${ONIGMO_BUILD_DIR}
     COMMAND sh autogen.sh
     COMMAND ./configure --with-pic --prefix "${ONIGMO_BUILD_DIR}"
-    COMMAND make
-    COMMAND make install
+    COMMAND ${CMAKE_MAKE_PROGRAM}
+    COMMAND ${CMAKE_MAKE_PROGRAM} install
     COMMAND ${CMAKE_COMMAND} -E copy "${ONIGMO_BUILD_DIR}/include/*.h" "${CMAKE_BINARY_DIR}/include/onigmo"
     COMMAND ${CMAKE_COMMAND} -E copy "${ONIGMO_BUILD_DIR}/lib/libonigmo.a" "${ONIGMO_LIB}")
 

--- a/include/natalie/io_value.hpp
+++ b/include/natalie/io_value.hpp
@@ -9,6 +9,10 @@
 #include "natalie/macros.hpp"
 #include "natalie/value.hpp"
 
+#ifdef fileno
+#undef fileno
+#endif
+
 namespace Natalie {
 
 struct IoValue : Value, finalizer {

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -186,11 +186,17 @@ module Natalie
     end
 
     def libraries
-      if ENV['NAT_CXX_FLAGS'] =~ /NAT_GC_DISABLE/
+      libs = if ENV['NAT_CXX_FLAGS'] =~ /NAT_GC_DISABLE/
         LIBRARIES - %w[-lgc -lgccpp]
       else
         LIBRARIES
       end
+
+      if `uname -s`.strip == "Linux"
+        libs.push "-ldl"
+      end
+
+      libs
     end
 
     def cc
@@ -201,8 +207,8 @@ module Natalie
       !!repl
     end
 
-    RELEASE_FLAGS = '-pthread -ldl -O1'
-    DEBUG_FLAGS = '-pthread -ldl -g -Wall -Wextra -Werror -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unknown-warning-option'
+    RELEASE_FLAGS = '-pthread -O1'
+    DEBUG_FLAGS = '-pthread -g -Wall -Wextra -Werror -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unknown-warning-option'
     COVERAGE_FLAGS = '-fprofile-arcs -ftest-coverage'
 
     def build_flags

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -8,6 +8,8 @@
 #include <sys/time.h>
 #include <sys/wait.h>
 
+extern char **environ;
+
 namespace Natalie {
 
 Value *KernelModule::Array(Env *env, Value *value) {
@@ -192,8 +194,8 @@ Value *KernelModule::p(Env *env, size_t argc, Value **args) {
 }
 
 Value *KernelModule::print(Env *env, size_t argc, Value **args) {
-    IoValue *stdout = env->global_get("$stdout")->as_io();
-    return stdout->print(env, argc, args);
+    IoValue *_stdout = env->global_get("$stdout")->as_io();
+    return _stdout->print(env, argc, args);
 }
 
 Value *KernelModule::proc(Env *env, Block *block) {
@@ -205,8 +207,8 @@ Value *KernelModule::proc(Env *env, Block *block) {
 }
 
 Value *KernelModule::puts(Env *env, size_t argc, Value **args) {
-    IoValue *stdout = env->global_get("$stdout")->as_io();
-    return stdout->puts(env, argc, args);
+    IoValue *_stdout = env->global_get("$stdout")->as_io();
+    return _stdout->puts(env, argc, args);
 }
 
 Value *KernelModule::raise(Env *env, Value *klass, Value *message) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,17 +137,17 @@ extern "C" Env *build_top_env() {
     self->add_main_object_flag();
     env->global_set("$NAT_main_object", self);
 
-    Value *stdin = new IoValue { env, STDIN_FILENO };
-    env->global_set("$stdin", stdin);
-    Object->const_set(env, "STDIN", stdin);
+    Value *_stdin = new IoValue { env, STDIN_FILENO };
+    env->global_set("$stdin", _stdin);
+    Object->const_set(env, "STDIN", _stdin);
 
-    Value *stdout = new IoValue { env, STDOUT_FILENO };
-    env->global_set("$stdout", stdout);
-    Object->const_set(env, "STDOUT", stdout);
+    Value *_stdout = new IoValue { env, STDOUT_FILENO };
+    env->global_set("$stdout", _stdout);
+    Object->const_set(env, "STDOUT", _stdout);
 
-    Value *stderr = new IoValue { env, STDERR_FILENO };
-    env->global_set("$stderr", stderr);
-    Object->const_set(env, "STDERR", stderr);
+    Value *_stderr = new IoValue { env, STDERR_FILENO };
+    env->global_set("$stderr", _stderr);
+    Object->const_set(env, "STDERR", _stderr);
 
     Value *ENV = new Value { env };
     Object->const_set(env, "ENV", ENV);

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -44,8 +44,8 @@ void run_at_exit_handlers(Env *env) {
 }
 
 void print_exception_with_backtrace(Env *env, ExceptionValue *exception) {
-    IoValue *stderr = env->global_get("$stderr")->as_io();
-    int fd = stderr->fileno();
+    IoValue *_stderr = env->global_get("$stderr")->as_io();
+    int fd = _stderr->fileno();
     const ArrayValue *backtrace = exception->backtrace();
     if (backtrace && backtrace->size() > 0) {
         dprintf(fd, "Traceback (most recent call last):\n");


### PR DESCRIPTION
Requires `gmake` to be installed, along with the `automake` and `autoconf` versions specified in the environment.

`-ldl` is not needed on OpenBSD, and I think is only used on Linux.  `RUBY_PLATFORM.match(/linux/)` would probably be nicer than shelling out to `uname` but I don't think that exists in Natalie yet. 

```
$ env AUTOCONF_VERSION=2.69 AUTOMAKE_VERSION=1.16 gmake
cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -S . -B build -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_MAKE_PROGRAM="gmake"
-- The C compiler identification is Clang 10.0.1
-- The CXX compiler identification is Clang 10.0.1
[...]
[ 96%] Building CXX object CMakeFiles/natalie.dir/generated/struct.cpp.o
[ 98%] Linking CXX static library libnatalie.a
[100%] Built target natalie
cp build/compile_commands.json .
$ uname -srp
OpenBSD 6.8 amd64
$ bin/natalie examples/hello.rb
hello world
$
```
