### PR TITLE
implement Array::deconstruct

### DIFF
--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -295,6 +295,7 @@ gen.binding('Array', 'collect!', 'ArrayValue', 'map_in_place', argc: 0, pass_env
 gen.binding('Array', 'concat', 'ArrayValue', 'concat', argc: :any, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Array', 'compact', 'ArrayValue', 'compact', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Array', 'compact!', 'ArrayValue', 'compact_in_place', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
+gen.binding('Array', 'deconstruct', 'ArrayValue', 'itself', argc: 0, pass_env: false, pass_block: false, return_type: :Value)
 gen.binding('Array', 'delete', 'ArrayValue', 'delete_item', argc: 1, pass_env: true, pass_block: true, return_type: :Value)
 gen.binding('Array', 'delete_at', 'ArrayValue', 'delete_at', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Array', 'delete_if', 'ArrayValue', 'delete_if', argc: 0, pass_env: true, pass_block: true, return_type: :Value)

--- a/spec/core/array/deconstruct_spec.rb
+++ b/spec/core/array/deconstruct_spec.rb
@@ -1,0 +1,11 @@
+require_relative '../../spec_helper'
+
+ruby_version_is "2.7" do
+  describe "Array#deconstruct" do
+    it "returns self" do
+      array = [1]
+
+      array.deconstruct.should equal array
+    end
+  end
+end


### PR DESCRIPTION
Hardest method from #39 . Interestingly enough this seems to be only available only on ruby < 3 