### PR TITLE
Add a Github Action workflow to run all ruby specs

### DIFF
--- a/.github/workflows/run_all_specs.yml
+++ b/.github/workflows/run_all_specs.yml
@@ -1,0 +1,29 @@
+name: Run all specs from ruby/spec
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+env:
+  BUNDLE_WITH: run_all_specs
+
+jobs:
+  specs:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+    - run: rake
+    - uses: actions/checkout@v2
+      with:
+        repository: ruby/spec
+        path: ruby_spec
+    - run: mv spec/support ruby_spec
+    - run: rm -rf spec/*/
+    - run: mv ruby_spec/*/ spec
+    - run: bundle exec ruby spec/support/ruby_spec_runner.rb

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,7 @@ gem 'ruby_parser'
 gem 'sexp_processor'
 gem 'minitest-reporters'
 gem 'rake'
+
+group :run_all_specs, optional: true do
+  gem 'concurrent-ruby'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     ansi (1.5.0)
     builder (3.2.4)
+    concurrent-ruby (1.1.9)
     minitest (5.14.4)
     minitest-reporters (1.4.3)
       ansi
@@ -19,6 +20,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  concurrent-ruby
   minitest
   minitest-reporters
   rake

--- a/spec/support/ruby_spec_runner.rb
+++ b/spec/support/ruby_spec_runner.rb
@@ -1,0 +1,63 @@
+require 'concurrent'
+require 'yaml'
+require 'io/wait'
+
+pool = Concurrent::ThreadPoolExecutor.new(
+  max_threads: 4,
+  max_queue: 0 # unbounded work queue
+)
+success_count = 0
+failure_count = 0
+error_count = 0
+compile_errors = 0
+crashed_count = 0
+timed_out_count = 0
+
+specs = 'spec/**/*_spec.rb'
+
+puts "Start running specs #{specs}"
+
+Dir[specs].each do |path|
+  pool.post {
+    binary_name = path[..-4]
+    unless system("bin/natalie #{path} -c #{binary_name} 2> /dev/null")
+      compile_errors += 1
+      puts "Spec #{path} could not be compiled"
+      return
+    end
+
+    IO.popen(["./#{binary_name}", "-f", "yaml"], err: '/dev/null') { |f|
+      if f.wait_readable(180)
+        yaml = YAML.safe_load(f.read) || {}
+        # If one of those is not given there is something wrong... (probably crashed)
+        if yaml["examples"] && yaml["errors"] && yaml["failures"]
+          success_count += yaml["examples"] - yaml["errors"] - yaml["failures"]
+          failure_count += yaml["failures"]
+          error_count += yaml["errors"]
+          puts "Ran spec #{path}"
+        end
+      else
+        puts "Spec #{path} timed out (after 3 seconds)"
+        timed_out_count += 1
+        Process.kill('TERM', f.pid)
+      end
+    }
+
+    status = $?
+    # If the process did not exit normally it was probably shut down by the
+    # `Process.kill` call when timeouting a spec
+    if status.exited? && !status.success?
+      puts "Spec #{path} crashed"
+      crashed_count += 1
+    end
+  }
+end
+pool.shutdown
+pool.wait_for_termination
+
+puts "Success: #{success_count}"
+puts "Failures: #{failure_count}"
+puts "Errors: #{error_count}"
+puts "Compile Errors: #{compile_errors}"
+puts "Crashes: #{crashed_count}"
+puts "Timeouts: #{timed_out_count}"


### PR DESCRIPTION
We are constantly working on improving spec compliance for Natalie. I think it is very interesting to see the progress we are making with this. This Github Action workflow will run one time each day and run all specs from ruby/spec against Natalie. 

The current results are:
```
Success: 2525
Failures: 1389
Errors: 6202
Compile Errors: 1403
Crashes: 847
Timeouts: 7
```

Compile Errors, Crashes and Timeouts count per file while Success, Failures and Errors count per example. The results can only be seen manually by looking at the action log for now.