### PR TITLE
Add specs for Array#take and Array#take_while

### DIFF
--- a/spec/core/array/take_spec.rb
+++ b/spec/core/array/take_spec.rb
@@ -1,0 +1,40 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Array#take" do
+  it "returns the first specified number of elements" do
+    [1, 2, 3].take(2).should == [1, 2]
+  end
+
+  it "returns all elements when the argument is greater than the Array size" do
+    [1, 2].take(99).should == [1, 2]
+  end
+
+  it "returns all elements when the argument is less than the Array size" do
+    [1, 2].take(4).should == [1, 2]
+  end
+
+  it "returns an empty Array when passed zero" do
+    [1].take(0).should == []
+  end
+
+  it "returns an empty Array when called on an empty Array" do
+    [].take(3).should == []
+  end
+
+  it "raises an ArgumentError when the argument is negative" do
+    ->{ [1].take(-3) }.should raise_error(ArgumentError)
+  end
+
+  ruby_version_is ''...'3.0' do
+    it 'returns a subclass instance for Array subclasses' do
+      ArraySpecs::MyArray[1, 2, 3, 4, 5].take(1).should be_an_instance_of(ArraySpecs::MyArray)
+    end
+  end
+
+  ruby_version_is '3.0' do
+    it 'returns a Array instance for Array subclasses' do
+      ArraySpecs::MyArray[1, 2, 3, 4, 5].take(1).should be_an_instance_of(Array)
+    end
+  end
+end

--- a/spec/core/array/take_while_spec.rb
+++ b/spec/core/array/take_while_spec.rb
@@ -1,0 +1,28 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Array#take_while" do
+  it "returns all elements until the block returns false" do
+    [1, 2, 3].take_while{ |element| element < 3 }.should == [1, 2]
+  end
+
+  it "returns all elements until the block returns nil" do
+    [1, 2, nil, 4].take_while{ |element| element }.should == [1, 2]
+  end
+
+  it "returns all elements until the block returns false" do
+    [1, 2, false, 4].take_while{ |element| element }.should == [1, 2]
+  end
+
+  ruby_version_is ''...'3.0' do
+    it 'returns a subclass instance for Array subclasses' do
+      ArraySpecs::MyArray[1, 2, 3, 4, 5].take_while { |n| n < 4 }.should be_an_instance_of(ArraySpecs::MyArray)
+    end
+  end
+
+  ruby_version_is '3.0' do
+    it 'returns a Array instance for Array subclasses' do
+      ArraySpecs::MyArray[1, 2, 3, 4, 5].take_while { |n| n < 4 }.should be_an_instance_of(Array)
+    end
+  end
+end


### PR DESCRIPTION
#39 

I believe this just uses the `Enumerable#take` and `Enumerable#take_while`, methods. Is that okay to do here or would it be preferable for array_value.cpp to have take and take_while methods defined?

