### PR TITLE
deduplicate some NAT_RUN_BLOCK_* macros

### DIFF
--- a/include/natalie/macros.hpp
+++ b/include/natalie/macros.hpp
@@ -33,38 +33,32 @@
     _result;                                                                                    \
 })
 
+#define NAT_RUN_BLOCK_GENERIC(env, the_block, argc, args, block, cleanup_code, on_break_flag) ({ \
+    Natalie::ValuePtr _result = nullptr;                                                         \
+    do {                                                                                         \
+        if (_result)                                                                             \
+            _result->remove_redo_flag();                                                         \
+        _result = the_block->_run(env, argc, args, block);                                       \
+        if (_result->has_break_flag()) {                                                         \
+            _result->remove_break_flag();                                                        \
+            cleanup_code;                                                                        \
+            on_break_flag;                                                                       \
+        }                                                                                        \
+    } while (_result->has_redo_flag());                                                          \
+    cleanup_code;                                                                                \
+    _result;                                                                                     \
+})
+
 #define NAT_RUN_BLOCK_AND_POSSIBLY_BREAK_WITH_CLEANUP(env, the_block, argc, args, block, cleanup_code) ({ \
-    Natalie::ValuePtr _result = nullptr;                                                                  \
-    do {                                                                                                  \
-        if (_result)                                                                                      \
-            _result->remove_redo_flag();                                                                  \
-        _result = the_block->_run(env, argc, args, block);                                                \
-        if (_result->has_break_flag()) {                                                                  \
-            _result->remove_break_flag();                                                                 \
-            cleanup_code;                                                                                 \
-            return _result;                                                                               \
-        }                                                                                                 \
-    } while (_result->has_redo_flag());                                                                   \
-    cleanup_code;                                                                                         \
-    _result;                                                                                              \
+    NAT_RUN_BLOCK_GENERIC(env, the_block, argc, args, block, cleanup_code, return _result);               \
 })
 
-#define NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, the_block, argc, args, block) ({            \
-    NAT_RUN_BLOCK_AND_POSSIBLY_BREAK_WITH_CLEANUP(env, the_block, argc, args, block, {}); \
+#define NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, the_block, argc, args, block) ({    \
+    NAT_RUN_BLOCK_GENERIC(env, the_block, argc, args, block, {}, return _result); \
 })
 
-#define NAT_RUN_BLOCK_WITHOUT_BREAK(env, the_block, argc, args, block) ({    \
-    Natalie::ValuePtr _result = nullptr;                                     \
-    do {                                                                     \
-        if (_result)                                                         \
-            _result->remove_redo_flag();                                     \
-        _result = the_block->_run(env, argc, args, block);                   \
-        if (_result->has_break_flag()) {                                     \
-            _result->remove_break_flag();                                    \
-            env->raise_local_jump_error(_result, "break from proc-closure"); \
-        }                                                                    \
-    } while (_result->has_redo_flag());                                      \
-    _result;                                                                 \
+#define NAT_RUN_BLOCK_WITHOUT_BREAK(env, the_block, argc, args, block) ({                                                          \
+    NAT_RUN_BLOCK_GENERIC(env, the_block, argc, args, block, {}, env->raise_local_jump_error(_result, "break from proc-closure")); \
 })
 
 #define NAT_CHECK_FOR_BREAK(value) ({ \


### PR DESCRIPTION
This adds a new NAT_RUN_BLOCK_GENERIC macro that is called from
NAT_RUN_BLOCK_AND_POSSIBLY_BREAK_WITH_CLEANUP, NAT_RUN_BLOCK_AND_POSSIBLY_BREAK and NAT_RUN_BLOCK_WITHOUT_BREAK.

Disclaimer: This might be the first C++ code I've written, so not sure if I've made a stupid mistake...