### PR TITLE
Implement Enumerator::Lazy#drop and Enumerator::Lazy#drop_while

### DIFF
--- a/include/natalie/range_value.hpp
+++ b/include/natalie/range_value.hpp
@@ -32,6 +32,7 @@ public:
     ValuePtr initialize(Env *, ValuePtr, ValuePtr, ValuePtr);
     ValuePtr to_a(Env *);
     ValuePtr each(Env *, Block *);
+    ValuePtr first(Env *, ValuePtr);
     ValuePtr inspect(Env *);
     ValuePtr eq(Env *, ValuePtr);
     ValuePtr eqeqeq(Env *, ValuePtr);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -608,6 +608,7 @@ gen.binding('Range', 'last', 'RangeValue', 'end', argc: 0, pass_env: false, pass
 gen.binding('Range', 'exclude_end?', 'RangeValue', 'exclude_end', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
 gen.binding('Range', 'to_a', 'RangeValue', 'to_a', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Range', 'each', 'RangeValue', 'each', argc: 0, pass_env: true, pass_block: true, return_type: :Value)
+gen.binding('Range', 'first', 'RangeValue', 'first', argc: 0..1, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Range', 'inspect', 'RangeValue', 'inspect', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Range', '==', 'RangeValue', 'eq', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Range', '===', 'RangeValue', 'eqeqeq', argc: 1, pass_env: true, pass_block: false, return_type: :Value)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -603,7 +603,6 @@ gen.static_binding('Process', 'pid', 'ProcessModule', 'pid', argc: 0, pass_env: 
 
 gen.binding('Range', 'initialize', 'RangeValue', 'initialize', argc: 2..3, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Range', 'begin', 'RangeValue', 'begin', argc: 0, pass_env: false, pass_block: false, return_type: :Value)
-gen.binding('Range', 'first', 'RangeValue', 'begin', argc: 0, pass_env: false, pass_block: false, return_type: :Value)
 gen.binding('Range', 'end', 'RangeValue', 'end', argc: 0, pass_env: false, pass_block: false, return_type: :Value)
 gen.binding('Range', 'last', 'RangeValue', 'end', argc: 0, pass_env: false, pass_block: false, return_type: :Value)
 gen.binding('Range', 'exclude_end?', 'RangeValue', 'exclude_end', argc: 0, pass_env: false, pass_block: false, return_type: :bool)

--- a/spec/core/enumerator/lazy/chunk_spec.rb
+++ b/spec/core/enumerator/lazy/chunk_spec.rb
@@ -47,8 +47,7 @@ describe "Enumerator::Lazy#chunk" do
   end
 
   describe "on a nested Lazy" do
-    # Implement Enumerator::Lazy#take(n)
-    xit "sets #size to nil" do
+    it "sets #size to nil" do
       Enumerator::Lazy.new(Object.new, 100) {}.take(20).chunk { |v| v }.size.should == nil
     end
 
@@ -60,8 +59,7 @@ describe "Enumerator::Lazy#chunk" do
     end
   end
 
-  # TODO: Implement Range#first(n)
-  xit "works with an infinite enumerable" do
+  it "works with an infinite enumerable" do
     s = 0..Float::INFINITY
     s.lazy.chunk { |n| n.even? }.first(100).should ==
       s.first(100).chunk { |n| n.even? }.to_a

--- a/spec/core/enumerator/lazy/drop_spec.rb
+++ b/spec/core/enumerator/lazy/drop_spec.rb
@@ -1,0 +1,59 @@
+# -*- encoding: us-ascii -*-
+
+require_relative '../../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Enumerator::Lazy#drop" do
+  before :each do
+    @yieldsmixed = EnumeratorLazySpecs::YieldsMixed.new.to_enum.lazy
+    @eventsmixed = EnumeratorLazySpecs::EventsMixed.new.to_enum.lazy
+    ScratchPad.record []
+  end
+
+  after :each do
+    ScratchPad.clear
+  end
+
+  it "returns a new instance of Enumerator::Lazy" do
+    ret = @yieldsmixed.drop(1)
+    ret.should be_an_instance_of(Enumerator::Lazy)
+    ret.should_not equal(@yieldsmixed)
+  end
+
+  it "sets difference of given count with old size to new size" do
+    Enumerator::Lazy.new(Object.new, 100) {}.drop(20).size.should == 80
+    Enumerator::Lazy.new(Object.new, 100) {}.drop(200).size.should == 0
+  end
+
+  describe "when the returned lazy enumerator is evaluated by Enumerable#first" do
+    it "stops after specified times" do
+      (0..Float::INFINITY).lazy.drop(2).first(2).should == [2, 3]
+
+      @eventsmixed.drop(0).first(1)
+      ScratchPad.recorded.should == [:before_yield]
+    end
+  end
+
+  describe "on a nested Lazy" do
+    it "sets difference of given count with old size to new size" do
+      Enumerator::Lazy.new(Object.new, 100) {}.drop(20).drop(50).size.should == 30
+      Enumerator::Lazy.new(Object.new, 100) {}.drop(50).drop(20).size.should == 30
+    end
+
+    describe "when the returned lazy enumerator is evaluated by Enumerable#first" do
+      it "stops after specified times" do
+        (0..Float::INFINITY).lazy.drop(2).drop(2).first(2).should == [4, 5]
+
+        @eventsmixed.drop(0).drop(0).first(1)
+        ScratchPad.recorded.should == [:before_yield]
+      end
+    end
+  end
+
+  # TODO: Implement Range#first(n)
+  xit "works with an infinite enumerable" do
+    s = 0..Float::INFINITY
+    s.lazy.drop(100).first(100).should ==
+      s.first(200).drop(100)
+  end
+end

--- a/spec/core/enumerator/lazy/drop_spec.rb
+++ b/spec/core/enumerator/lazy/drop_spec.rb
@@ -50,8 +50,7 @@ describe "Enumerator::Lazy#drop" do
     end
   end
 
-  # TODO: Implement Range#first(n)
-  xit "works with an infinite enumerable" do
+  it "works with an infinite enumerable" do
     s = 0..Float::INFINITY
     s.lazy.drop(100).first(100).should ==
       s.first(200).drop(100)

--- a/spec/core/enumerator/lazy/drop_while_spec.rb
+++ b/spec/core/enumerator/lazy/drop_while_spec.rb
@@ -1,0 +1,67 @@
+# -*- encoding: us-ascii -*-
+
+require_relative '../../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Enumerator::Lazy#drop_while" do
+  before :each do
+    @yieldsmixed = EnumeratorLazySpecs::YieldsMixed.new.to_enum.lazy
+    @eventsmixed = EnumeratorLazySpecs::EventsMixed.new.to_enum.lazy
+    ScratchPad.record []
+  end
+
+  after :each do
+    ScratchPad.clear
+  end
+
+  it "returns a new instance of Enumerator::Lazy" do
+    ret = @yieldsmixed.drop_while {}
+    ret.should be_an_instance_of(Enumerator::Lazy)
+    ret.should_not equal(@yieldsmixed)
+  end
+
+  it "sets #size to nil" do
+    Enumerator::Lazy.new(Object.new, 100) {}.drop_while { |v| v }.size.should == nil
+  end
+
+  describe "when the returned lazy enumerator is evaluated by Enumerable#first" do
+    it "stops after specified times" do
+      (0..Float::INFINITY).lazy.drop_while { |n| n < 5 }.first(2).should == [5, 6]
+
+      @eventsmixed.drop_while { false }.first(1)
+      ScratchPad.recorded.should == [:before_yield]
+    end
+  end
+
+  it "calls the block with initial values when yield with multiple arguments" do
+    yields = []
+    @yieldsmixed.drop_while { |v| yields << v; true }.force
+    yields.should == EnumeratorLazySpecs::YieldsMixed.initial_yields
+  end
+
+  it "raises an ArgumentError when not given a block" do
+    -> { @yieldsmixed.drop_while }.should raise_error(ArgumentError)
+  end
+
+  describe "on a nested Lazy" do
+    it "sets #size to nil" do
+      Enumerator::Lazy.new(Object.new, 100) {}.take(20).drop_while { |v| v }.size.should == nil
+    end
+
+    describe "when the returned lazy enumerator is evaluated by Enumerable#first" do
+      it "stops after specified times" do
+        (0..Float::INFINITY).lazy.drop_while { |n| n < 5 }.drop_while { |n| n.odd? }.first(2).should == [6, 7]
+
+        @eventsmixed.drop_while { false }.drop_while { false }.first(1)
+        ScratchPad.recorded.should == [:before_yield]
+      end
+    end
+  end
+
+  # TODO: Implement Range#first(n)
+  xit "works with an infinite enumerable" do
+    s = 0..Float::INFINITY
+    s.lazy.drop_while { |n| n < 100 }.first(100).should ==
+      s.first(200).drop_while { |n| n < 100 }
+  end
+end

--- a/spec/core/enumerator/lazy/drop_while_spec.rb
+++ b/spec/core/enumerator/lazy/drop_while_spec.rb
@@ -58,8 +58,7 @@ describe "Enumerator::Lazy#drop_while" do
     end
   end
 
-  # TODO: Implement Range#first(n)
-  xit "works with an infinite enumerable" do
+  it "works with an infinite enumerable" do
     s = 0..Float::INFINITY
     s.lazy.drop_while { |n| n < 100 }.first(100).should ==
       s.first(200).drop_while { |n| n < 100 }

--- a/spec/core/enumerator/lazy/shared/collect.rb
+++ b/spec/core/enumerator/lazy/shared/collect.rb
@@ -54,8 +54,7 @@ describe :enumerator_lazy_collect, shared: true do
     end
   end
 
-  # TODO: Implement Range#first(n)
-  xit "works with an infinite enumerable" do
+  it "works with an infinite enumerable" do
     s = 0..Float::INFINITY
     s.lazy.send(@method) { |n| n }.first(100).should ==
       s.first(100).send(@method) { |n| n }.to_a

--- a/spec/core/enumerator/lazy/shared/collect_concat.rb
+++ b/spec/core/enumerator/lazy/shared/collect_concat.rb
@@ -72,7 +72,7 @@ describe :enumerator_lazy_collect_concat, shared: true do
     end
   end
 
-  # TODO: Implement Range#first(n) and +Integer
+  # TODO: Implement +Integer
   xit "works with an infinite enumerable" do
     s = 0..Float::INFINITY
     s.lazy.send(@method) { |n| [-n, +n] }.first(200).should ==

--- a/spec/core/enumerator/lazy/shared/select.rb
+++ b/spec/core/enumerator/lazy/shared/select.rb
@@ -44,8 +44,7 @@ describe :enumerator_lazy_select, shared: true do
   end
 
   describe "on a nested Lazy" do
-    # Enumerable::Lazy#take(n) is not implemented yet
-    xit "sets #size to nil" do
+    it "sets #size to nil" do
       Enumerator::Lazy.new(Object.new, 100) {}.take(50) {}.send(@method) { true }.size.should == nil
     end
 
@@ -59,8 +58,7 @@ describe :enumerator_lazy_select, shared: true do
     end
   end
 
-  # TODO: Implement Range#first(n)
-  xit "works with an infinite enumerable" do
+  it "works with an infinite enumerable" do
     s = 0..Float::INFINITY
     s.lazy.send(@method) { |n| true }.first(100).should ==
       s.first(100).send(@method) { |n| true }

--- a/spec/core/enumerator/lazy/shared/to_enum.rb
+++ b/spec/core/enumerator/lazy/shared/to_enum.rb
@@ -51,7 +51,7 @@ describe :enumerator_lazy_to_enum, shared: true do
     end
   end
 
-  # TODO: Enumerator::Lazy#with_index and Range#first(n) have to be implemented
+  # TODO: Enumerator::Lazy#with_index has to be implemented
   xit "works with an infinite enumerable" do
     s = 0..Float::INFINITY
     s.lazy.send(@method, :with_index).first(100).should ==

--- a/spec/core/range/first_spec.rb
+++ b/spec/core/range/first_spec.rb
@@ -1,0 +1,56 @@
+require_relative '../../spec_helper'
+require_relative 'shared/begin'
+
+describe "Range#first" do
+  it_behaves_like :range_begin, :first
+
+  it "returns the specified number of elements from the beginning" do
+    (0..2).first(2).should == [0, 1]
+  end
+
+  it "returns an empty array for an empty Range" do
+    (0...0).first(2).should == []
+  end
+
+  it "returns an empty array when passed zero" do
+    (0..2).first(0).should == []
+  end
+
+  it "returns all elements in the range when count exceeds the number of elements" do
+    (0..2).first(4).should == [0, 1, 2]
+  end
+
+  it "raises an ArgumentError when count is negative" do
+    -> { (0..2).first(-1) }.should raise_error(ArgumentError)
+  end
+
+  it "calls #to_int to convert the argument" do
+    obj = mock_int(2)
+    (3..7).first(obj).should == [3, 4]
+  end
+
+  it "raises a TypeError if #to_int does not return an Integer" do
+    obj = mock("to_int")
+    obj.should_receive(:to_int).and_return("1")
+    -> { (2..3).first(obj) }.should raise_error(TypeError)
+  end
+
+  it "truncates the value when passed a Float" do
+    (2..9).first(2.8).should == [2, 3]
+  end
+
+  it "raises a TypeError when passed nil" do
+    -> { (2..3).first(nil) }.should raise_error(TypeError)
+  end
+
+  it "raises a TypeError when passed a String" do
+    -> { (2..3).first("1") }.should raise_error(TypeError)
+  end
+
+  ruby_version_is "2.7" do
+    # TODO: implement beginless ranges
+    xit "raises a RangeError when called on an beginless range" do
+      -> { eval("(..1)").first }.should raise_error(RangeError)
+    end
+  end
+end

--- a/spec/core/range/shared/begin.rb
+++ b/spec/core/range/shared/begin.rb
@@ -1,0 +1,10 @@
+describe :range_begin, shared: true do
+  it "returns the first element of self" do
+    (-1..1).send(@method).should == -1
+    (0..1).send(@method).should == 0
+    (0xffff...0xfffff).send(@method).should == 65535
+    ('Q'..'T').send(@method).should == 'Q'
+    ('Q'...'T').send(@method).should == 'Q'
+    (0.5..2.4).send(@method).should == 0.5
+  end
+end

--- a/src/enumerator.rb
+++ b/src/enumerator.rb
@@ -169,6 +169,18 @@ class Enumerator
       lazy
     end
 
+    def drop(n)
+      size = @size ? [0, @size - n].max : nil
+
+      Lazy.new(self, size) do |yielder, *element|
+        if n == 0
+          yielder.yield(*element)
+        else
+          n -= 1
+        end
+      end
+    end
+
     def eager
       Enumerator.new(@size) do |yielder|
         the_proc = yielder.to_proc || ->(*i) { yielder.yield(*i) }

--- a/src/enumerator.rb
+++ b/src/enumerator.rb
@@ -181,6 +181,19 @@ class Enumerator
       end
     end
 
+    def drop_while(&block)
+      raise ArgumentError, 'tried to call lazy drop_while without a block' unless block_given?
+
+      drop = true
+      Lazy.new(self) do |yielder, *elements|
+        unless block.call(*elements)
+          drop = false
+        end
+
+        yielder.yield(*elements) unless drop
+      end
+    end
+
     def eager
       Enumerator.new(@size) do |yielder|
         the_proc = yielder.to_proc || ->(*i) { yielder.yield(*i) }

--- a/src/range_value.cpp
+++ b/src/range_value.cpp
@@ -63,6 +63,34 @@ ValuePtr RangeValue::each(Env *env, Block *block) {
     return this;
 }
 
+ValuePtr RangeValue::first(Env *env, ValuePtr n) {
+    if (n) {
+        if (n->respond_to(env, SymbolValue::intern("to_int"))) {
+            n = n->send(env, SymbolValue::intern("to_int"));
+        }
+        n->assert_type(env, Value::Type::Integer, "Integer");
+
+        nat_int_t count = n->as_integer()->to_nat_int_t();
+        if (count < 0) {
+            env->raise("ArgumentError", "negative array size (or size too big)");
+            return nullptr;
+        }
+
+        ArrayValue *ary = new ArrayValue {};
+        iterate_over_range(env, [&](ValuePtr item) -> ValuePtr {
+            if (count == 0) return n;
+
+            ary->push(item);
+            count--;
+            return nullptr;
+        });
+
+        return ary;
+    } else {
+        return begin();
+    }
+}
+
 ValuePtr RangeValue::inspect(Env *env) {
     if (m_exclude_end) {
         return StringValue::format(env, "{}...{}", m_begin->inspect_str(env), m_end->inspect_str(env));

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -701,6 +701,26 @@ def mock(name)
   end
 end
 
+class MockIntObject
+  def initialize(value)
+    @value = value
+  end
+
+  def to_int
+    @value.to_int
+  end
+
+  def inspect
+    "<mock_int: #{@value}>"
+  end
+end
+
+def mock_int(value)
+  mock("int #{value}").tap do |obj|
+    obj.should_receive(:to_int).at_least(:once).and_return(value.to_int)
+  end
+end
+
 def run_specs
   @failures = []
   @errors = []


### PR DESCRIPTION
This also removes the binding for Range#first, because Range includes the Enumerable module that provides this method.