### PR TITLE
More OpenBSD fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ cleanall:
 	rm -rf build
 
 test: build
-	ruby test/all.rb
+	bundle exec ruby test/all.rb
 
 test_valgrind:
 	NAT_CXX_FLAGS="-DNAT_GC_DISABLE" make clean build

--- a/ext/bdwgc-openbsd.patch
+++ b/ext/bdwgc-openbsd.patch
@@ -1,0 +1,30 @@
+diff --git include/private/gcconfig.h include/private/gcconfig.h
+index b342883b..f4e04743 100644
+--- include/private/gcconfig.h
++++ include/private/gcconfig.h
+@@ -117,6 +117,10 @@ EXTERN_C_BEGIN
+ /* And one for OpenBSD: */
+ # if defined(__OpenBSD__)
+ #    define OPENBSD
++#    ifndef USE_MMAP
++#      define USE_MMAP
++#    endif
++#    define USE_MMAP_ANON
+ # endif
+ 
+ /* And one for FreeBSD: */
+diff --git os_dep.c os_dep.c
+index a74155e0..02ff7414 100644
+--- os_dep.c
++++ os_dep.c
+@@ -2152,7 +2152,9 @@ void GC_register_data_segments(void)
+ 
+ #ifdef USE_MMAP_ANON
+ # define zero_fd -1
+-# if defined(MAP_ANONYMOUS) && !defined(CPPCHECK)
++# if defined(OPENBSD)
++#   define OPT_MAP_ANON MAP_ANON | MAP_STACK
++# elif defined(MAP_ANONYMOUS) && !defined(CPPCHECK)
+ #   define OPT_MAP_ANON MAP_ANONYMOUS
+ # else
+ #   define OPT_MAP_ANON MAP_ANON

--- a/ext/bdwgc.cmake
+++ b/ext/bdwgc.cmake
@@ -14,6 +14,7 @@ add_custom_command(
     DEPENDS make_bdwgc_build_dir
     COMMAND ${CMAKE_COMMAND} -E copy_directory "${BDWGC_SRC}" "${BDWGC_BUILD_DIR}"
     WORKING_DIRECTORY ${BDWGC_BUILD_DIR}
+    COMMAND [ -e .patched0 ] || (patch -sp0 < ../../ext/bdwgc-openbsd.patch && touch .patched0)
     COMMAND sh autogen.sh
     COMMAND ./configure --enable-cplusplus --enable-threads=pthreads --enable-static --with-pic
     COMMAND ${CMAKE_MAKE_PROGRAM}

--- a/src/class_value.cpp
+++ b/src/class_value.cpp
@@ -11,7 +11,7 @@ ClassValue *ClassValue::subclass(Env *env, const char *name, Type object_type) {
     subclass->m_env = Env::new_detatched_env(&m_env);
     if (singleton_class()) {
         char singleton_name[255];
-        snprintf(singleton_name, 255, "#<Class:%s>", name);
+        snprintf(singleton_name, 255, "#<Class:%s>", name == NULL ? "NULL" : name);
         ClassValue *singleton = singleton_class()->subclass(env, singleton_name);
         subclass->set_singleton_class(singleton);
     }


### PR DESCRIPTION
The bdwgc patch is kind of broad, but it fixes the crashing binary during tests.

The other two get all non-skipped tests passing without `dmesg` chatter, except for the first REPL test which seems to be a completely separate issue.