### PR TITLE
Trying to fix the argument count when calling a method with a splat

### DIFF
--- a/lib/natalie/compiler/method_args.rb
+++ b/lib/natalie/compiler/method_args.rb
@@ -63,8 +63,8 @@ module Natalie
                 @required_args += 1
                 default_value = 'nullptr'
               end
-              non_kwargs = names.reject { |name| name.sexp_type == :kwarg }
-              value = s(:arg_value_by_path, :env, value_name, default_value, :false, non_kwargs.size, defaults.size, defaults_on_right ? :true : :false, 0, path.size, *path)
+              total_argument_count = names.reject { |name| name.sexp_type == :kwarg || name.sexp_type == :splat }.size
+              value = s(:arg_value_by_path, :env, value_name, default_value, :false, total_argument_count, defaults.size, defaults_on_right ? :true : :false, 0, path.size, *path)
               masgn_set(name, value)
             end
           else

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -143,7 +143,7 @@ ValuePtr arg_value_by_path(Env *env, ValuePtr value, ValuePtr default_value, boo
                     } else {
                         // not enough values to fill from the right
                         // also, assume there is a splat prior to this index
-                        index = total_count - 1 + index;
+                        index = total_count + index;
                     }
                 }
 

--- a/test/natalie/method_test.rb
+++ b/test/natalie/method_test.rb
@@ -57,6 +57,10 @@ def default_with_splat_last(x, y = 2, *rest)
   [x, y, rest]
 end
 
+def only_default_with_splat_last(x = 2, *rest)
+  [x, rest]
+end
+
 def default_nils(x = nil, y = nil)
   [x, y]
 end
@@ -186,6 +190,9 @@ describe 'method' do
     default_after_regular(2).should == [2, 2]
     default_after_regular(2, 3).should == [2, 3]
     default_with_splat_last(2).should == [2, 2, []]
+    default_with_splat_last(2, 3).should == [2, 3, []]
+    only_default_with_splat_last.should == [2, []]
+    only_default_with_splat_last(1).should == [1, []]
     default_calling_another_method.should == 1
     default_calling_another_method2.should == 2
     default_nils().should == [nil, nil]


### PR DESCRIPTION
This commit tries to fix #60, by calculating the `total_count` of arguments differently. 

Previously we only rejected keyword arguments which results in splats being counted into the total number of arguments.
This results in choosing the default value even though an argument is passed. 

See the following example:

```ruby
def foo(a = 2, *args)
  puts [a, args]
end
foo(1)
```

The [if-condition](https://github.com/seven1m/natalie/blob/fix-default-with-splat/src/natalie.cpp#L122) evaluates to `true` because `remain` is calculated by subtracting the number of arguments passed and the number of required arguments which is calculated by the `total_count` passed. 

Here `ary_len` would be 1, `total_count` would be 2, which results in `required_count` being 1.

`remain` would then evaluate to 0, which makes the if-condition evaluate to `true`, even though it should not. 

Rejecting the splat arguments from the `total_count` would result in it being 1, `required_count` would be 0 and `remain` would be 1, which seems to be the behavior that we want.

Also this let's us get rid of the subtraction when we assume a splat prior to the currently evaluated argument.