### PR TITLE
Implement Enumerable#slice_after and Enumerable#slice_before

### DIFF
--- a/spec/core/enumerable/slice_before_spec.rb
+++ b/spec/core/enumerable/slice_before_spec.rb
@@ -1,5 +1,3 @@
-# skip-test
-
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/enumerable_enumeratorized'

--- a/src/enumerable.rb
+++ b/src/enumerable.rb
@@ -781,9 +781,7 @@ module Enumerable
       index = 0
       each do |*item|
         item = gather.(item)
-        # FIXME: Putting this directly into the if condition does not work here?
-        condition_result = condition.(item)
-        if condition_result && index > 0
+        if condition.(item) && index > 0
           yielder << current_slice
           current_slice = [item]
         else

--- a/src/enumerable.rb
+++ b/src/enumerable.rb
@@ -682,6 +682,87 @@ module Enumerable
     end
   end
 
+  def slice_after(*args, &block)
+    enum = to_enum
+    current_slice = []
+    block_given = block_given?
+    gather = ->(item) { item.size <= 1 ? item.first : item }
+
+    if block_given
+      if !args.empty?
+        raise ArgumentError, "wrong number of arguments (given #{args.size}, expected 0)"
+      end
+    elsif args.size != 1
+      raise ArgumentError, "wrong number of arguments (given #{args.size}, expected 1)"
+    end
+
+    condition = ->(item) {
+      if block_given
+        block.(item)
+      else
+        args[0] === item
+      end
+    }
+
+    Enumerator.new do |yielder|
+      each do |*item|
+        item = gather.(item)
+        current_slice << item
+        if condition.(item)
+          yielder << current_slice
+          current_slice = []
+        end
+      end
+
+      unless current_slice.empty?
+        yielder << current_slice
+      end
+    end
+  end
+
+  def slice_before(*args, &block)
+    enum = to_enum
+    current_slice = []
+    block_given = block_given?
+    gather = ->(item) { item.size <= 1 ? item.first : item }
+
+    if block_given
+      if !args.empty?
+        raise ArgumentError, "wrong number of arguments (given #{args.size}, expected 0)"
+      end
+    elsif args.size != 1
+      raise ArgumentError, "wrong number of arguments (given #{args.size}, expected 1)"
+    end
+
+    condition = ->(item) {
+      if block_given
+        block.(item)
+      else
+        args[0] === item
+      end
+    }
+
+    Enumerator.new do |yielder|
+      index = 0
+      each do |*item|
+        item = gather.(item)
+        # FIXME: Putting this directly into the if condition does not work here?
+        condition_result = condition.(item)
+        if condition_result && index > 0
+          yielder << current_slice
+          current_slice = [item]
+        else
+          current_slice << item
+        end
+        index += 1
+      end
+
+      unless current_slice.empty?
+        yielder << current_slice
+      end
+    end
+  end
+
   def slice_when(&block)
     block = proc(&block)
     current_slice = []

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -472,15 +472,16 @@ class Stub
     self
   end
 
-  def and_return(result)
+  def and_return(*results)
     should_receive_called = -> { @pass = @count_restriction === @count }
     increment = -> { @count += 1 }
+    result = -> { results.size > 1 ? results[@count - 1] : results[0] }
     expected_args = @args
     @subject.define_singleton_method(@message) do |*args|
       increment.()
       if expected_args.nil? || args == expected_args
         should_receive_called.()
-        result
+        result.()
       else
         puts 'TODO: make a way for the original method to be called from the stub'
         fail

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -518,7 +518,6 @@ class Stub
     self
   end
 
-
   def at_most(n)
     case n
     when :once
@@ -532,7 +531,12 @@ class Stub
   end
 
   def once
-    @count_restriction = 1
+    exactly(1)
+    self
+  end
+
+  def exactly(n)
+    @count_restriction = n
     self
   end
 


### PR DESCRIPTION
This patch implements Enumerable#slice_after, Enumerable#slice_before and some more stuff in spec.rb.

I'm particularly not happy with the argument checking... Also I do not really get the issue with the FIXME above it. When moving the condition directly into the if-statement some specs are not passing...