### PR TITLE
Implement Enumerable#tally

### DIFF
--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -168,6 +168,8 @@ public:
 
     nat_int_t object_id() { return reinterpret_cast<nat_int_t>(this); }
 
+    ValuePtr itself() { return this; }
+
     const String *pointer_id() {
         char buf[100]; // ought to be enough for anybody ;-)
         snprintf(buf, 100, "%p", this);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -539,6 +539,7 @@ gen.binding('NilClass', 'to_i', 'NilValue', 'to_i', argc: 0, pass_env: true, pas
 gen.binding('NilClass', 'to_s', 'NilValue', 'to_s', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 
 gen.binding('Object', 'nil?', 'Value', 'is_nil', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
+gen.binding('Object', 'itself', 'Value', 'itself', argc: 0, pass_env: false, pass_block: false, return_type: :Value)
 
 gen.singleton_binding('Parser', 'parse', 'ParserValue', 'parse', argc: 1..2, pass_env: true, pass_block: false, return_type: :Value)
 gen.singleton_binding('Parser', 'tokens', 'ParserValue', 'tokens', argc: 1..2, pass_env: true, pass_block: false, return_type: :Value)

--- a/spec/core/enumerable/tally_spec.rb
+++ b/spec/core/enumerable/tally_spec.rb
@@ -1,5 +1,3 @@
-# skip-test
-
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 

--- a/spec/core/hash/transform_values_spec.rb
+++ b/spec/core/hash/transform_values_spec.rb
@@ -1,0 +1,97 @@
+require_relative '../../spec_helper'
+
+describe "Hash#transform_values" do
+  before :each do
+    @hash = { a: 1, b: 2, c: 3 }
+  end
+
+  it "returns new hash" do
+    ret = @hash.transform_values(&:succ)
+    ret.should_not equal(@hash)
+    ret.should be_an_instance_of(Hash)
+  end
+
+  it "sets the result as transformed values with the given block" do
+    @hash.transform_values(&:succ).should ==  { a: 2, b: 3, c: 4 }
+  end
+
+  it "makes both hashes to share keys" do
+    key = [1, 2, 3]
+    new_hash = { key => 1 }.transform_values(&:succ)
+    new_hash[key].should == 2
+    new_hash.keys[0].should equal(key)
+  end
+
+  context "when no block is given" do
+    it "returns a sized Enumerator" do
+      enumerator = @hash.transform_values
+      enumerator.should be_an_instance_of(Enumerator)
+      enumerator.size.should == @hash.size
+      enumerator.each(&:succ).should == { a: 2, b: 3, c: 4 }
+    end
+  end
+
+  it "returns a Hash instance, even on subclasses" do
+    klass = Class.new(Hash)
+    h = klass.new
+    h[:foo] = 42
+    r = h.transform_values{|v| 2 * v}
+    r[:foo].should == 84
+    r.class.should == Hash
+  end
+end
+
+xdescribe "Hash#transform_values!" do
+  before :each do
+    @hash = { a: 1, b: 2, c: 3 }
+    @initial_pairs = @hash.dup
+  end
+
+  it "returns self" do
+    @hash.transform_values!(&:succ).should equal(@hash)
+  end
+
+  it "updates self as transformed values with the given block" do
+    @hash.transform_values!(&:succ)
+    @hash.should == { a: 2, b: 3, c: 4 }
+  end
+
+  it "partially modifies the contents if we broke from the block" do
+    @hash.transform_values! do |v|
+      break if v == 3
+      100 + v
+    end
+    @hash.should == { a: 101, b: 102, c: 3}
+  end
+
+  context "when no block is given" do
+    it "returns a sized Enumerator" do
+      enumerator = @hash.transform_values!
+      enumerator.should be_an_instance_of(Enumerator)
+      enumerator.size.should == @hash.size
+      enumerator.each(&:succ)
+      @hash.should == { a: 2, b: 3, c: 4 }
+    end
+  end
+
+  describe "on frozen instance" do
+    before :each do
+      @hash.freeze
+    end
+
+    it "raises a FrozenError on an empty hash" do
+      ->{ {}.freeze.transform_values!(&:succ) }.should raise_error(FrozenError)
+    end
+
+    it "keeps pairs and raises a FrozenError" do
+      ->{ @hash.transform_values!(&:succ) }.should raise_error(FrozenError)
+      @hash.should == @initial_pairs
+    end
+
+    context "when no block is given" do
+      it "does not raise an exception" do
+        @hash.transform_values!.should be_an_instance_of(Enumerator)
+      end
+    end
+  end
+end

--- a/spec/core/kernel/itself_spec.rb
+++ b/spec/core/kernel/itself_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../../spec_helper'
+# require_relative 'fixtures/classes'
+
+describe "Kernel#itself" do
+  it "returns the receiver itself" do
+    foo = Object.new
+    foo.itself.should equal foo
+  end
+end

--- a/src/enumerable.rb
+++ b/src/enumerable.rb
@@ -705,6 +705,18 @@ module Enumerable
     broken_value
   end
 
+  def tally
+    hash = {}
+    gather = ->(item) { item.size <= 1 ? item.first : item }
+
+    each do |*item|
+      hash[gather.(item)] ||= 0
+      hash[gather.(item)] += 1
+    end
+
+    hash
+  end
+
   def to_a(*args)
     result = []
     gather = ->(item) { item.size <= 1 ? item.first : item }

--- a/src/hash.rb
+++ b/src/hash.rb
@@ -1,0 +1,11 @@
+class Hash
+  def transform_values
+    return enum_for(:transform_values) { size } unless block_given?
+
+    new_hash = {}
+    each do |key, value|
+      new_hash[key] = yield(value)
+    end
+    new_hash
+  end
+end


### PR DESCRIPTION
This PR implements Enumerable#tally. To make the specs work I also needed to implement Object#itself and Hash#transform_values.

I'm kind of unsure about the implementation of Object#itself in CPP and about Hash#transform_values being in hash.rb instead of the HashValue class. Feel free to correct me if there are any mistakes 😅 

I also skipped Hash#transform_values! for now because it was not relevant to make the tally spec working.