### PR TITLE
Array flatten in place

### DIFF
--- a/include/natalie/array_value.hpp
+++ b/include/natalie/array_value.hpp
@@ -160,7 +160,7 @@ private:
 
     Vector<ValuePtr> m_vector {};
 
-    bool _flatten_in_place(Env *, nat_int_t depth, Hashmap<ArrayValue *> visited_arrays = Hashmap<ArrayValue *>{});
+    bool _flatten_in_place(Env *, nat_int_t depth, Hashmap<ArrayValue *> visited_arrays = Hashmap<ArrayValue *> {});
 };
 
 }

--- a/include/natalie/array_value.hpp
+++ b/include/natalie/array_value.hpp
@@ -107,6 +107,7 @@ public:
     ValuePtr eql(Env *, ValuePtr);
     ValuePtr first(Env *, ValuePtr);
     ValuePtr flatten(Env *, ValuePtr);
+    ValuePtr flatten_in_place(Env *, ValuePtr);
     ValuePtr include(Env *, ValuePtr);
     ValuePtr index(Env *, ValuePtr, Block *);
     ValuePtr inspect(Env *);
@@ -157,12 +158,9 @@ private:
         : Value { Value::Type::Array, GlobalEnv::the()->Array() }
         , m_vector { std::move(vector) } { }
 
-    ArrayValue(ClassValue *klass)
-        : Value { Value::Type::Array, klass } { }
-
     Vector<ValuePtr> m_vector {};
 
-    ValuePtr _flatten(Env *, nat_int_t depth, Vector<ArrayValue *> visited_arrays);
+    bool _flatten_in_place(Env *, nat_int_t depth, Vector<ArrayValue *> visited_arrays);
 };
 
 }

--- a/include/natalie/array_value.hpp
+++ b/include/natalie/array_value.hpp
@@ -160,7 +160,7 @@ private:
 
     Vector<ValuePtr> m_vector {};
 
-    bool _flatten_in_place(Env *, nat_int_t depth, Vector<ArrayValue *> visited_arrays);
+    bool _flatten_in_place(Env *, nat_int_t depth, Hashmap<ArrayValue *> visited_arrays = Hashmap<ArrayValue *>{});
 };
 
 }

--- a/include/tm/vector.hpp
+++ b/include/tm/vector.hpp
@@ -115,10 +115,12 @@ public:
     }
 
     T pop_front() {
-        return pop_at(0);
+        T val = m_data[0];
+        remove(0);
+        return val;
     }
 
-    T pop_at(size_t index) {
+    void remove(size_t index) {
         assert(m_size > index);
         T val = m_data[index];
 
@@ -126,8 +128,6 @@ public:
             m_data[i - 1] = m_data[i];
         }
         --m_size;
-
-        return val;
     }
 
     bool is_empty() const { return m_size == 0; }

--- a/include/tm/vector.hpp
+++ b/include/tm/vector.hpp
@@ -100,21 +100,29 @@ public:
     }
 
     void push_front(T val) {
+        insert(0, val);
+    }
+
+    void insert(size_t index, T val) {
         if (m_size >= m_capacity) {
             grow_at_least(m_size + 1);
         }
         m_size++;
-        for (size_t i = m_size - 1; i > 0; i--) {
+        for (size_t i = m_size - 1; i > index; i--) {
             m_data[i] = m_data[i - 1];
         }
-        m_data[0] = val;
+        m_data[index] = val;
     }
 
     T pop_front() {
-        assert(m_size != 0);
-        T val = m_data[0];
+        return pop_at(0);
+    }
 
-        for (size_t i = 1; i < m_size; i++) {
+    T pop_at(size_t index) {
+        assert(m_size > index);
+        T val = m_data[index];
+
+        for (size_t i = index + 1; i < m_size; i++) {
             m_data[i - 1] = m_data[i];
         }
         --m_size;

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -289,6 +289,7 @@ gen.binding('Array', 'filter', 'ArrayValue', 'select', argc: 0, pass_env: true, 
 gen.binding('Array', 'find_index', 'ArrayValue', 'index', argc: 0..1, pass_env: true, pass_block: true, return_type: :Value)
 gen.binding('Array', 'first', 'ArrayValue', 'first', argc: 0..1, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Array', 'flatten', 'ArrayValue', 'flatten', argc: 0..1, pass_env: true, pass_block: false, return_type: :Value)
+gen.binding('Array', 'flatten!', 'ArrayValue', 'flatten_in_place', argc: 0..1, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Array', 'include?', 'ArrayValue', 'include', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Array', 'index', 'ArrayValue', 'index', argc: 0..1, pass_env: true, pass_block: true, return_type: :Value)
 gen.binding('Array', 'intersection', 'ArrayValue', 'intersection', argc: :any, pass_env: true, pass_block: false, return_type: :Value)

--- a/spec/core/array/flatten_spec.rb
+++ b/spec/core/array/flatten_spec.rb
@@ -182,58 +182,58 @@ describe "Array#flatten" do
 end
 
 describe "Array#flatten!" do
-  xit "modifies array to produce a one-dimensional flattening recursively" do
+  it "modifies array to produce a one-dimensional flattening recursively" do
     a = [[[1, [2, 3]],[2, 3, [4, [4, [5, 5]], [1, 2, 3]]], [4]], []]
     a.flatten!
     a.should == [1, 2, 3, 2, 3, 4, 4, 5, 5, 1, 2, 3, 4]
   end
 
-  xit "returns self if made some modifications" do
+  it "returns self if made some modifications" do
     a = [[[1, [2, 3]],[2, 3, [4, [4, [5, 5]], [1, 2, 3]]], [4]], []]
     a.flatten!.should equal(a)
   end
 
-  xit "returns nil if no modifications took place" do
+  it "returns nil if no modifications took place" do
     a = [1, 2, 3]
     a.flatten!.should == nil
     a = [1, [2, 3]]
     a.flatten!.should_not == nil
   end
 
-  xit "should not check modification by size" do
+  it "should not check modification by size" do
     a = [1, 2, [3]]
     a.flatten!.should_not == nil
     a.should == [1, 2, 3]
   end
 
-  xit "takes an optional argument that determines the level of recursion" do
+  it "takes an optional argument that determines the level of recursion" do
     [ 1, 2, [3, [4, 5] ] ].flatten!(1).should == [1, 2, 3, [4, 5]]
   end
 
   # redmine #1440
-  xit "returns nil when the level of recursion is 0" do
+  it "returns nil when the level of recursion is 0" do
     a = [ 1, 2, [3, [4, 5] ] ]
     a.flatten!(0).should == nil
   end
 
-  xit "treats negative levels as no arguments" do
+  it "treats negative levels as no arguments" do
     [ 1, 2, [ 3, 4, [5, 6] ] ].flatten!(-1).should == [1, 2, 3, 4, 5, 6]
     [ 1, 2, [ 3, 4, [5, 6] ] ].flatten!(-10).should == [1, 2, 3, 4, 5, 6]
   end
 
-  xit "tries to convert passed Objects to Integers using #to_int" do
+  it "tries to convert passed Objects to Integers using #to_int" do
     obj = mock("Converted to Integer")
     obj.should_receive(:to_int).and_return(1)
 
     [ 1, 2, [3, [4, 5] ] ].flatten!(obj).should == [1, 2, 3, [4, 5]]
   end
 
-  xit "raises a TypeError when the passed Object can't be converted to an Integer" do
+  it "raises a TypeError when the passed Object can't be converted to an Integer" do
     obj = mock("Not converted")
     -> { [ 1, 2, [3, [4, 5] ] ].flatten!(obj) }.should raise_error(TypeError)
   end
 
-  xit "does not call flatten! on elements" do
+  it "does not call flatten! on elements" do
     obj = mock('[1,2]')
     obj.should_not_receive(:flatten!)
     [obj, obj].flatten!.should == nil
@@ -243,7 +243,7 @@ describe "Array#flatten!" do
     [obj, obj].flatten!.should == [5, 4, 5, 4]
   end
 
-  xit "raises an ArgumentError on recursive arrays" do
+  it "raises an ArgumentError on recursive arrays" do
     x = []
     x << x
     -> { x.flatten! }.should raise_error(ArgumentError)
@@ -255,7 +255,7 @@ describe "Array#flatten!" do
     -> { x.flatten! }.should raise_error(ArgumentError)
   end
 
-  xit "flattens any elements which responds to #to_ary, using the return value of said method" do
+  it "flattens any elements which responds to #to_ary, using the return value of said method" do
     x = mock("[3,4]")
     x.should_receive(:to_ary).at_least(:once).and_return([3, 4])
     [1, 2, x, 5].flatten!.should == [1, 2, 3, 4, 5]
@@ -274,14 +274,14 @@ describe "Array#flatten!" do
     ary.should == [1, 2, 3]
   end
 
-  xit "raises a FrozenError on frozen arrays when the array is modified" do
+  it "raises a FrozenError on frozen arrays when the array is modified" do
     nested_ary = [1, 2, []]
     nested_ary.freeze
     -> { nested_ary.flatten! }.should raise_error(FrozenError)
   end
 
   # see [ruby-core:23663]
-  xit "raises a FrozenError on frozen arrays when the array would not be modified" do
+  it "raises a FrozenError on frozen arrays when the array would not be modified" do
     -> { ArraySpecs.frozen_array.flatten! }.should raise_error(FrozenError)
     -> { ArraySpecs.empty_frozen_array.flatten! }.should raise_error(FrozenError)
   end

--- a/src/array_value.cpp
+++ b/src/array_value.cpp
@@ -347,10 +347,7 @@ ValuePtr ArrayValue::flatten(Env *env, ValuePtr depth) {
 }
 
 ValuePtr ArrayValue::flatten_in_place(Env *env, ValuePtr depth) {
-    if (is_frozen()) {
-        env->raise("FrozenError", "can't modify frozen Array: {}", inspect_str(env));
-        return nullptr;
-    }
+    this->assert_not_frozen(env);
 
     bool changed { false };
 
@@ -427,7 +424,7 @@ bool ArrayValue::_flatten_in_place(Env *env, nat_int_t depth, Hashmap<ArrayValue
 
         if (item->is_array()) {
             changed = true;
-            m_vector.pop_at(i - 1);
+            m_vector.remove(i - 1);
 
             auto array_item = item->as_array();
 


### PR DESCRIPTION
Partially implements Array::flatten! from #39 with the exception of:
- Make use of respond_to_missing and method_missing in value for when respond_to would otherwise return false. These methods seem to be more something we should implement in Value and in a separate PR/Issue, but if preferred I'll gladly cover both in this PR.

Followed suggestion from #75 and replaced vector with Hashmap.