### PR TITLE
Implement Enumerable#minmax and Enumerable#minmax_by

### DIFF
--- a/spec/core/enumerable/minmax_by_spec.rb
+++ b/spec/core/enumerable/minmax_by_spec.rb
@@ -1,5 +1,3 @@
-# skip-test
-
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/enumerable_enumeratorized'

--- a/spec/core/enumerable/minmax_spec.rb
+++ b/spec/core/enumerable/minmax_spec.rb
@@ -1,5 +1,3 @@
-# skip-test
-
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 


### PR DESCRIPTION
The simplest way would be to use `Enumerable#sort` here, but one spec requires that objects that appear first will be returned first in case of a tie, which is not guaranteed with `Enumerable#sort`.

[#19]