### PR TITLE
Implement Hash#keep_if

### DIFF
--- a/include/natalie/hash_value.hpp
+++ b/include/natalie/hash_value.hpp
@@ -141,6 +141,7 @@ public:
     ValuePtr has_value(Env *, ValuePtr);
     ValuePtr initialize(Env *, ValuePtr, Block *);
     ValuePtr inspect(Env *);
+    ValuePtr keep_if(Env *, Block *);
     ValuePtr keys(Env *);
     ValuePtr merge(Env *, size_t, ValuePtr *, Block *);
     ValuePtr merge_in_place(Env *, size_t, ValuePtr *, Block *);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -479,6 +479,7 @@ gen.binding('Hash', 'initialize', 'HashValue', 'initialize', argc: 0..1, pass_en
 gen.binding('Hash', 'initialize_copy', 'HashValue', 'replace', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'inspect', 'HashValue', 'inspect', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'include?', 'HashValue', 'has_key', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
+gen.binding('Hash', 'keep_if', 'HashValue', 'keep_if', argc: 0, pass_env: true, pass_block: true, return_type: :Value)
 gen.binding('Hash', 'key?', 'HashValue', 'has_key', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'keys', 'HashValue', 'keys', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'length', 'HashValue', 'size', argc: 0, pass_env: true, pass_block: false, return_type: :Value)

--- a/spec/core/hash/keep_if_spec.rb
+++ b/spec/core/hash/keep_if_spec.rb
@@ -1,0 +1,37 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/iteration'
+require_relative '../enumerable/shared/enumeratorized'
+
+describe "Hash#keep_if" do
+  it "yields two arguments: key and value" do
+    all_args = []
+    { 1 => 2, 3 => 4 }.keep_if { |*args| all_args << args }
+    all_args.should == [[1, 2], [3, 4]]
+  end
+
+  it "keeps every entry for which block is true and returns self" do
+    h = { a: 1, b: 2, c: 3, d: 4 }
+    h.keep_if { |k,v| v % 2 == 0 }.should equal(h)
+    h.should == { b: 2, d: 4 }
+  end
+
+  it "removes all entries if the block is false" do
+    h = { a: 1, b: 2, c: 3 }
+    h.keep_if { |k,v| false }.should equal(h)
+    h.should == {}
+  end
+
+  it "returns self even if unmodified" do
+    h = { 1 => 2, 3 => 4 }
+    h.keep_if { true }.should equal(h)
+  end
+
+  it "raises a FrozenError if called on a frozen instance" do
+    -> { HashSpecs.frozen_hash.keep_if { true } }.should raise_error(FrozenError)
+    -> { HashSpecs.empty_frozen_hash.keep_if { false } }.should raise_error(FrozenError)
+  end
+
+  it_behaves_like :hash_iteration_no_block, :keep_if
+  it_behaves_like :enumeratorized_with_origin_size, :keep_if, { 1 => 2, 3 => 4, 5 => 6 }
+end

--- a/src/hash_value.cpp
+++ b/src/hash_value.cpp
@@ -295,7 +295,7 @@ ValuePtr HashValue::replace(Env *env, ValuePtr other) {
 
 ValuePtr HashValue::delete_if(Env *env, Block *block) {
     if (!block)
-        return send(env, SymbolValue::intern("enum_for"), { SymbolValue::intern("each") });
+        return send(env, SymbolValue::intern("enum_for"), { SymbolValue::intern("delete_if") });
 
     assert_not_frozen(env);
     for (auto &node : *this) {

--- a/src/hash_value.cpp
+++ b/src/hash_value.cpp
@@ -483,6 +483,21 @@ ValuePtr HashValue::keys(Env *env) {
     return array;
 }
 
+ValuePtr HashValue::keep_if(Env *env, Block *block) {
+    if (!block)
+        return send(env, SymbolValue::intern("enum_for"), { SymbolValue::intern("keep_if") });
+
+    assert_not_frozen(env);
+    for (auto &node : *this) {
+        ValuePtr args[2] = { node.key, node.val };
+        if (!NAT_RUN_BLOCK_WITHOUT_BREAK(env, block, 2, args, nullptr)->is_truthy()) {
+            delete_key(env, node.key, nullptr);
+        }
+    }
+
+    return this;
+}
+
 ValuePtr HashValue::to_h(Env *env, Block *block) {
     if (!block)
         return this;


### PR DESCRIPTION
This also fixes a small bug in Hash#delete_if, where the wrong method is sent to Kernel#enum_for if no block is passed.