### PR TITLE
Repl: If we don't have a TTY, don't use Readline

### DIFF
--- a/lib/natalie/repl.rb
+++ b/lib/natalie/repl.rb
@@ -3,12 +3,18 @@ require 'fileutils'
 require 'tempfile'
 
 begin
-  require 'readline'
+  if STDOUT.tty?
+    require 'readline'
+  else
+    raise LoadError
+  end
 rescue LoadError
   class Readline
     def self.readline(prompt, _)
-      print prompt
-      gets
+      if !(i = gets)
+        exit
+      end
+      i
     end
   end
 end

--- a/test/ruby/repl_test.rb
+++ b/test/ruby/repl_test.rb
@@ -8,7 +8,7 @@ class ReplWrapper
   end
 
   def execute(input)
-    @in.puts(input + "\n")
+    @in.puts input
   end
 
   def out
@@ -16,7 +16,7 @@ class ReplWrapper
   end
 
   def quit
-    @in.puts("\x04")
+    @in.close
   end
 
   private
@@ -40,19 +40,12 @@ describe 'REPL' do
     @repl.execute('self')
     @repl.quit
     expect(@repl.out).must_equal dedent(<<-EOF)
-      nat> x = 100
       100
-      nat> y = 3 * 4
       12
-      nat> @z = "z"
       "z"
-      nat> x
       100
-      nat> [y, @z]
       [12, "z"]
-      nat> self
       main
-      nat> 
     EOF
   end
 


### PR DESCRIPTION
The failure of this test on OpenBSD was due to some differences in Readline/TTY handling which caused Readline to not echo the input back to the output when not on a TTY.  I spent some time trying to figure out why and how to force the echoing by using a PTY in `ReplWrapper`, but I couldn't get it to work properly.

In the end, I'm not sure it's that useful to test Readline's behavior anyway, so maybe the REPL should just print its output when STDOUT isn't a TTY, and the test can just check for the expected output.

🎄 🎁 🎅 

```
Finished in 496.087667s, 0.4334 runs/s, 0.5826 assertions/s.

215 runs, 289 assertions, 0 failures, 0 errors, 54 skips
```