### PR TITLE
Initial stab at trying to implement min_by

### DIFF
--- a/src/enumerable.rb
+++ b/src/enumerable.rb
@@ -505,6 +505,19 @@ module Enumerable
     end
   end
 
+  def min_by(n = nil)
+    return enum_for(:min_by) unless block_given?
+
+    ary = []
+
+    gather = ->(obj) { obj.size <= 1 ? obj.first : obj }
+    each do |*item|
+      ary << gather.(item)
+    end
+
+    ary.size == 0 ? nil : ary.min(n)
+  end
+
   def reject
     return enum_for(:reject) unless block_given?
 


### PR DESCRIPTION
This function ideally should call the already defined min function to get
the existing behaviour with the 'n' parameter but with my non existant ruby
knowledge I am unable to call this function.

Addresses #19

I am getting:

```
Failed specs:                                                                                                              
Enumerable#min_by                                                                                                          
  returns the object for whom the value returned by block is the smallest                  
    wrong number of arguments (given 1, expected 0) (ArgumentError)          
      /home/philbert/workspace/natalie/src/enumerable.rb:519:in `min'             
      /home/philbert/workspace/natalie/src/enumerable.rb:519:in `min_by'               
      ../spec/core/enumerable/min_by_spec.rb:15:in `block in block in block'
      /home/philbert/workspace/natalie/test/support/spec.rb:663:in `call'
      /home/philbert/workspace/natalie/test/support/spec.rb:663:in `block in run_specs'
      /home/philbert/workspace/natalie/test/support/spec.rb:644:in `each'
      /home/philbert/workspace/natalie/test/support/spec.rb:644:in `run_specs'
      /home/philbert/workspace/natalie/test/support/spec.rb:734:in `block in block'
      ../spec/core/enumerable/min_by_spec.rb:5:in `<main>'

12 spec(s) passed.
0 spec(s) failed.                                          
8 spec(s) errored.                                                                                                         
2 spec(s) skipped.
```