### PR TITLE
Fix return code if an unhandled exception occurrs

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ extern "C" Value *EVAL(Env *env) {
         return NilValue::the(); // just in case there's no return value
     } catch (ExceptionValue *exception) {
         handle_top_level_exception(env, exception, run_exit_handlers);
-        return NilValue::the();
+        return nullptr;
     }
 }
 


### PR DESCRIPTION
Hey I'm finally back 👋

I found a small issue that I wanted to fix. When running code that compiles but throws an exception when running, Natalie will exit with a zero status instead of a non-zero one (1 for MRI).

Example:
```
bin/natalie -e "1.bar"
# => NoMethodError
echo $?
# => 0
``` 

If an exception occurred that is not handled by the user, we returned a `NilValue` from `EVAL` which resulted in returning a zero return code. I'm not sure if my solution to this problem is appropriate, so please tell me if there is a better way for this!