### PR TITLE
Implement Hash#rehash and Hash#compare_by_identity(?)

### DIFF
--- a/include/natalie/hash_value.hpp
+++ b/include/natalie/hash_value.hpp
@@ -39,7 +39,8 @@ public:
         , m_default_value { NilValue::the() } { }
 
     HashValue(Env *env, HashValue &other)
-        : Value { other } {
+        : Value { other }
+        , m_is_comparing_by_identity { other.m_is_comparing_by_identity } {
         for (auto node : other) {
             put(env, node.key, node.val);
         }
@@ -126,6 +127,8 @@ public:
         return iterator { nullptr, this };
     }
 
+    ValuePtr compare_by_identity(Env *);
+    ValuePtr is_comparing_by_identity();
     ValuePtr delete_if(Env *, Block *);
     ValuePtr delete_key(Env *, ValuePtr, Block *);
     ValuePtr dig(Env *, size_t, ValuePtr *);
@@ -162,6 +165,7 @@ public:
 private:
     void key_list_remove_node(Key *);
     Key *key_list_append(Env *, ValuePtr, nat_int_t, ValuePtr);
+    nat_int_t generate_key_hash(Env *, ValuePtr);
 
     void destroy_key_list() {
         if (!m_key_list) return;
@@ -177,6 +181,7 @@ private:
     Key *m_key_list { nullptr };
     TM::Hashmap<Key *, Value *> m_hashmap { hash, compare, 10 }; // TODO: profile and tune this initial capacity
     bool m_is_iterating { false };
+    bool m_is_comparing_by_identity { false };
     ValuePtr m_default_value { nullptr };
     ProcValue *m_default_proc { nullptr };
 };

--- a/include/natalie/hash_value.hpp
+++ b/include/natalie/hash_value.hpp
@@ -46,6 +46,17 @@ public:
         }
     }
 
+    HashValue &operator=(HashValue &&other) {
+        m_hashmap.clear();
+        m_hashmap = other.m_hashmap;
+        m_key_list = other.m_key_list;
+        m_is_comparing_by_identity = other.m_is_comparing_by_identity;
+        m_default_value = other.m_default_value;
+        m_default_proc = other.m_default_proc;
+        other.m_key_list = nullptr;
+        return *this;
+    }
+
     static ValuePtr square_new(Env *, size_t argc, ValuePtr *args, ClassValue *klass);
 
     static size_t hash(const void *);

--- a/include/natalie/hash_value.hpp
+++ b/include/natalie/hash_value.hpp
@@ -147,6 +147,7 @@ public:
     ValuePtr refeq(Env *, ValuePtr, ValuePtr);
     ValuePtr slice(Env *, size_t, ValuePtr *);
     ValuePtr replace(Env *, ValuePtr);
+    ValuePtr rehash(Env *);
     ValuePtr values(Env *);
 
     ValuePtr to_h(Env *, Block *);

--- a/include/natalie/hash_value.hpp
+++ b/include/natalie/hash_value.hpp
@@ -47,8 +47,9 @@ public:
     }
 
     HashValue &operator=(HashValue &&other) {
+        Value::operator=(std::move(other));
         m_hashmap.clear();
-        m_hashmap = other.m_hashmap;
+        m_hashmap = std::move(other.m_hashmap);
         m_key_list = other.m_key_list;
         m_is_comparing_by_identity = other.m_is_comparing_by_identity;
         m_default_value = other.m_default_value;

--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -63,6 +63,15 @@ public:
 
     Value &operator=(const Value &) = delete;
 
+    Value &operator=(Value &&other) {
+        m_type = other.m_type;
+        m_singleton_class = other.m_singleton_class;
+        m_owner = other.m_owner;
+        m_flags = other.m_flags;
+        m_ivars = std::move(other.m_ivars);
+        return *this;
+    }
+
     virtual ~Value() override {
         m_type = ValueType::Nil;
     }

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -455,6 +455,8 @@ gen.binding('Hash', '[]=', 'HashValue', 'refeq', argc: 2, pass_env: true, pass_b
 gen.binding('Hash', 'clear', 'HashValue', 'clear', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'compact', 'HashValue', 'compact', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'compact!', 'HashValue', 'compact_in_place', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
+gen.binding('Hash', 'compare_by_identity', 'HashValue', 'compare_by_identity', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
+gen.binding('Hash', 'compare_by_identity?', 'HashValue', 'is_comparing_by_identity', argc: 0, pass_env: false, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'default', 'HashValue', 'get_default', argc: 0..1, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'default=', 'HashValue', 'set_default', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'default_proc', 'HashValue', 'default_proc', argc: 0, pass_env: true, pass_block: false, return_type: :Value)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -482,6 +482,7 @@ gen.binding('Hash', 'member?', 'HashValue', 'has_key', argc: 1, pass_env: true, 
 gen.binding('Hash', 'merge', 'HashValue', 'merge', argc: :any, pass_env: true, pass_block: true, return_type: :Value)
 gen.binding('Hash', 'merge!', 'HashValue', 'merge_in_place', argc: :any, pass_env: true, pass_block: true, return_type: :Value)
 gen.binding('Hash', 'replace', 'HashValue', 'replace', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
+gen.binding('Hash', 'rehash', 'HashValue', 'rehash', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'size', 'HashValue', 'size', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'slice', 'HashValue', 'slice', argc: :any, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'store', 'HashValue', 'refeq', argc: 2, pass_env: true, pass_block: false, return_type: :Value)

--- a/spec/core/hash/compare_by_identity_spec.rb
+++ b/spec/core/hash/compare_by_identity_spec.rb
@@ -1,0 +1,138 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Hash#compare_by_identity" do
+  before :each do
+    @h = {}
+    @idh = {}.compare_by_identity
+  end
+
+  it "causes future comparisons on the receiver to be made by identity" do
+    @h[[1]] = :a
+    @h[[1]].should == :a
+    @h.compare_by_identity
+    @h[[1].dup].should be_nil
+  end
+
+  it "rehashes internally so that old keys can be looked up" do
+    h = {}
+    (1..10).each { |k| h[k] = k }
+    o = Object.new
+    def o.hash; 123; end
+    h[o] = 1
+    h.compare_by_identity
+    h[o].should == 1
+  end
+
+  it "returns self" do
+    h = {}
+    h[:foo] = :bar
+    h.compare_by_identity.should equal h
+  end
+
+  it "has no effect on an already compare_by_identity hash" do
+    @idh[:foo] = :bar
+    @idh.compare_by_identity.should equal @idh
+    @idh.should.compare_by_identity?
+    @idh[:foo].should == :bar
+  end
+
+  it "uses the semantics of BasicObject#equal? to determine key identity" do
+    [1].should_not equal([1])
+    @idh[[1]] = :c
+    @idh[[1]] = :d
+    :bar.should equal(:bar)
+    @idh[:bar] = :e
+    @idh[:bar] = :f
+    @idh.values.should == [:c, :d, :f]
+  end
+
+  it "uses #equal? semantics, but doesn't actually call #equal? to determine identity" do
+    obj = mock('equal')
+    obj.should_not_receive(:equal?)
+    @idh[:foo] = :glark
+    @idh[obj] = :a
+    @idh[obj].should == :a
+  end
+
+  it "does not call #hash on keys" do
+    key = HashSpecs::ByIdentityKey.new
+    @idh[key] = 1
+    @idh[key].should == 1
+  end
+
+  it "regards #dup'd objects as having different identities" do
+    key = ['foo']
+    @idh[key.dup] = :str
+    @idh[key].should be_nil
+  end
+
+  it "regards #clone'd objects as having different identities" do
+    key = ['foo']
+    @idh[key.clone] = :str
+    @idh[key].should be_nil
+  end
+
+  it "regards references to the same object as having the same identity" do
+    o = Object.new
+    @h[o] = :o
+    @h[:a] = :a
+    @h[o].should == :o
+  end
+
+  it "raises a FrozenError on frozen hashes" do
+    @h = @h.freeze
+    -> { @h.compare_by_identity }.should raise_error(FrozenError)
+  end
+
+  # Behaviour confirmed in bug #1871
+  it "persists over #dups" do
+    @idh['foo'] = :bar
+    @idh['foo'] = :glark
+    @idh.dup.should == @idh
+    @idh.dup.size.should == @idh.size
+  end
+
+  it "persists over #clones" do
+    @idh['foo'] = :bar
+    @idh['foo'] = :glark
+    @idh.clone.should == @idh
+    @idh.clone.size.should == @idh.size
+  end
+
+  it "does not copy string keys" do
+    foo = 'foo'
+    @idh[foo] = true
+    @idh[foo] = true
+    @idh.size.should == 1
+    @idh.keys.first.should equal foo
+  end
+
+  it "gives different identity for string literals" do
+    @idh['foo'] = 1
+    @idh['foo'] = 2
+    @idh.values.should == [1, 2]
+    @idh.size.should == 2
+  end
+end
+
+describe "Hash#compare_by_identity?" do
+  it "returns false by default" do
+    h = {}
+    h.compare_by_identity?.should be_false
+  end
+
+  it "returns true once #compare_by_identity has been invoked on self" do
+    h = {}
+    h.compare_by_identity
+    h.compare_by_identity?.should be_true
+  end
+
+  it "returns true when called multiple times on the same ident hash" do
+    h = {}
+    h.compare_by_identity
+    h.compare_by_identity?.should be_true
+    h.compare_by_identity?.should be_true
+    h.compare_by_identity?.should be_true
+  end
+end

--- a/spec/core/hash/rehash_spec.rb
+++ b/spec/core/hash/rehash_spec.rb
@@ -1,0 +1,84 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Hash#rehash" do
+  it "reorganizes the Hash by recomputing all key hash codes" do
+    k1 = Object.new
+    k2 = Object.new
+    def k1.hash; 0; end
+    def k2.hash; 1; end
+
+    h = {}
+    h[k1] = :v1
+    h[k2] = :v2
+
+    def k1.hash; 1; end
+
+    # The key should no longer be found as the #hash changed.
+    # Hash values 0 and 1 should not conflict, even with 1-bit stored hash.
+    h.key?(k1).should == false
+
+    h.keys.include?(k1).should == true
+
+    h.rehash.should equal(h)
+    h.key?(k1).should == true
+    h[k1].should == :v1
+  end
+
+  it "calls #hash for each key" do
+    k1 = mock('k1')
+    k2 = mock('k2')
+    v1 = mock('v1')
+    v2 = mock('v2')
+
+    v1.should_not_receive(:hash)
+    v2.should_not_receive(:hash)
+
+    h = { k1 => v1, k2 => v2 }
+
+    k1.should_receive(:hash).twice.and_return(0)
+    k2.should_receive(:hash).twice.and_return(0)
+
+    h.rehash
+    h[k1].should == v1
+    h[k2].should == v2
+  end
+
+  it "removes duplicate keys" do
+    a = [1,2]
+    b = [1]
+
+    h = {}
+    h[a] = true
+    h[b] = true
+    b << 2
+    h.size.should == 2
+    h.keys.should == [a, b]
+    h.rehash
+    h.size.should == 1
+    h.keys.should == [a]
+  end
+
+  it "removes duplicate keys for large hashes" do
+    a = [1,2]
+    b = [1]
+
+    h = {}
+    h[a] = true
+    h[b] = true
+    100.times { |n| h[n] = true }
+    b << 2
+    h.size.should == 102
+    h.keys.should.include? a
+    h.keys.should.include? b
+    h.rehash
+    h.size.should == 101
+    h.keys.should.include? a
+    h.keys.should_not.include? [1]
+  end
+
+  it "raises a FrozenError if called on a frozen instance" do
+    -> { HashSpecs.frozen_hash.rehash  }.should raise_error(FrozenError)
+    -> { HashSpecs.empty_frozen_hash.rehash }.should raise_error(FrozenError)
+  end
+end

--- a/src/hash_value.cpp
+++ b/src/hash_value.cpp
@@ -21,11 +21,34 @@ bool HashValue::compare(const void *a, const void *b, void *env) {
     return a_p->key.send((Env *)env, SymbolValue::intern("eql?"), { b_p->key })->is_truthy();
 }
 
+ValuePtr HashValue::compare_by_identity(Env *env) {
+    assert_not_frozen(env);
+    this->m_is_comparing_by_identity = true;
+    this->rehash(env);
+    return this;
+}
+
+ValuePtr HashValue::is_comparing_by_identity() {
+    if (m_is_comparing_by_identity) {
+        return TrueValue::the();
+    } else {
+        return FalseValue::the();
+    }
+}
+
 ValuePtr HashValue::get(Env *env, ValuePtr key) {
     Key key_container;
     key_container.key = key;
-    key_container.hash = key.send(env, SymbolValue::intern("hash"))->as_integer()->to_nat_int_t();
+    key_container.hash = generate_key_hash(env, key);
     return m_hashmap.get(&key_container, env);
+}
+
+nat_int_t HashValue::generate_key_hash(Env *env, ValuePtr key) {
+    if (m_is_comparing_by_identity) {
+        return TM::Hashmap<void *>::hash_ptr(key.value());
+    } else {
+        return key.send(env, SymbolValue::intern("hash"))->as_integer()->to_nat_int_t();
+    }
 }
 
 ValuePtr HashValue::get_default(Env *env, ValuePtr key) {
@@ -49,12 +72,12 @@ ValuePtr HashValue::set_default(Env *env, ValuePtr value) {
 void HashValue::put(Env *env, ValuePtr key, ValuePtr val) {
     assert_not_frozen(env);
     Key key_container;
-    if (key->is_string() && !key->is_frozen()) {
+    if (!m_is_comparing_by_identity && key->is_string() && !key->is_frozen()) {
         key = key->as_string()->dup(env);
     }
     key_container.key = key;
 
-    auto hash = key.send(env, SymbolValue::intern("hash"))->as_integer()->to_nat_int_t();
+    auto hash = generate_key_hash(env, key);
     key_container.hash = hash;
     auto entry = m_hashmap.find_item(&key_container, hash, env);
     if (entry) {
@@ -72,7 +95,7 @@ void HashValue::put(Env *env, ValuePtr key, ValuePtr val) {
 ValuePtr HashValue::remove(Env *env, ValuePtr key) {
     Key key_container;
     key_container.key = key;
-    auto hash = key.send(env, SymbolValue::intern("hash"))->as_integer()->to_nat_int_t();
+    auto hash = generate_key_hash(env, key);
     key_container.hash = hash;
     auto entry = m_hashmap.find_item(&key_container, hash, env);
     if (entry) {

--- a/src/hash_value.cpp
+++ b/src/hash_value.cpp
@@ -277,6 +277,19 @@ ValuePtr HashValue::refeq(Env *env, ValuePtr key, ValuePtr val) {
     return val;
 }
 
+ValuePtr HashValue::rehash(Env *env) {
+    assert_not_frozen(env);
+
+    auto old_hashmap = TM::Hashmap<Key *, Value *> { m_hashmap };
+    clear(env);
+
+    for (auto pair : old_hashmap) {
+        put(env, pair.first->key, pair.second);
+    }
+
+    return this;
+}
+
 ValuePtr HashValue::replace(Env *env, ValuePtr other) {
     if (!other->is_hash() && other->respond_to(env, SymbolValue::intern("to_hash")))
         other = other->send(env, SymbolValue::intern("to_hash"));

--- a/src/hash_value.cpp
+++ b/src/hash_value.cpp
@@ -303,12 +303,8 @@ ValuePtr HashValue::refeq(Env *env, ValuePtr key, ValuePtr val) {
 ValuePtr HashValue::rehash(Env *env) {
     assert_not_frozen(env);
 
-    auto old_hashmap = TM::Hashmap<Key *, Value *> { m_hashmap };
-    clear(env);
-
-    for (auto pair : old_hashmap) {
-        put(env, pair.first->key, pair.second);
-    }
+    auto copy = new HashValue { env, *this };
+    HashValue::operator=(std::move(*copy));
 
     return this;
 }

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -605,6 +605,11 @@ class Stub
     self
   end
 
+  def twice
+    exactly(2)
+    self
+  end
+
   def exactly(n)
     @count_restriction = n
     self

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -263,6 +263,7 @@ class Matcher
   def <=(other); method_missing(:<=, other); end
   def all?; method_missing(:all?); end
   def any?; method_missing(:any?); end
+  def compare_by_identity?; method_missing(:compare_by_identity?); end
   def empty?; method_missing(:empty?); end
   def finite?; method_missing(:finite?); end
   def include?(other); method_missing(:include?, other); end

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -265,6 +265,7 @@ class Matcher
   def any?; method_missing(:any?); end
   def empty?; method_missing(:empty?); end
   def finite?; method_missing(:finite?); end
+  def include?(other); method_missing(:include?, other); end
   def lambda?; method_missing(:lambda?); end
   def nan?; method_missing(:nan?); end
   def none?; method_missing(:none?); end


### PR DESCRIPTION
Instead of using the `hash` method I'm using the `object_id` when `Hash#compare_by_identity` is called as the hash for the hash map. This seems to be working fine....

I'm not sure about the `rehash` implementation. Maybe we can make this more elegant?