### PR TITLE
Array remove recursive spec check exclusions

### DIFF
--- a/spec/core/array/sort_spec.rb
+++ b/spec/core/array/sort_spec.rb
@@ -46,7 +46,7 @@ describe "Array#sort" do
   end
 
   # TODO: Natalie does not support recursive arrays yet
-  xit "properly handles recursive arrays" do
+  it "properly handles recursive arrays" do
     empty = ArraySpecs.empty_recursive_array
     empty.sort.should == empty
 
@@ -198,8 +198,7 @@ describe "Array#sort!" do
     a.should == [1, 2, 3, 4, 5]
   end
 
-  # TODO: Natalie does not support recursive arrays yet
-  xit "properly handles recursive arrays" do
+  it "properly handles recursive arrays" do
     empty = ArraySpecs.empty_recursive_array
     empty.sort!.should == empty
 

--- a/spec/core/array/to_a_spec.rb
+++ b/spec/core/array/to_a_spec.rb
@@ -16,7 +16,7 @@ describe "Array#to_a" do
 
   # Recoursive equality is not guarded yet and this 
   # would result in an endless loop
-  xit "properly handles recursive arrays" do
+  it "properly handles recursive arrays" do
     empty = ArraySpecs.empty_recursive_array
     empty.to_a.should == empty
 

--- a/spec/core/array/to_ary_spec.rb
+++ b/spec/core/array/to_ary_spec.rb
@@ -11,7 +11,7 @@ describe "Array#to_ary" do
 
   # Recoursive equality is not guarded yet and this 
   # would result in an endless loop
-  xit "properly handles recursive arrays" do
+  it "properly handles recursive arrays" do
     empty = ArraySpecs.empty_recursive_array
     empty.to_ary.should == empty
 

--- a/spec/core/array/uniq_spec.rb
+++ b/spec/core/array/uniq_spec.rb
@@ -6,7 +6,7 @@ describe "Array#uniq" do
     ["a", "a", "b", "b", "c"].uniq.should == ["a", "b", "c"]
   end
 
-  xit "properly handles recursive arrays" do
+  it "properly handles recursive arrays" do
     empty = ArraySpecs.empty_recursive_array
     empty.uniq.should == [empty]
 
@@ -190,7 +190,7 @@ describe "Array#uniq!" do
     a.should equal(a.uniq!)
   end
 
-  xit "properly handles recursive arrays" do
+  it "properly handles recursive arrays" do
     empty = ArraySpecs.empty_recursive_array
     empty_dup = empty.dup
     empty.uniq!

--- a/spec/core/array/zip_spec.rb
+++ b/spec/core/array/zip_spec.rb
@@ -12,7 +12,7 @@ describe "Array#zip" do
       [[1, "a"], [2, "b"], [3, "c"], [4, "d"], [5, nil]]
   end
 
-  xit "properly handles recursive arrays" do
+  it "properly handles recursive arrays" do
     a = []; a << a
     b = [1]; b << b
 


### PR DESCRIPTION
follow up to #105 , now that proper recursive equality is in place, we can get rid of all the exclusions we had in Array specs. I have not included reverse_each since it's addressed by #130 (that was actually what made me notice this :^) )

PS: this was extremely relaxing and soothing, skipping tests always makes me feel really uncomfortable!