### PR TITLE
add spec for Array::compact and compact! and implement Array compact!

### DIFF
--- a/include/natalie/array_value.hpp
+++ b/include/natalie/array_value.hpp
@@ -100,6 +100,7 @@ public:
     ValuePtr cmp(Env *, ValuePtr);
     ValuePtr clear(Env *);
     ValuePtr compact(Env *);
+    ValuePtr compact_in_place(Env *);
     ValuePtr concat(Env *, size_t, ValuePtr *);
     ValuePtr dig(Env *, size_t, ValuePtr *);
     ValuePtr drop(Env *, ValuePtr);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -282,6 +282,7 @@ gen.binding('Array', 'clear', 'ArrayValue', 'clear', argc: 0, pass_env: true, pa
 gen.binding('Array', 'collect', 'ArrayValue', 'map', argc: 0, pass_env: true, pass_block: true, return_type: :Value)
 gen.binding('Array', 'concat', 'ArrayValue', 'concat', argc: :any, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Array', 'compact', 'ArrayValue', 'compact', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
+gen.binding('Array', 'compact!', 'ArrayValue', 'compact_in_place', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Array', 'dig', 'ArrayValue', 'dig', argc: :any, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Array', 'drop', 'ArrayValue', 'drop', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Array', 'each', 'ArrayValue', 'each', argc: 0, pass_env: true, pass_block: true, return_type: :Value)

--- a/spec/core/array/compact_spec.rb
+++ b/spec/core/array/compact_spec.rb
@@ -1,0 +1,81 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Array#compact" do
+  it "returns a copy of array with all nil elements removed" do
+    a = [1, 2, 4]
+    a.compact.should == [1, 2, 4]
+    a = [1, nil, 2, 4]
+    a.compact.should == [1, 2, 4]
+    a = [1, 2, 4, nil]
+    a.compact.should == [1, 2, 4]
+    a = [nil, 1, 2, 4]
+    a.compact.should == [1, 2, 4]
+  end
+
+  it "does not return self" do
+    a = [1, 2, 3]
+    a.compact.should_not equal(a)
+  end
+
+  it "does not return subclass instance for Array subclasses" do
+    ArraySpecs::MyArray[1, 2, 3, nil].compact.should be_an_instance_of(Array)
+  end
+
+  ruby_version_is ''...'2.7' do
+    it "does not keep tainted status even if all elements are removed" do
+      a = [nil, nil]
+      a.taint
+      a.compact.tainted?.should be_false
+    end
+
+    it "does not keep untrusted status even if all elements are removed" do
+      a = [nil, nil]
+      a.untrust
+      a.compact.untrusted?.should be_false
+    end
+  end
+end
+
+describe "Array#compact!" do
+  it "removes all nil elements" do
+    a = ['a', nil, 'b', false, 'c']
+    a.compact!.should equal(a)
+    a.should == ["a", "b", false, "c"]
+    a = [nil, 'a', 'b', false, 'c']
+    a.compact!.should equal(a)
+    a.should == ["a", "b", false, "c"]
+    a = ['a', 'b', false, 'c', nil]
+    a.compact!.should equal(a)
+    a.should == ["a", "b", false, "c"]
+  end
+
+  it "returns self if some nil elements are removed" do
+    a = ['a', nil, 'b', false, 'c']
+    a.compact!.should equal a
+  end
+
+  it "returns nil if there are no nil elements to remove" do
+    [1, 2, false, 3].compact!.should == nil
+  end
+
+  ruby_version_is ''...'2.7' do
+    it "keeps tainted status even if all elements are removed" do
+      a = [nil, nil]
+      a.taint
+      a.compact!
+      a.tainted?.should be_true
+    end
+
+    it "keeps untrusted status even if all elements are removed" do
+      a = [nil, nil]
+      a.untrust
+      a.compact!
+      a.untrusted?.should be_true
+    end
+  end
+
+  it "raises a FrozenError on a frozen array" do
+    -> { ArraySpecs.frozen_array.compact! }.should raise_error(FrozenError)
+  end
+end

--- a/src/array_value.cpp
+++ b/src/array_value.cpp
@@ -779,6 +779,24 @@ ValuePtr ArrayValue::compact(Env *env) {
     return ary;
 }
 
+ValuePtr ArrayValue::compact_in_place(Env *env) {
+    this->assert_not_frozen(env);
+
+    bool changed { false };
+    for (size_t i = size(); i > 0; --i) {
+        auto item = (*this)[i - 1];
+        if (item->is_nil()) {
+            changed = true;
+            m_vector.remove(i - 1);
+        }
+    }
+
+    if (changed)
+        return this;
+
+    return NilValue::the();
+}
+
 ValuePtr ArrayValue::uniq_in_place(Env *env, Block *block) {
     this->assert_not_frozen(env);
 


### PR DESCRIPTION
Implement Array::compact! from #39 and adds the spec for both compact and compact!

compact was already implemented and I kept it as it easy as it is much simpler to add elements to a new array rather than creating a copy of the current one and then compacting that. 