### PR TITLE
make Array first spec compliant

### DIFF
--- a/spec/core/array/first_spec.rb
+++ b/spec/core/array/first_spec.rb
@@ -1,0 +1,93 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Array#first" do
+  it "returns the first element" do
+    %w{a b c}.first.should == 'a'
+    [nil].first.should == nil
+  end
+
+  it "returns nil if self is empty" do
+    [].first.should == nil
+  end
+
+  it "returns the first count elements if given a count" do
+    [true, false, true, nil, false].first(2).should == [true, false]
+  end
+
+  it "returns an empty array when passed count on an empty array" do
+    [].first(0).should == []
+    [].first(1).should == []
+    [].first(2).should == []
+  end
+
+  it "returns an empty array when passed count == 0" do
+    [1, 2, 3, 4, 5].first(0).should == []
+  end
+
+  it "returns an array containing the first element when passed count == 1" do
+    [1, 2, 3, 4, 5].first(1).should == [1]
+  end
+
+  it "raises an ArgumentError when count is negative" do
+    -> { [1, 2].first(-1) }.should raise_error(ArgumentError)
+  end
+
+  it "raises a RangeError when count is a Bignum" do
+    -> { [].first(bignum_value) }.should raise_error(RangeError)
+  end
+
+  it "returns the entire array when count > length" do
+    [1, 2, 3, 4, 5, 9].first(10).should == [1, 2, 3, 4, 5, 9]
+  end
+
+  it "returns an array which is independent to the original when passed count" do
+    ary = [1, 2, 3, 4, 5]
+    ary.first(0).replace([1,2])
+    ary.should == [1, 2, 3, 4, 5]
+    ary.first(1).replace([1,2])
+    ary.should == [1, 2, 3, 4, 5]
+    ary.first(6).replace([1,2])
+    ary.should == [1, 2, 3, 4, 5]
+  end
+
+  it "properly handles recursive arrays" do
+    empty = ArraySpecs.empty_recursive_array
+    empty.first.should equal(empty)
+
+    ary = ArraySpecs.head_recursive_array
+    ary.first.should equal(ary)
+  end
+
+  it "tries to convert the passed argument to an Integer using #to_int" do
+    obj = mock('to_int')
+    obj.should_receive(:to_int).and_return(2)
+    [1, 2, 3, 4, 5].first(obj).should == [1, 2]
+  end
+
+  it "raises a TypeError if the passed argument is not numeric" do
+    -> { [1,2].first(nil) }.should raise_error(TypeError)
+    -> { [1,2].first("a") }.should raise_error(TypeError)
+
+    obj = mock("nonnumeric")
+    -> { [1,2].first(obj) }.should raise_error(TypeError)
+  end
+
+  it "does not return subclass instance when passed count on Array subclasses" do
+    ArraySpecs::MyArray[].first(0).should be_an_instance_of(Array)
+    ArraySpecs::MyArray[].first(2).should be_an_instance_of(Array)
+    ArraySpecs::MyArray[1, 2, 3].first(0).should be_an_instance_of(Array)
+    ArraySpecs::MyArray[1, 2, 3].first(1).should be_an_instance_of(Array)
+    ArraySpecs::MyArray[1, 2, 3].first(2).should be_an_instance_of(Array)
+  end
+
+  it "is not destructive" do
+    a = [1, 2, 3]
+    a.first
+    a.should == [1, 2, 3]
+    a.first(2)
+    a.should == [1, 2, 3]
+    a.first(3)
+    a.should == [1, 2, 3]
+  end
+end

--- a/spec/core/array/first_spec.rb
+++ b/spec/core/array/first_spec.rb
@@ -33,7 +33,8 @@ describe "Array#first" do
     -> { [1, 2].first(-1) }.should raise_error(ArgumentError)
   end
 
-  it "raises a RangeError when count is a Bignum" do
+  # FIXME currently the value of bignum_value would be too large for natalie to build, add this back once fixed
+  xit "raises a RangeError when count is a Bignum" do
     -> { [].first(bignum_value) }.should raise_error(RangeError)
   end
 
@@ -41,7 +42,8 @@ describe "Array#first" do
     [1, 2, 3, 4, 5, 9].first(10).should == [1, 2, 3, 4, 5, 9]
   end
 
-  it "returns an array which is independent to the original when passed count" do
+  # TODO add this test back once we have a replace method
+  xit "returns an array which is independent to the original when passed count" do
     ary = [1, 2, 3, 4, 5]
     ary.first(0).replace([1,2])
     ary.should == [1, 2, 3, 4, 5]

--- a/src/array_value.cpp
+++ b/src/array_value.cpp
@@ -424,6 +424,10 @@ ValuePtr ArrayValue::first(Env *env, ValuePtr n) {
 
     ArrayValue *array = new ArrayValue();
 
+    auto to_int = SymbolValue::intern("to_int");
+    if (!n.is_integer() && n->respond_to(env, to_int))
+        n = n->send(env, to_int);
+
     n->assert_type(env, Value::Type::Integer, "Integer");
     nat_int_t n_value = n->as_integer()->to_nat_int_t();
 


### PR DESCRIPTION
Added spec to Array::first and made it compliant as per #39 . Currently ignoring the test using replace as that is not implemented yet and the one using bignum_value as that would not even compile.

[bignum_value](https://rubydoc.org/gems/rhodes/Object:bignum_value) implementation

Leads to:
```
/tmp/natalie.cpp20210912-722288-brxn2a:1103:54: error: integer constant is so large that it is unsigned [-Werror]
 1103 |     ValuePtr ValuePtrinteger1357 = ValuePtr::integer(9223372036854775808);
      |                                                      ^~~~~~~~~~~~~~~~~~~
cc1plus: note: unrecognized command-line option ‘-Wno-unknown-warning-option’ may have been intended to silence earlier diagnostics
cc1plus: all warnings being treated as errors
Traceback (most recent call last):
        4: from ./bin/natalie:215:in `<main>'
        3: from ./bin/natalie:108:in `run'
        2: from ./bin/natalie:133:in `compile_and_run'
        1: from /home/adistefano/Documents/natalie/lib/natalie/compiler.rb:50:in `compile'
/home/adistefano/Documents/natalie/lib/natalie/compiler.rb:58:in `compile_c_to_binary': There was an error compiling. (Natalie::Compiler::CompileError)
```