### PR TITLE
Implement Enumerable#entries

### DIFF
--- a/spec/core/enumerable/entries_spec.rb
+++ b/spec/core/enumerable/entries_spec.rb
@@ -1,5 +1,3 @@
-# skip-test
-
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/entries'

--- a/spec/core/enumerable/shared/entries.rb
+++ b/spec/core/enumerable/shared/entries.rb
@@ -4,7 +4,7 @@ describe :enumerable_entries, shared: true do
     numerous.send(@method).should == [1, nil, "a", 2, false, true]
   end
 
-  xit "passes through the values yielded by #each_with_index" do
+  it "passes through the values yielded by #each_with_index" do
     [:a, :b].each_with_index.send(@method).should == [[:a, 0], [:b, 1]]
   end
 

--- a/src/enumerable.rb
+++ b/src/enumerable.rb
@@ -889,6 +889,8 @@ module Enumerable
     result
   end
 
+  alias entries to_a
+
   def to_h(*args)
     h = {}
 


### PR DESCRIPTION
[#19]

Let me know if this is a stretch. Looking over the ruby [`#entries`](https://ruby-doc.org/core-2.7.3/Enumerable.html#method-i-entries) documentation, it seemed like the entries implementation didn't seem to far off from `#to_a`.