### PR TITLE
Implement Hash#to_proc

### DIFF
--- a/spec/core/hash/to_proc_spec.rb
+++ b/spec/core/hash/to_proc_spec.rb
@@ -1,0 +1,101 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Hash#to_proc" do
+  before :each do
+    @key = Object.new
+    @value = Object.new
+    @hash = { @key => @value }
+    @default = Object.new
+    @unstored = Object.new
+  end
+
+  it "returns an instance of Proc" do
+    @hash.to_proc.should be_an_instance_of Proc
+  end
+
+  describe "the returned proc" do
+    before :each do
+      @proc = @hash.to_proc
+    end
+
+    ruby_version_is ""..."3.0" do
+      it "is not a lambda" do
+        @proc.should_not.lambda?
+      end
+    end
+
+    ruby_version_is "3.0" do
+      it "is a lambda" do
+        @proc.should.lambda?
+      end
+
+      it "has an arity of 1" do
+        @proc.arity.should == 1
+      end
+    end
+
+    it "raises ArgumentError if not passed exactly one argument" do
+      -> {
+        @proc.call
+      }.should raise_error(ArgumentError)
+
+      -> {
+        @proc.call 1, 2
+      }.should raise_error(ArgumentError)
+    end
+
+    context "with a stored key" do
+      it "returns the paired value" do
+        @proc.call(@key).should equal(@value)
+      end
+    end
+
+    context "passed as a block" do
+      it "retrieves the hash's values" do
+        [@key].map(&@proc)[0].should equal(@value)
+      end
+
+      # TODO: implement instance_exec
+      # I think this spec might even fail because we are using `self` in the returned proc
+      context "to instance_exec" do
+        xit "always retrieves the original hash's values" do
+          hash = {foo: 1, bar: 2}
+          proc = hash.to_proc
+
+          hash.instance_exec(:foo, &proc).should == 1
+
+          hash2 = {quux: 1}
+          hash2.instance_exec(:foo, &proc).should == 1
+        end
+      end
+    end
+
+    context "with no stored key" do
+      it "returns nil" do
+        @proc.call(@unstored).should be_nil
+      end
+
+      context "when the hash has a default value" do
+        before :each do
+          @hash.default = @default
+        end
+
+        it "returns the default value" do
+          @proc.call(@unstored).should equal(@default)
+        end
+      end
+
+      context "when the hash has a default proc" do
+        it "returns an evaluated value from the default proc" do
+          @hash.default_proc = -> hash, called_with { [hash.keys, called_with] }
+          @proc.call(@unstored).should == [[@key], @unstored]
+        end
+      end
+    end
+
+    it "raises an ArgumentError when calling #call on the Proc with no arguments" do
+      -> { @hash.to_proc.call }.should raise_error(ArgumentError)
+    end
+  end
+end

--- a/src/hash.rb
+++ b/src/hash.rb
@@ -45,4 +45,10 @@ class Hash
     end
     new_hash
   end
+
+  def to_proc
+    Proc.new do |*args|
+      self[*args]
+    end
+  end
 end

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -265,6 +265,7 @@ class Matcher
   def any?; method_missing(:any?); end
   def empty?; method_missing(:empty?); end
   def finite?; method_missing(:finite?); end
+  def lambda?; method_missing(:lambda?); end
   def nan?; method_missing(:nan?); end
   def none?; method_missing(:none?); end
   def one?; method_missing(:one?); end
@@ -686,8 +687,8 @@ class Object
 
   def eql(other)
     EqlExpectation.new(other)
-  end  
-  
+  end
+
   def be_empty()
     BeEmptyExpectation.new
   end

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -84,6 +84,8 @@ alias context describe
 
 def xdescribe(description, &block)
   @context << Context.new(description, skip: true)
+  yield
+  @context.pop
 end
 
 alias xcontext xdescribe


### PR DESCRIPTION
  Please not that this targets Ruby 2.7. With Ruby version > 3 this should return a lambda instead of a proc.