### PR TITLE
defer: Forward the callback object instead of copying it

### DIFF
--- a/include/tm/defer.hpp
+++ b/include/tm/defer.hpp
@@ -1,12 +1,14 @@
 #pragma once
 
+#include <utility>
+
 namespace TM {
 
 template <typename F>
 class Defer {
 public:
-    Defer(F callback)
-        : m_callback { callback } { }
+    Defer(F &&callback)
+        : m_callback { std::forward<F>(callback) } { }
 
     ~Defer() {
         m_callback();


### PR DESCRIPTION
Just a minor thing I noticed while watching @seven1m's latest video, nothing too major :)

This is not going to make a difference in most cases, but there are some
possible scenarios where copying the callable object would not be
possible (e.g. when the lambda captures a smart pointer that doesn't
allow copying, like `std::unique_ptr`).