### PR TITLE
Fix behavior of Hash#value? if value is falsey

### DIFF
--- a/include/natalie/hash_value.hpp
+++ b/include/natalie/hash_value.hpp
@@ -137,6 +137,7 @@ public:
     ValuePtr fetch(Env *, ValuePtr, ValuePtr, Block *);
     ValuePtr fetch_values(Env *, size_t, ValuePtr *, Block *);
     ValuePtr has_key(Env *, ValuePtr);
+    ValuePtr has_value(Env *, ValuePtr);
     ValuePtr initialize(Env *, ValuePtr, Block *);
     ValuePtr inspect(Env *);
     ValuePtr keys(Env *);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -470,6 +470,7 @@ gen.binding('Hash', 'except', 'HashValue', 'except', argc: :any, pass_env: true,
 gen.binding('Hash', 'fetch', 'HashValue', 'fetch', argc: 1..2, pass_env: true, pass_block: true, return_type: :Value)
 gen.binding('Hash', 'fetch_values', 'HashValue', 'fetch_values', argc: :any, pass_env: true, pass_block: true, return_type: :Value)
 gen.binding('Hash', 'has_key?', 'HashValue', 'has_key', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
+gen.binding('Hash', 'has_value?', 'HashValue', 'has_value', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'initialize', 'HashValue', 'initialize', argc: 0..1, pass_env: true, pass_block: true, return_type: :Value)
 gen.binding('Hash', 'initialize_copy', 'HashValue', 'replace', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'inspect', 'HashValue', 'inspect', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
@@ -487,6 +488,7 @@ gen.binding('Hash', 'to_h', 'HashValue', 'to_h', argc: 0, pass_env: true, pass_b
 gen.binding('Hash', 'to_hash', 'HashValue', 'to_hash', argc: 0, pass_env: false, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'to_s', 'HashValue', 'inspect', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'update', 'HashValue', 'merge_in_place', argc: :any, pass_env: true, pass_block: true, return_type: :Value)
+gen.binding('Hash', 'value?', 'HashValue', 'has_value', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'values', 'HashValue', 'values', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 
 gen.undefine_singleton_method('Integer', 'new')

--- a/src/hash.rb
+++ b/src/hash.rb
@@ -49,11 +49,6 @@ class Hash
     end
   end
 
-  def has_value?(value)
-    !!key(value)
-  end
-  alias value? has_value?
-
   def invert
     new_hash = {}
     each do |key, value|

--- a/src/hash_value.cpp
+++ b/src/hash_value.cpp
@@ -481,6 +481,15 @@ ValuePtr HashValue::has_key(Env *env, ValuePtr key) {
     }
 }
 
+ValuePtr HashValue::has_value(Env *env, ValuePtr value) {
+    for (auto &node : *this) {
+        if (node.val.send(env, SymbolValue::intern("=="), { value })->is_true()) {
+            return TrueValue::the();
+        }
+    }
+    return FalseValue::the();
+}
+
 ValuePtr HashValue::merge(Env *env, size_t argc, ValuePtr *args, Block *block) {
     return dup(env)->as_hash()->merge_in_place(env, argc, args, block);
 }

--- a/test/natalie/hash_test.rb
+++ b/test/natalie/hash_test.rb
@@ -282,4 +282,11 @@ describe 'hash' do
       h.values_at(:a, :b, :c).should == [1, 2, 3]
     end
   end
+
+  describe '#value?' do
+    it "work with falsey values" do
+      h = { nil => :a }
+      h.value?(:a).should == true
+    end
+  end
 end


### PR DESCRIPTION
Noticed this bug while working on `Hash#slice`:

Previously we double-negated the returned key from `Hash#key`. However,
this method returns `nil` when no key is found. As hash keys can also
be `nil`, we cannot differentiate between a found key that's `nil` and
no found key.