### PR TITLE
Adds aliases for Enumerable#find_all and Enumerable#filter

### DIFF
--- a/spec/core/enumerable/filter_spec.rb
+++ b/spec/core/enumerable/filter_spec.rb
@@ -1,5 +1,3 @@
-# skip-test
-
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/find_all'

--- a/spec/core/enumerable/find_all_spec.rb
+++ b/spec/core/enumerable/find_all_spec.rb
@@ -1,5 +1,3 @@
-# skip-test
-
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/find_all'

--- a/src/enumerable.rb
+++ b/src/enumerable.rb
@@ -558,6 +558,9 @@ module Enumerable
     ary
   end
 
+  alias find_all select
+  alias filter select
+
   def collect
     return enum_for(:map) unless block_given?
 


### PR DESCRIPTION
[#19]

Adds a couple of method aliases for `#find_all` and `#filter`

[ruby 2.7.3 Enumerable#filter](https://ruby-doc.org/core-2.7.3/Enumerable.html#method-i-filter)
[ruby 2.7.3 Enumerable#find_all](https://ruby-doc.org/core-2.7.3/Enumerable.html#method-i-find_all)
