### PR TITLE
Array zip implementation

### DIFF
--- a/include/natalie/array_value.hpp
+++ b/include/natalie/array_value.hpp
@@ -146,6 +146,7 @@ public:
     ValuePtr union_of(Env *, ValuePtr);
     ValuePtr union_of(Env *, size_t, ValuePtr *);
     ValuePtr uniq_in_place(Env *, Block *);
+    ValuePtr zip(Env *, size_t, ValuePtr *, Block *);
 
     virtual void visit_children(Visitor &visitor) override final {
         Value::visit_children(visitor);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -339,6 +339,7 @@ gen.binding('Array', 'to_s', 'ArrayValue', 'inspect', argc: 0, pass_env: true, p
 gen.binding('Array', 'sample', 'ArrayValue', 'sample', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Array', 'union', 'ArrayValue', 'union_of', argc: :any, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Array', 'uniq!', 'ArrayValue', 'uniq_in_place', argc: 0, pass_env: true, pass_block: true, return_type: :Value)
+gen.binding('Array', 'zip', 'ArrayValue', 'zip', argc: 0.., pass_env: true, pass_block: true, return_type: :Value)
 gen.binding('Array', '|', 'ArrayValue', 'union_of', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
 
 gen.binding('BasicObject', '__send__', 'Value', 'send', argc: 1.., pass_env: true, pass_block: true, return_type: :Value)

--- a/spec/core/array/zip_spec.rb
+++ b/spec/core/array/zip_spec.rb
@@ -1,0 +1,65 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Array#zip" do
+  it "returns an array of arrays containing corresponding elements of each array" do
+    [1, 2, 3, 4].zip(["a", "b", "c", "d", "e"]).should ==
+      [[1, "a"], [2, "b"], [3, "c"], [4, "d"]]
+  end
+
+  it "fills in missing values with nil" do
+    [1, 2, 3, 4, 5].zip(["a", "b", "c", "d"]).should ==
+      [[1, "a"], [2, "b"], [3, "c"], [4, "d"], [5, nil]]
+  end
+
+  xit "properly handles recursive arrays" do
+    a = []; a << a
+    b = [1]; b << b
+
+    a.zip(a).should == [ [a[0], a[0]] ]
+    a.zip(b).should == [ [a[0], b[0]] ]
+    b.zip(a).should == [ [b[0], a[0]], [b[1], a[1]] ]
+    b.zip(b).should == [ [b[0], b[0]], [b[1], b[1]] ]
+  end
+
+  it "calls #to_ary to convert the argument to an Array" do
+    obj = mock('[3,4]')
+    obj.should_receive(:to_ary).and_return([3, 4])
+    [1, 2].zip(obj).should == [[1, 3], [2, 4]]
+  end
+
+  it "uses #each to extract arguments' elements when #to_ary fails" do
+    obj = Class.new do
+      def each(&b)
+        [3,4].each(&b)
+      end
+    end.new
+
+    [1, 2].zip(obj).should == [[1, 3], [2, 4]]
+  end
+
+  xit "stops at own size when given an infinite enumerator" do
+    [1, 2].zip(10.upto(Float::INFINITY)).should == [[1, 10], [2, 11]]
+  end
+
+  xit "fills nil when the given enumerator is shorter than self" do
+    obj = Object.new
+    def obj.each
+      yield 10
+    end
+    [1, 2].zip(obj).should == [[1, 10], [2, nil]]
+  end
+
+  it "calls block if supplied" do
+    values = []
+    [1, 2, 3, 4].zip(["a", "b", "c", "d", "e"]) { |value|
+      values << value
+    }.should == nil
+
+    values.should == [[1, "a"], [2, "b"], [3, "c"], [4, "d"]]
+  end
+
+  it "does not return subclass instance on Array subclasses" do
+    ArraySpecs::MyArray[1, 2, 3].zip(["a", "b"]).should be_an_instance_of(Array)
+  end
+end

--- a/src/array_value.cpp
+++ b/src/array_value.cpp
@@ -1267,7 +1267,10 @@ ValuePtr ArrayValue::try_convert(Env *env, ValuePtr val) {
 }
 
 ValuePtr ArrayValue::zip(Env *env, size_t argc, ValuePtr *args, Block *block) {
-    return nullptr;
+    // FIXME: this is not exactly the way ruby does it
+    auto Enumerable = GlobalEnv::the()->Object()->const_fetch(SymbolValue::intern("Enumerable"))->as_module();
+    auto zip_method = Enumerable->find_method(env, SymbolValue::intern("zip"));
+    return zip_method->call(env, this, argc, args, block);
 }
 
 }

--- a/src/array_value.cpp
+++ b/src/array_value.cpp
@@ -1266,4 +1266,8 @@ ValuePtr ArrayValue::try_convert(Env *env, ValuePtr val) {
         new_item_class_name);
 }
 
+ValuePtr ArrayValue::zip(Env *env, size_t argc, ValuePtr *args, Block *block) {
+    return nullptr;
+}
+
 }

--- a/src/enumerable.rb
+++ b/src/enumerable.rb
@@ -1092,7 +1092,11 @@ module Enumerable
       if arg.respond_to? :to_ary
         arg.to_ary
       elsif arg.respond_to? :to_enum
-        arg.to_enum :each
+        enumerable_value = arg.to_enum :each
+        unless enumerable_value.is_a? Array
+          enumerable_value = enumerable_value.to_a if enumerable_value.respond_to? :to_a
+        end
+        enumerable_value
       else
         arg
       end


### PR DESCRIPTION
Array::zip from #39 
The implementation itself is trivial as it relies on zip from enumerable, but that and some good old investigation on MRI revealed that in fact, the ruby spec was not explicitly covering the scenario where calling :each would return a non-array value, which is in fact supported by MRI

```ruby
class E 
 include Enumberable

 def each
  yield 1
  yield 2
  yield 3
 end
end

irb(main):025:0> E.new.zip(E.new)
=> [[1, 1], [2, 2], [3, 3]]

# Natalie would have returned an error saying not every item was an array, lots of fun :)
```