### PR TITLE
Array equality

### DIFF
--- a/spec/core/array/eql_spec.rb
+++ b/spec/core/array/eql_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/eql'
+
+describe "Array#eql?" do
+  it_behaves_like :array_eql, :eql?
+
+  it "returns false if any corresponding elements are not #eql?" do
+    [1, 2, 3, 4].should_not eql([1, 2, 3, 4.0])
+  end
+
+  it "returns false if other is not a kind of Array" do
+    obj = mock("array eql?")
+    obj.should_not_receive(:to_ary)
+    obj.should_not_receive(:eql?)
+
+    [1, 2, 3].should_not eql(obj)
+  end
+end

--- a/spec/core/array/equal_value_spec.rb
+++ b/spec/core/array/equal_value_spec.rb
@@ -1,0 +1,51 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/eql'
+
+describe "Array#==" do
+  it_behaves_like :array_eql, :==
+
+  it "compares with an equivalent Array-like object using #to_ary" do
+    obj = mock('array-like')
+    obj.should_receive(:respond_to?).at_least(1).with(:to_ary).and_return(true)
+    obj.should_receive(:==).with([1]).at_least(1).and_return(true)
+
+    ([1] == obj).should be_true
+    ([[1]] == [obj]).should be_true
+    ([[[1], 3], 2] == [[obj, 3], 2]).should be_true
+
+    # recursive arrays
+    arr1 = [[1]]
+    arr1 << arr1
+    arr2 = [obj]
+    arr2 << arr2
+    (arr1 == arr2).should be_true
+    (arr2 == arr1).should be_true
+  end
+
+  it "returns false if any corresponding elements are not #==" do
+    a = ["a", "b", "c"]
+    b = ["a", "b", "not equal value"]
+    a.should_not == b
+
+    c = mock("c")
+    c.should_receive(:==).and_return(false)
+    ["a", "b", c].should_not == a
+  end
+
+  it "returns true if corresponding elements are #==" do
+    [].should == []
+    ["a", "c", 7].should == ["a", "c", 7]
+
+    [1, 2, 3].should == [1.0, 2.0, 3.0]
+
+    obj = mock('5')
+    obj.should_receive(:==).and_return(true)
+    [obj].should == [5]
+  end
+
+  # See https://bugs.ruby-lang.org/issues/1720
+  it "returns true for [NaN] == [NaN] because Array#== first checks with #equal? and NaN.equal?(NaN) is true" do
+    [Float::NAN].should == [Float::NAN]
+  end
+end

--- a/spec/core/array/shared/eql.rb
+++ b/spec/core/array/shared/eql.rb
@@ -1,0 +1,92 @@
+describe :array_eql, shared: true do
+  it "returns true if other is the same array" do
+    a = [1]
+    a.send(@method, a).should be_true
+  end
+
+  it "returns true if corresponding elements are #eql?" do
+    [].send(@method, []).should be_true
+    [1, 2, 3, 4].send(@method, [1, 2, 3, 4]).should be_true
+  end
+
+  it "returns false if other is shorter than self" do
+    [1, 2, 3, 4].send(@method, [1, 2, 3]).should be_false
+  end
+
+  it "returns false if other is longer than self" do
+    [1, 2, 3, 4].send(@method, [1, 2, 3, 4, 5]).should be_false
+  end
+
+  it "returns false immediately when sizes of the arrays differ" do
+    obj = mock('1')
+    obj.should_not_receive(@method)
+
+    []        .send(@method,    [obj]  ).should be_false
+    [obj]     .send(@method,    []     ).should be_false
+  end
+
+  it "handles well recursive arrays" do
+    a = ArraySpecs.empty_recursive_array
+    a       .send(@method,    [a]    ).should be_true
+    a       .send(@method,    [[a]]  ).should be_true
+    [a]     .send(@method,    a      ).should be_true
+    [[a]]   .send(@method,    a      ).should be_true
+    # These may be surprising, but no difference can be
+    # found between these arrays, so they are ==.
+    # There is no "path" that will lead to a difference
+    # (contrary to other examples below)
+
+    a2 = ArraySpecs.empty_recursive_array
+    a       .send(@method,    a2     ).should be_true
+    a       .send(@method,    [a2]   ).should be_true
+    a       .send(@method,    [[a2]] ).should be_true
+    [a]     .send(@method,    a2     ).should be_true
+    [[a]]   .send(@method,    a2     ).should be_true
+
+    back = []
+    forth = [back]; back << forth;
+    back   .send(@method,  a  ).should be_true
+
+    x = []; x << x << x
+    x       .send(@method,    a                ).should be_false  # since x.size != a.size
+    x       .send(@method,    [a, a]           ).should be_false  # since x[0].size != [a, a][0].size
+    x       .send(@method,    [x, a]           ).should be_false  # since x[1].size != [x, a][1].size
+    [x, a]  .send(@method,    [a, x]           ).should be_false  # etc...
+    x       .send(@method,    [x, x]           ).should be_true
+    x       .send(@method,    [[x, x], [x, x]] ).should be_true
+
+    tree = [];
+    branch = []; branch << tree << tree; tree << branch
+    tree2 = [];
+    branch2 = []; branch2 << tree2 << tree2; tree2 << branch2
+    forest = [tree, branch, :bird, a]; forest << forest
+    forest2 = [tree2, branch2, :bird, a2]; forest2 << forest2
+
+    forest .send(@method,     forest2         ).should be_true
+    forest .send(@method,     [tree2, branch, :bird, a, forest2]).should be_true
+
+    diffforest = [branch2, tree2, :bird, a2]; diffforest << forest2
+    forest .send(@method,     diffforest      ).should be_false # since forest[0].size == 1 != 3 == diffforest[0]
+    forest .send(@method,     [nil]           ).should be_false
+    forest .send(@method,     [forest]        ).should be_false
+  end
+
+  it "does not call #to_ary on its argument" do
+    obj = mock('to_ary')
+    obj.should_not_receive(:to_ary)
+
+    [1, 2, 3].send(@method, obj).should be_false
+  end
+
+  it "does not call #to_ary on Array subclasses" do
+    ary = ArraySpecs::ToAryArray[5, 6, 7]
+    ary.should_not_receive(:to_ary)
+    [5, 6, 7].send(@method, ary).should be_true
+  end
+
+  it "ignores array class differences" do
+    ArraySpecs::MyArray[1, 2, 3].send(@method, [1, 2, 3]).should be_true
+    ArraySpecs::MyArray[1, 2, 3].send(@method, ArraySpecs::MyArray[1, 2, 3]).should be_true
+    [1, 2, 3].send(@method, ArraySpecs::MyArray[1, 2, 3]).should be_true
+  end
+end

--- a/src/array_value.cpp
+++ b/src/array_value.cpp
@@ -329,12 +329,12 @@ ValuePtr ArrayValue::eq(Env *env, ValuePtr other) {
                                               ->send(env, equality, { item->send(env, object_id) });
 
                 // This allows us to check NAN equality and other potentially similar constants
-                if (same_object_id->type() == Value::Type::True)
+                if (same_object_id->is_true())
                     continue;
             }
 
             ValuePtr result = this_item.send(env, equality, 1, &item, nullptr);
-            if (result->type() == Value::Type::False)
+            if (result->is_false())
                 return result;
         }
 
@@ -366,7 +366,7 @@ ValuePtr ArrayValue::eql(Env *env, ValuePtr other) {
         for (size_t i = 0; i < size(); ++i) {
             ValuePtr item = (*other_array)[i];
             ValuePtr result = (*this)[i].send(env, SymbolValue::intern("eql?"), 1, &item, nullptr);
-            if (result->type() == Value::Type::False)
+            if (result->is_false())
                 return result;
         }
 

--- a/src/array_value.cpp
+++ b/src/array_value.cpp
@@ -306,6 +306,10 @@ ValuePtr ArrayValue::eq(Env *env, ValuePtr other) {
             && other->send(env, SymbolValue::intern("respond_to?"), { SymbolValue::intern("to_ary") })->is_true())
             return other->send(env, equality, { this });
 
+        if (! other->is_array()) {
+            return FalseValue::the();
+        }
+
         auto other_array = other->as_array();
         if (size() != other_array->size())
             return FalseValue::the(); 
@@ -346,6 +350,10 @@ ValuePtr ArrayValue::eql(Env *env, ValuePtr other) {
             return TrueValue::the();
         if (!other->is_array())
             return FalseValue::the();
+
+        if (! other->is_array()) {
+            return FalseValue::the();
+        }
 
         auto other_array = other->as_array();
         if (size() != other_array->size())

--- a/src/array_value.cpp
+++ b/src/array_value.cpp
@@ -306,13 +306,13 @@ ValuePtr ArrayValue::eq(Env *env, ValuePtr other) {
             && other->send(env, SymbolValue::intern("respond_to?"), { SymbolValue::intern("to_ary") })->is_true())
             return other->send(env, equality, { this });
 
-        if (! other->is_array()) {
+        if (!other->is_array()) {
             return FalseValue::the();
         }
 
         auto other_array = other->as_array();
         if (size() != other_array->size())
-            return FalseValue::the(); 
+            return FalseValue::the();
 
         if (is_recursive)
             //since == is an & of all the == of each value, this will just leave the expression uneffected
@@ -323,15 +323,15 @@ ValuePtr ArrayValue::eq(Env *env, ValuePtr other) {
             ValuePtr this_item = (*this)[i];
             ValuePtr item = (*other_array)[i];
 
-            ValuePtr same_object_id = this_item
-                ->send(env, object_id)
-                ->send(env, equality, {
-                    item->send(env, object_id)
-                });
+            if (this_item->respond_to(env, object_id) && item->respond_to(env, object_id)) {
+                ValuePtr same_object_id = this_item
+                                              ->send(env, object_id)
+                                              ->send(env, equality, { item->send(env, object_id) });
 
-            // This allows us to check NAN equality and other potentially similar constants
-            if (same_object_id->type() == Value::Type::True)
-                continue;
+                // This allows us to check NAN equality and other potentially similar constants
+                if (same_object_id->type() == Value::Type::True)
+                    continue;
+            }
 
             ValuePtr result = this_item.send(env, equality, 1, &item, nullptr);
             if (result->type() == Value::Type::False)
@@ -351,7 +351,7 @@ ValuePtr ArrayValue::eql(Env *env, ValuePtr other) {
         if (!other->is_array())
             return FalseValue::the();
 
-        if (! other->is_array()) {
+        if (!other->is_array()) {
             return FalseValue::the();
         }
 


### PR DESCRIPTION
Implemented both eql? and == from #39 .

The test "compares with an equivalent Array-like object using #to_ary" highlighted an issue on how we use respond_to? in natalie's standard library. We rely on calling the method on the c++ impl rather than send the event "respond_to? :method_name" so mocks won't be able to correctly override such value and neither will anything else :) We should replace all the direct respond_to with the ruby method and maybe create a utility that wraps `send(env, Symbol::intern("respond_to?")...)` so the ergonomics won't change much for us but natalie will in fact behave correctly. What do you think about this?