### PR TITLE
Add Enumerable#max_by and Enumerable#min_by methods

### DIFF
--- a/spec/core/enumerable/max_by_spec.rb
+++ b/spec/core/enumerable/max_by_spec.rb
@@ -1,5 +1,3 @@
-# skip-test
-
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/enumerable_enumeratorized'

--- a/spec/core/enumerable/min_by_spec.rb
+++ b/spec/core/enumerable/min_by_spec.rb
@@ -1,5 +1,3 @@
-# skip-test
-
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/enumerable_enumeratorized'

--- a/src/enumerable.rb
+++ b/src/enumerable.rb
@@ -479,6 +479,19 @@ module Enumerable
     end
   end
 
+  def max_by(n = nil)
+    return enum_for(:max_by) unless block_given?
+    if n
+      to_a.sort_by { |a| yield a }.last(n).reverse
+    else
+      max(n) { |a, b|
+        fa = yield(a)
+        fb = yield(b)
+        fa <=> fb
+      }
+    end
+  end
+
   def min(n = nil)
     has_block = block_given?
     cmp = ->(result) {
@@ -524,6 +537,19 @@ module Enumerable
       rescue StopIteration
       end
       val
+    end
+  end
+
+  def min_by(n = nil)
+    return enum_for(:min_by) unless block_given?
+    if n
+      to_a.sort_by { |a| yield a }.take(n)
+    else
+      min(n) { |a, b|
+        fa = yield(a)
+        fb = yield(b)
+        fa <=> fb
+      }
     end
   end
 


### PR DESCRIPTION
The "min/max n elements" implementation is not the most efficient, but their implementations within Enumerable#max and Enumerable#min did not seem the veryefficient either, so I figured this was "good enough"

