### PR TITLE
Implement Hash#deconstruct_keys

### DIFF
--- a/spec/core/hash/deconstruct_keys_spec.rb
+++ b/spec/core/hash/deconstruct_keys_spec.rb
@@ -1,0 +1,25 @@
+require_relative '../../spec_helper'
+
+ruby_version_is "2.7" do
+  describe "Hash#deconstruct_keys" do
+    it "returns self" do
+      hash = {a: 1, b: 2}
+
+      hash.deconstruct_keys([:a, :b]).should equal hash
+    end
+
+    it "requires one argument" do
+      -> {
+        {a: 1}.deconstruct_keys
+      }.should raise_error(ArgumentError, /wrong number of arguments \(given 0, expected 1\)/)
+    end
+
+    it "ignores argument" do
+      hash = {a: 1, b: 2}
+
+      hash.deconstruct_keys([:a]).should == {a: 1, b: 2}
+      hash.deconstruct_keys(0   ).should == {a: 1, b: 2}
+      hash.deconstruct_keys(''  ).should == {a: 1, b: 2}
+    end
+  end
+end

--- a/src/hash.rb
+++ b/src/hash.rb
@@ -24,6 +24,10 @@ class Hash
     nil
   end
 
+  def deconstruct_keys(keys)
+    self
+  end
+
   def key(value)
     each do |k, v|
       return k if v == value


### PR DESCRIPTION
The method does not seem to have any use and the spec only runs for
rubies with version 2.7, so I'm not sure what the purpose is. However,
here it is :^)
