### PR TITLE
add spec for array's reverse methods

### DIFF
--- a/spec/core/array/reverse_each_spec.rb
+++ b/spec/core/array/reverse_each_spec.rb
@@ -22,13 +22,13 @@ describe "Array#reverse_each" do
     a.reverse_each { |x| }.should equal(a)
   end
 
-  xit "yields only the top level element of an empty recursive arrays" do
+  it "yields only the top level element of an empty recursive arrays" do
     empty = ArraySpecs.empty_recursive_array
     empty.reverse_each { |i| ScratchPad << i }
     ScratchPad.recorded.should == [empty]
   end
 
-  xit "yields only the top level element of a recursive array" do
+  it "yields only the top level element of a recursive array" do
     array = ArraySpecs.recursive_array
     array.reverse_each { |i| ScratchPad << i }
     ScratchPad.recorded.should == [array, array, array, array, array, 3.0, 'two', 1]

--- a/spec/core/array/reverse_spec.rb
+++ b/spec/core/array/reverse_spec.rb
@@ -1,0 +1,42 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Array#reverse" do
+  it "returns a new array with the elements in reverse order" do
+    [].reverse.should == []
+    [1, 3, 5, 2].reverse.should == [2, 5, 3, 1]
+  end
+
+  it "properly handles recursive arrays" do
+    empty = ArraySpecs.empty_recursive_array
+    empty.reverse.should == empty
+
+    array = ArraySpecs.recursive_array
+    array.reverse.should == [array, array, array, array, array, 3.0, 'two', 1]
+  end
+
+  it "does not return subclass instance on Array subclasses" do
+    ArraySpecs::MyArray[1, 2, 3].reverse.should be_an_instance_of(Array)
+  end
+end
+
+describe "Array#reverse!" do
+  it "reverses the elements in place" do
+    a = [6, 3, 4, 2, 1]
+    a.reverse!.should equal(a)
+    a.should == [1, 2, 4, 3, 6]
+    [].reverse!.should == []
+  end
+
+  it "properly handles recursive arrays" do
+    empty = ArraySpecs.empty_recursive_array
+    empty.reverse!.should == [empty]
+
+    array = ArraySpecs.recursive_array
+    array.reverse!.should == [array, array, array, array, array, 3.0, 'two', 1]
+  end
+
+  it "raises a FrozenError on a frozen array" do
+    -> { ArraySpecs.frozen_array.reverse! }.should raise_error(FrozenError)
+  end
+end


### PR DESCRIPTION
specs for #39 for all the reverse mehods. Uncomment excluded tests with recursion since now recursive equality is supported :^)