### PR TITLE
Generic recursion guard

### DIFF
--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -42,6 +42,7 @@
 #include "natalie/proc_value.hpp"
 #include "natalie/process_module.hpp"
 #include "natalie/range_value.hpp"
+#include "natalie/recursion_guard.hpp"
 #include "natalie/regexp_value.hpp"
 #include "natalie/sexp_value.hpp"
 #include "natalie/string_value.hpp"
@@ -51,7 +52,6 @@
 #include "natalie/value.hpp"
 #include "natalie/value_ptr.hpp"
 #include "natalie/void_p_value.hpp"
-#include "natalie/recursion_guard.hpp"
 
 namespace Natalie {
 

--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -51,6 +51,7 @@
 #include "natalie/value.hpp"
 #include "natalie/value_ptr.hpp"
 #include "natalie/void_p_value.hpp"
+#include "natalie/recursion_guard.hpp"
 
 namespace Natalie {
 

--- a/include/natalie/array_value.hpp
+++ b/include/natalie/array_value.hpp
@@ -169,7 +169,6 @@ private:
     Vector<ValuePtr> m_vector {};
 
     bool _flatten_in_place(Env *, nat_int_t depth, Hashmap<ArrayValue *> visited_arrays = Hashmap<ArrayValue *> {});
-    ValuePtr _inspect(Env *, Hashmap<ArrayValue *> visited_arrays = Hashmap<ArrayValue *> {});
 };
 
 }

--- a/include/natalie/recursion_guard.hpp
+++ b/include/natalie/recursion_guard.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <functional>
+
+#include "natalie/hashmap.hpp"
+#include "tm/defer.hpp"
+
+namespace Natalie {
+static Hashmap<void *> did_run;
+
+template<typename ReturnType>
+class RecursionGuard {
+public:
+    RecursionGuard(void *instance) 
+        : m_instance { instance } {
+    }
+
+    ReturnType run(std::function<ReturnType(bool)> callback) {
+        if (did_run.get(m_instance) != nullptr)
+            return callback(true);
+
+        mark();
+        Defer on_close([&] () { clear(); });
+        return callback(false);
+    }
+
+private:
+    void *m_instance;
+
+    void mark() {
+        if (did_run.get(m_instance) == nullptr) {
+            did_run.set(m_instance);
+        }
+    }
+
+    void clear() {
+        if (did_run.get(m_instance) != nullptr) {
+            did_run.remove(m_instance);
+        }
+    }
+};
+
+
+
+}

--- a/include/natalie/recursion_guard.hpp
+++ b/include/natalie/recursion_guard.hpp
@@ -8,10 +8,10 @@
 namespace Natalie {
 static Hashmap<void *> did_run;
 
-template<typename ReturnType>
+template <typename ReturnType>
 class RecursionGuard {
 public:
-    RecursionGuard(void *instance) 
+    RecursionGuard(void *instance)
         : m_instance { instance } {
     }
 
@@ -20,7 +20,7 @@ public:
             return callback(true);
 
         mark();
-        Defer on_close([&] () { clear(); });
+        Defer on_close([&]() { clear(); });
         return callback(false);
     }
 
@@ -39,7 +39,5 @@ private:
         }
     }
 };
-
-
 
 }

--- a/src/array_value.cpp
+++ b/src/array_value.cpp
@@ -33,12 +33,12 @@ ValuePtr ArrayValue::initialize(Env *env, ValuePtr size, ValuePtr value, Block *
 }
 
 ValuePtr ArrayValue::inspect(Env *env) {
-    RecursionGuard<StringValue*> guard { this };
+    RecursionGuard<StringValue *> guard { this };
 
-    return guard.run([&] (bool is_recursive) {
-        if (is_recursive) 
+    return guard.run([&](bool is_recursive) {
+        if (is_recursive)
             return new StringValue { "[...]" };
-        
+
         StringValue *out = new StringValue { "[" };
         for (size_t i = 0; i < size(); i++) {
             ValuePtr obj = (*this)[i];

--- a/src/array_value.cpp
+++ b/src/array_value.cpp
@@ -33,23 +33,16 @@ ValuePtr ArrayValue::initialize(Env *env, ValuePtr size, ValuePtr value, Block *
 }
 
 ValuePtr ArrayValue::inspect(Env *env) {
-    return _inspect(env);
-}
+    RecursionGuard<StringValue*> guard { this };
 
-ValuePtr ArrayValue::_inspect(Env *env, Hashmap<ArrayValue *> visited) {
-    StringValue *out = new StringValue { "[" };
-    visited.set(this);
-    for (size_t i = 0; i < size(); i++) {
-        ValuePtr obj = (*this)[i];
+    return guard.run([&] (bool is_recursive) {
+        if (is_recursive) 
+            return new StringValue { "[...]" };
+        
+        StringValue *out = new StringValue { "[" };
+        for (size_t i = 0; i < size(); i++) {
+            ValuePtr obj = (*this)[i];
 
-        if (obj->is_array()) {
-            auto array_val = obj->as_array();
-            if (visited.get(array_val) != nullptr) {
-                out->append(env, "[...]");
-            } else {
-                out->append(env, array_val->_inspect(env, visited));
-            }
-        } else {
             auto inspected_repr = obj.send(env, SymbolValue::intern("inspect"));
             SymbolValue *to_s = SymbolValue::intern("to_s");
 
@@ -66,15 +59,14 @@ ValuePtr ArrayValue::_inspect(Env *env, Hashmap<ArrayValue *> visited) {
                 sprintf(buf, "#<%s:%p>", inspected_repr->klass()->class_name_or_blank()->c_str(), (void *)&inspected_repr);
                 out->append(env, buf);
             }
-        }
 
-        if (i < size() - 1) {
-            out->append(env, ", ");
+            if (i < size() - 1) {
+                out->append(env, ", ");
+            }
         }
-    }
-    out->append_char(env, ']');
-    visited.remove(this);
-    return out;
+        out->append_char(env, ']');
+        return out;
+    });
 }
 
 ValuePtr ArrayValue::ltlt(Env *env, ValuePtr arg) {

--- a/src/hash_value.cpp
+++ b/src/hash_value.cpp
@@ -223,41 +223,42 @@ ValuePtr HashValue::square_new(Env *env, size_t argc, ValuePtr *args, ClassValue
 }
 
 ValuePtr HashValue::inspect(Env *env) {
-    if (has_inspecting_flag())
-        return new StringValue("{...}");
-    add_inspecting_flag();
+    RecursionGuard<StringValue*> guard { this };
 
-    StringValue *out = new StringValue { "{" };
-    size_t last_index = size() - 1;
-    size_t index = 0;
+    return guard.run([&] (bool is_recursive) {
+        if (is_recursive)
+            return new StringValue("{...}");
+            StringValue *out = new StringValue { "{" };
+        size_t last_index = size() - 1;
+        size_t index = 0;
 
-    auto to_s = [env](ValuePtr obj) {
-        if (obj->is_string())
+        auto to_s = [env](ValuePtr obj) {
+            if (obj->is_string())
+                return obj->as_string();
+            if (obj->respond_to(env, SymbolValue::intern("to_s")))
+                obj = obj->send(env, SymbolValue::intern("to_s"));
+            else
+                obj = new StringValue("?");
+            if (!obj->is_string())
+                obj = StringValue::format(env, "#<{}:{}>", obj->klass()->class_name_or_blank(), int_to_hex_string(obj->object_id(), false));
             return obj->as_string();
-        if (obj->respond_to(env, SymbolValue::intern("to_s")))
-            obj = obj->send(env, SymbolValue::intern("to_s"));
-        else
-            obj = new StringValue("?");
-        if (!obj->is_string())
-            obj = StringValue::format(env, "#<{}:{}>", obj->klass()->class_name_or_blank(), int_to_hex_string(obj->object_id(), false));
-        return obj->as_string();
-    };
+        };
 
-    for (HashValue::Key &node : *this) {
-        StringValue *key_repr = to_s(node.key.send(env, SymbolValue::intern("inspect")));
-        out->append(env, key_repr);
-        out->append(env, "=>");
-        StringValue *val_repr = to_s(node.val.send(env, SymbolValue::intern("inspect")));
-        out->append(env, val_repr);
-        if (index < last_index) {
-            out->append(env, ", ");
+        for (HashValue::Key &node : *this) {
+            StringValue *key_repr = to_s(node.key.send(env, SymbolValue::intern("inspect")));
+            out->append(env, key_repr);
+            out->append(env, "=>");
+            StringValue *val_repr = to_s(node.val.send(env, SymbolValue::intern("inspect")));
+            out->append(env, val_repr);
+            if (index < last_index) {
+                out->append(env, ", ");
+            }
+            index++;
         }
-        index++;
-    }
 
-    out->append_char(env, '}');
-    remove_inspecting_flag();
-    return out;
+        out->append_char(env, '}');
+        return out;
+    });
 }
 
 ValuePtr HashValue::ref(Env *env, ValuePtr key) {

--- a/src/hash_value.cpp
+++ b/src/hash_value.cpp
@@ -223,12 +223,12 @@ ValuePtr HashValue::square_new(Env *env, size_t argc, ValuePtr *args, ClassValue
 }
 
 ValuePtr HashValue::inspect(Env *env) {
-    RecursionGuard<StringValue*> guard { this };
+    RecursionGuard<StringValue *> guard { this };
 
-    return guard.run([&] (bool is_recursive) {
+    return guard.run([&](bool is_recursive) {
         if (is_recursive)
             return new StringValue("{...}");
-            StringValue *out = new StringValue { "{" };
+        StringValue *out = new StringValue { "{" };
         size_t last_index = size() - 1;
         size_t index = 0;
 


### PR DESCRIPTION
Added a simple and probably naive mechanism to handle recursion guarding across various objects. Can handle the now infamous dirty_inspect.rb case described in #97 

 % ./bin/natalie ./dirty_inspect.rb 
"[[Up and counting 1]]"
"It went boom!"
"[[Up and counting 3]]"