### PR TITLE
Make Hash#initialize spec compliant

### DIFF
--- a/include/natalie/module_value.hpp
+++ b/include/natalie/module_value.hpp
@@ -107,8 +107,8 @@ public:
 
     ValuePtr module_eval(Env *, Block *);
 
-    ValuePtr private_method(Env *, ValuePtr method_name);
-    ValuePtr protected_method(Env *, ValuePtr method_name);
+    virtual ValuePtr private_method(Env *, ValuePtr method_name) override;
+    virtual ValuePtr protected_method(Env *, ValuePtr method_name) override;
     ValuePtr public_method(Env *, ValuePtr method_name);
 
     bool const_defined(Env *, ValuePtr);

--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -175,6 +175,9 @@ public:
     SymbolValue *define_singleton_method(Env *, SymbolValue *, Block *);
     SymbolValue *undefine_singleton_method(Env *, SymbolValue *);
 
+    virtual ValuePtr private_method(Env *, ValuePtr method_name);
+    virtual ValuePtr protected_method(Env *, ValuePtr method_name);
+
     virtual void alias(Env *, SymbolValue *, SymbolValue *);
 
     nat_int_t object_id() { return reinterpret_cast<nat_int_t>(this); }

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -36,6 +36,9 @@ class BindingGen
         @consts[binding.rb_class] = true
       end
       puts "    #{binding.rb_class_as_c_variable}->#{binding.define_method_name}(env, SymbolValue::intern(#{binding.rb_method.inspect}), #{binding.name}, #{binding.arity});"
+      if binding.needs_to_set_visibility?
+        puts "    #{binding.rb_class_as_c_variable}->#{binding.set_visibility_method_name}(env, SymbolValue::intern(#{binding.rb_method.inspect}));"
+      end
     end
     @undefine_singleton_methods.each do |rb_class, method|
       puts "    #{rb_class}->undefine_singleton_method(env, SymbolValue::intern(#{method.inspect}));"
@@ -44,7 +47,7 @@ class BindingGen
   end
 
   class Binding
-    def initialize(rb_class, rb_method, cpp_class, cpp_method, argc:, pass_env:, pass_block:, return_type:, singleton: false, static: false, pass_klass: false)
+    def initialize(rb_class, rb_method, cpp_class, cpp_method, argc:, pass_env:, pass_block:, return_type:, singleton: false, static: false, pass_klass: false, visibility: :public)
       @rb_class = rb_class
       @rb_method = rb_method
       @cpp_class = cpp_class
@@ -56,10 +59,11 @@ class BindingGen
       @return_type = return_type
       @singleton = singleton
       @static = static
+      @visibility = visibility
       generate_name
     end
 
-    attr_reader :rb_class, :rb_method, :cpp_class, :cpp_method, :argc, :pass_env, :pass_block, :pass_klass, :return_type, :name
+    attr_reader :rb_class, :rb_method, :cpp_class, :cpp_method, :argc, :pass_env, :pass_block, :pass_klass, :return_type, :name, :visibility
 
     def arity
       case argc
@@ -152,6 +156,21 @@ ValuePtr #{name}(Env *env, ValuePtr klass, size_t argc, ValuePtr *args, Block *b
 
     def rb_class_as_c_variable
       rb_class.split('::').last
+    end
+
+    def needs_to_set_visibility?
+      visibility != :public
+    end
+
+    def set_visibility_method_name
+      case visibility
+      when :private
+        'private_method'
+      when :protected
+        'protected_method'
+      else
+        raise "Unknown visibility: #{visibility.inspect}"
+      end
     end
 
     private
@@ -254,7 +273,7 @@ ValuePtr #{name}(Env *env, ValuePtr klass, size_t argc, ValuePtr *args, Block *b
     end
 
     def generate_name
-      @name = "#{cpp_class}_#{cpp_method}#{@singleton ? '_singleton' : ''}#{@static ? '_static' : ''}_binding"
+      @name = "#{cpp_class}_#{cpp_method}#{@singleton ? '_singleton' : ''}#{@static ? '_static' : ''}_#{@visibility}_binding"
     end
   end
 end

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -499,7 +499,7 @@ gen.binding('Hash', 'fetch', 'HashValue', 'fetch', argc: 1..2, pass_env: true, p
 gen.binding('Hash', 'fetch_values', 'HashValue', 'fetch_values', argc: :any, pass_env: true, pass_block: true, return_type: :Value)
 gen.binding('Hash', 'has_key?', 'HashValue', 'has_key', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'has_value?', 'HashValue', 'has_value', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
-gen.binding('Hash', 'initialize', 'HashValue', 'initialize', argc: 0..1, pass_env: true, pass_block: true, return_type: :Value)
+gen.binding('Hash', 'initialize', 'HashValue', 'initialize', argc: 0..1, pass_env: true, pass_block: true, return_type: :Value, visibility: :private)
 gen.binding('Hash', 'initialize_copy', 'HashValue', 'replace', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'inspect', 'HashValue', 'inspect', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'include?', 'HashValue', 'has_key', argc: 1, pass_env: true, pass_block: false, return_type: :Value)

--- a/spec/core/hash/initialize_spec.rb
+++ b/spec/core/hash/initialize_spec.rb
@@ -1,0 +1,62 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Hash#initialize" do
+  it "is private" do
+    # Hash.should have_private_instance_method("initialize")
+    -> { {}.initialize }.should raise_error(NoMethodError, "private method `initialize' called for {}")
+  end
+
+  it "can be used to reset default_proc" do
+    h = { "foo" => 1, "bar" => 2 }
+    h.default_proc.should == nil
+    h.send(:initialize) { |_, k| k * 2 }
+    h.default_proc.should_not == nil
+    h["a"].should == "aa"
+  end
+
+  it "can be used to reset the default value" do
+    h = {}
+    h.default = 42
+    h.default.should == 42
+    h.send(:initialize, 1)
+    h.default.should == 1
+    h.send(:initialize)
+    h.default.should == nil
+  end
+
+  it "receives the arguments passed to Hash#new" do
+    HashSpecs::NewHash.new(:one, :two)[0].should == :one
+    HashSpecs::NewHash.new(:one, :two)[1].should == :two
+  end
+
+  it "does not change the storage, only the default value or proc" do
+    h = HashSpecs::SubHashSettingInInitialize.new
+    h.to_a.should == [[:foo, :bar]]
+
+    h = HashSpecs::SubHashSettingInInitialize.new(:default)
+    h.to_a.should == [[:foo, :bar]]
+
+    h = HashSpecs::SubHashSettingInInitialize.new { :default_block }
+    h.to_a.should == [[:foo, :bar]]
+  end
+
+  it "returns self" do
+    h = Hash.new
+    h.send(:initialize).should equal(h)
+  end
+
+  it "raises a FrozenError if called on a frozen instance" do
+    block = -> { HashSpecs.frozen_hash.instance_eval { initialize() }}
+    block.should raise_error(FrozenError)
+
+    block = -> { HashSpecs.frozen_hash.instance_eval { initialize(nil) }  }
+    block.should raise_error(FrozenError)
+
+    block = -> { HashSpecs.frozen_hash.instance_eval { initialize(5) }    }
+    block.should raise_error(FrozenError)
+
+    block = -> { HashSpecs.frozen_hash.instance_eval { initialize { 5 } } }
+    block.should raise_error(FrozenError)
+  end
+end

--- a/src/hash_value.cpp
+++ b/src/hash_value.cpp
@@ -191,12 +191,18 @@ void HashValue::key_list_remove_node(Key *node) {
 }
 
 ValuePtr HashValue::initialize(Env *env, ValuePtr default_value, Block *block) {
+    assert_not_frozen(env);
+
     if (block) {
         if (default_value) {
             env->raise("ArgumentError", "wrong number of arguments (given 1, expected 0)");
         }
         set_default_proc(new ProcValue { block });
-    } else if (default_value) {
+    } else {
+        if (!default_value) {
+            default_value = NilValue::the();
+        }
+
         set_default(env, default_value);
     }
     return this;

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -401,6 +401,22 @@ SymbolValue *Value::undefine_method(Env *env, SymbolValue *name) {
     return name;
 }
 
+ValuePtr Value::private_method(Env *env, ValuePtr name) {
+    if (!is_main_object()) {
+        printf("tried to call private_method on something that has no methods\n");
+        abort();
+    }
+    return m_klass->private_method(env, name);
+}
+
+ValuePtr Value::protected_method(Env *env, ValuePtr name) {
+    if (!is_main_object()) {
+        printf("tried to call protected_method on something that has no methods\n");
+        abort();
+    }
+    return m_klass->protected_method(env, name);
+}
+
 ValuePtr Value::public_send(Env *env, SymbolValue *name, size_t argc, ValuePtr *args, Block *block) {
     Method *method = find_method(env, name, MethodVisibility::Public);
     return method->call(env, this, argc, args, block);


### PR DESCRIPTION
I did not see another way of defining a private method, then defining it and making it private afterwards. Is there better way to do this?