### PR TITLE
Implement Hash#except

### DIFF
--- a/include/natalie/hash_value.hpp
+++ b/include/natalie/hash_value.hpp
@@ -132,6 +132,7 @@ public:
     bool eq(Env *, ValuePtr, SymbolValue *);
     bool eq(Env *, ValuePtr);
     bool eql(Env *, ValuePtr);
+    ValuePtr except(Env *, size_t, ValuePtr *);
     ValuePtr fetch(Env *, ValuePtr, ValuePtr, Block *);
     ValuePtr fetch_values(Env *, size_t, ValuePtr *, Block *);
     ValuePtr has_key(Env *, ValuePtr);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -465,6 +465,7 @@ gen.binding('Hash', 'each', 'HashValue', 'each', argc: 0, pass_env: true, pass_b
 gen.binding('Hash', 'each_pair', 'HashValue', 'each', argc: 0, pass_env: true, pass_block: true, return_type: :Value)
 gen.binding('Hash', 'empty?', 'HashValue', 'is_empty', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
 gen.binding('Hash', 'eql?', 'HashValue', 'eql', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
+gen.binding('Hash', 'except', 'HashValue', 'except', argc: :any, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'fetch', 'HashValue', 'fetch', argc: 1..2, pass_env: true, pass_block: true, return_type: :Value)
 gen.binding('Hash', 'fetch_values', 'HashValue', 'fetch_values', argc: :any, pass_env: true, pass_block: true, return_type: :Value)
 gen.binding('Hash', 'has_key?', 'HashValue', 'has_key', argc: 1, pass_env: true, pass_block: false, return_type: :Value)

--- a/spec/core/hash/except_spec.rb
+++ b/spec/core/hash/except_spec.rb
@@ -1,0 +1,34 @@
+require_relative '../../spec_helper'
+
+ruby_version_is "3.0" do
+  describe "Hash#except" do
+    before :each do
+      @hash = { a: 1, b: 2, c: 3 }
+    end
+
+    it "returns a new duplicate hash without arguments" do
+      ret = @hash.except
+      ret.should_not equal(@hash)
+      ret.should == @hash
+    end
+
+    it "returns a hash without the requested subset" do
+      @hash.except(:c, :a).should == { b: 2 }
+    end
+
+    it "ignores keys not present in the original hash" do
+      @hash.except(:a, :chunky_bacon).should == { b: 2, c: 3 }
+    end
+
+    it "always returns a Hash without a default" do
+      klass = Class.new(Hash)
+      h = klass.new(:default)
+      h[:bar] = 12
+      h[:foo] = 42
+      r = h.except(:foo)
+      r.should == {bar: 12}
+      r.class.should == Hash
+      r.default.should == nil
+    end
+  end
+end

--- a/src/hash_value.cpp
+++ b/src/hash_value.cpp
@@ -378,6 +378,18 @@ ValuePtr HashValue::each(Env *env, Block *block) {
     return this;
 }
 
+ValuePtr HashValue::except(Env *env, size_t argc, ValuePtr *args) {
+    HashValue *new_hash = new HashValue {};
+    for (auto &node : *this) {
+        new_hash->put(env, node.key, node.val);
+    }
+
+    for (size_t i = 0; i < argc; i++) {
+        new_hash->remove(env, args[i]);
+    }
+    return new_hash;
+}
+
 ValuePtr HashValue::fetch(Env *env, ValuePtr key, ValuePtr default_value, Block *block) {
     ValuePtr value = get(env, key);
     if (!value) {
@@ -531,5 +543,4 @@ ValuePtr HashValue::compact_in_place(Env *env) {
         return NilValue::the();
     return this;
 }
-
 }


### PR DESCRIPTION
I do not know if there is an easier way of copying the hash. I cannot use the constructor like `new HashValue { *this }`, because it expects the new Hash to be of class Hash (and not of a sub class). Is there an easier way to do it?