### PR TITLE
Fix "spec(s) passed" count if some specs errored

### DIFF
--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -717,7 +717,7 @@ def run_specs
       end
     end
     puts
-    puts "#{@tested - @failures.size} spec(s) passed."
+    puts "#{@tested - @failures.size - @errors.size} spec(s) passed."
     puts "#{@failures.size} spec(s) failed."
     puts "#{@errors.size} spec(s) errored."
     puts "#{@skipped.size} spec(s) skipped." if @skipped.any?


### PR DESCRIPTION
Previously when running a test that throws an error, the summary message
of the spec reporter would report one passed and one errored spec. This
fixes this behavior by substracting the number of errored specs from the
passed spec count.