### PR TITLE
Implement Enumerator::Lazy#grep and #grep_v

### DIFF
--- a/spec/core/enumerator/lazy/grep_spec.rb
+++ b/spec/core/enumerator/lazy/grep_spec.rb
@@ -1,0 +1,125 @@
+# -*- encoding: us-ascii -*-
+
+require_relative '../../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Enumerator::Lazy#grep" do
+  before :each do
+    @yieldsmixed = EnumeratorLazySpecs::YieldsMixed.new.to_enum.lazy
+    @eventsmixed = EnumeratorLazySpecs::EventsMixed.new.to_enum.lazy
+    ScratchPad.record []
+  end
+
+  after :each do
+    ScratchPad.clear
+  end
+
+  it "requires an argument" do
+    # Enumerator::Lazy.instance_method(:grep).arity.should == 1
+    Enumerator::Lazy.new(nil) {}.method(:grep).arity.should == 1
+  end
+
+  it "returns a new instance of Enumerator::Lazy" do
+    ret = @yieldsmixed.grep(Object) {}
+    ret.should be_an_instance_of(Enumerator::Lazy)
+    ret.should_not equal(@yieldsmixed)
+
+    ret = @yieldsmixed.grep(Object)
+    ret.should be_an_instance_of(Enumerator::Lazy)
+    ret.should_not equal(@yieldsmixed)
+  end
+
+  it "sets #size to nil" do
+    Enumerator::Lazy.new(Object.new, 100) {}.grep(Object) {}.size.should == nil
+    Enumerator::Lazy.new(Object.new, 100) {}.grep(Object).size.should == nil
+  end
+
+  # FIXME: back ref inside block
+  xit "sets $~ in the block" do
+    "z" =~ /z/ # Reset $~
+    ["abc", "def"].lazy.grep(/b/) { |e|
+      e.should == "abc"
+      $&.should == "b"
+    }.force
+
+    # Set by the failed match of "def"
+    $~.should == nil
+  end
+
+  # FIXME: back ref inside block
+  xit "sets $~ in the next block with each" do
+    "z" =~ /z/ # Reset $~
+    ["abc", "def"].lazy.grep(/b/).each { |e|
+      e.should == "abc"
+      $&.should == "b"
+    }
+
+    # Set by the failed match of "def"
+    $~.should == nil
+  end
+
+  # FIXME: back ref inside block
+  xit "sets $~ in the next block with map" do
+    "z" =~ /z/ # Reset $~
+    ["abc", "def"].lazy.grep(/b/).map { |e|
+      e.should == "abc"
+      $&.should == "b"
+    }.force
+
+    # Set by the failed match of "def"
+    $~.should == nil
+  end
+
+  describe "when the returned lazy enumerator is evaluated by Enumerable#first" do
+    it "stops after specified times when not given a block" do
+      (0..Float::INFINITY).lazy.grep(Integer).first(3).should == [0, 1, 2]
+
+      @eventsmixed.grep(BasicObject).first(1)
+      ScratchPad.recorded.should == [:before_yield]
+    end
+
+    it "stops after specified times when given a block" do
+      (0..Float::INFINITY).lazy.grep(Integer, &:succ).first(3).should == [1, 2, 3]
+
+      @eventsmixed.grep(BasicObject) {}.first(1)
+      ScratchPad.recorded.should == [:before_yield]
+    end
+  end
+
+  it "calls the block with a gathered array when yield with multiple arguments" do
+    yields = []
+    @yieldsmixed.grep(BasicObject) { |v| yields << v }.force
+    yields.should == EnumeratorLazySpecs::YieldsMixed.gathered_yields
+
+    @yieldsmixed.grep(BasicObject).force.should == yields
+  end
+
+  describe "on a nested Lazy" do
+    it "sets #size to nil" do
+      Enumerator::Lazy.new(Object.new, 100) {}.grep(Object) {}.size.should == nil
+      Enumerator::Lazy.new(Object.new, 100) {}.grep(Object).size.should == nil
+    end
+
+    describe "when the returned lazy enumerator is evaluated by Enumerable#first" do
+      it "stops after specified times when not given a block" do
+        (0..Float::INFINITY).lazy.grep(Integer).grep(Object).first(3).should == [0, 1, 2]
+
+        @eventsmixed.grep(BasicObject).grep(Object).first(1)
+        ScratchPad.recorded.should == [:before_yield]
+      end
+
+      it "stops after specified times when given a block" do
+        (0..Float::INFINITY).lazy.grep(Integer) { |n| n > 3 ? n : false }.grep(Integer) { |n| n.even? ? n : false }.first(3).should == [4, false, 6]
+
+        @eventsmixed.grep(BasicObject) {}.grep(Object) {}.first(1)
+        ScratchPad.recorded.should == [:before_yield]
+      end
+    end
+  end
+
+  it "works with an infinite enumerable" do
+    s = 0..Float::INFINITY
+    s.lazy.grep(Numeric).first(100).should ==
+      s.first(100).grep(Numeric)
+  end
+end

--- a/spec/core/enumerator/lazy/grep_v_spec.rb
+++ b/spec/core/enumerator/lazy/grep_v_spec.rb
@@ -1,0 +1,124 @@
+require_relative '../../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Enumerator::Lazy#grep_v" do
+  before(:each) do
+    @yieldsmixed = EnumeratorLazySpecs::YieldsMixed.new.to_enum.lazy
+    @eventsmixed = EnumeratorLazySpecs::EventsMixed.new.to_enum.lazy
+    ScratchPad.record []
+  end
+
+  after(:each) do
+    ScratchPad.clear
+  end
+
+  it "requires an argument" do
+    # Enumerator::Lazy.instance_method(:grep_v).arity.should == 1
+    Enumerator::Lazy.new(nil) {}.method(:grep_v).arity.should == 1
+  end
+
+  it "returns a new instance of Enumerator::Lazy" do
+    ret = @yieldsmixed.grep_v(Object) {}
+    ret.should be_an_instance_of(Enumerator::Lazy)
+    ret.should_not equal(@yieldsmixed)
+
+    ret = @yieldsmixed.grep_v(Object)
+    ret.should be_an_instance_of(Enumerator::Lazy)
+    ret.should_not equal(@yieldsmixed)
+  end
+
+  it "sets #size to nil" do
+    Enumerator::Lazy.new(Object.new, 100) {}.grep_v(Object) {}.size.should == nil
+    Enumerator::Lazy.new(Object.new, 100) {}.grep_v(Object).size.should == nil
+  end
+
+  xit "sets $~ in the block" do
+    "z" =~ /z/ # Reset $~
+    ["abc", "def"].lazy.grep_v(/e/) { |e|
+      e.should == "abc"
+      $~.should == nil
+    }.force
+
+    # Set by the match of "def"
+    $&.should == "e"
+  end
+
+  xit "sets $~ in the next block with each" do
+    "z" =~ /z/ # Reset $~
+    ["abc", "def"].lazy.grep_v(/e/).each { |e|
+      e.should == "abc"
+      $~.should == nil
+    }
+
+    # Set by the match of "def"
+    $&.should == "e"
+  end
+
+  xit "sets $~ in the next block with map" do
+    "z" =~ /z/ # Reset $~
+    ["abc", "def"].lazy.grep_v(/e/).map { |e|
+      e.should == "abc"
+      $~.should == nil
+    }.force
+
+    # Set by the match of "def"
+    $&.should == "e"
+  end
+
+  describe "when the returned lazy enumerator is evaluated by Enumerable#first" do
+    it "stops after specified times when not given a block" do
+      (0..Float::INFINITY).lazy.grep_v(3..5).first(3).should == [0, 1, 2]
+
+      @eventsmixed.grep_v(Symbol).first(1)
+      ScratchPad.recorded.should == [:before_yield]
+    end
+
+    it "stops after specified times when given a block" do
+      (0..Float::INFINITY).lazy.grep_v(4..8, &:succ).first(3).should == [1, 2, 3]
+
+      @eventsmixed.grep_v(Symbol) {}.first(1)
+      ScratchPad.recorded.should == [:before_yield]
+    end
+  end
+
+  it "calls the block with a gathered array when yield with multiple arguments" do
+    yields = []
+    @yieldsmixed.grep_v(Array) { |v| yields << v }.force
+    yields.should == EnumeratorLazySpecs::YieldsMixed.gathered_non_array_yields
+
+    @yieldsmixed.grep_v(Array).force.should == yields
+  end
+
+  describe "on a nested Lazy" do
+    it "sets #size to nil" do
+      Enumerator::Lazy.new(Object.new, 100) {}.grep_v(Object).grep_v(Object) {}.size.should == nil
+      Enumerator::Lazy.new(Object.new, 100) {}.grep_v(Object).grep_v(Object).size.should == nil
+    end
+
+    describe "when the returned lazy enumerator is evaluated by Enumerable#first" do
+      it "stops after specified times when not given a block" do
+        (0..Float::INFINITY).lazy.grep_v(3..5).grep_v(6..10).first(3).should == [0, 1, 2]
+
+        @eventsmixed.grep_v(Symbol).grep_v(String).first(1)
+        ScratchPad.recorded.should == [:before_yield]
+      end
+
+      it "stops after specified times when given a block" do
+        (0..Float::INFINITY).lazy
+          .grep_v(1..2) { |n| n > 3 ? n : false }
+          .grep_v(false) { |n| n.even? ? n : false }
+          .first(3)
+          .should == [4, false, 6]
+
+        @eventsmixed.grep_v(Symbol) {}.grep_v(String) {}.first(1)
+        ScratchPad.recorded.should == [:before_yield]
+      end
+    end
+  end
+
+  it "works with an infinite enumerable" do
+    s = 0..Float::INFINITY
+    s.lazy.grep_v(String).first(100).should ==
+      s.first(100).grep_v(String)
+  end
+end

--- a/src/enumerator.rb
+++ b/src/enumerator.rb
@@ -232,6 +232,16 @@ class Enumerator
       end
     end
 
+    def grep_v(pattern, &block)
+      process = ->(item) { block ? block.call(item) : item }
+      Lazy.new(self) do |yielder, *item|
+        item = item.size > 1 ? item : item[0]
+        unless pattern === item
+          yielder << process.(item)
+        end
+      end
+    end
+
     def map(&block)
       raise ArgumentError, 'tried to call lazy select without a block' unless block_given?
 

--- a/src/enumerator.rb
+++ b/src/enumerator.rb
@@ -222,6 +222,16 @@ class Enumerator
     end
     alias collect_concat flat_map
 
+    def grep(pattern, &block)
+      process = ->(item) { block ? block.call(item) : item }
+      Lazy.new(self) do |yielder, *item|
+        item = item.size > 1 ? item : item[0]
+        if pattern === item
+          yielder << process.(item)
+        end
+      end
+    end
+
     def map(&block)
       raise ArgumentError, 'tried to call lazy select without a block' unless block_given?
 

--- a/src/enumerator.rb
+++ b/src/enumerator.rb
@@ -148,6 +148,7 @@ class Enumerator
       @obj = obj
       enum = @obj.is_a?(Enumerator) ? @obj : @obj.to_enum
       enum_block = ->(yielder) {
+        enum.rewind
         loop do
           block.call(yielder, *enum.next_values)
         end

--- a/test/natalie/enumerator_test.rb
+++ b/test/natalie/enumerator_test.rb
@@ -133,4 +133,13 @@ describe 'Enumerator' do
   it 'can yield multiple' do
     YieldMultiple.new.max.should == [3, 4]
   end
+
+  describe 'Lazy' do
+    it 'rewind enum before looping' do
+      enum = (1..5).lazy
+      select = enum.select { true }
+      select.force.should == [1, 2, 3, 4, 5]
+      enum.force.should == [1, 2, 3, 4, 5]
+    end
+  end
 end


### PR DESCRIPTION
This also fixes a critical bug in Enumerator::Lazy which I described in the commit message and added a test for. Basically the following example failed:

```ruby
enum = [1,2].lazy
select = enum.select { true }
select.to_a
# => [1,2]
enum.to_a
# => []
```

In MRI Ruby both calls to #to_a returned `[1, 2]`. This happened because we consumed Enumerator objects when passed to Enumerator::Lazy. Now we rewind them before looping which makes this work.