### PR TITLE
Implement test to check that our collision rate for Array::hash is comparable or lower MRI's collision rate

### DIFF
--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -143,6 +143,12 @@ def ruby_version_is(version)
   end
 end
 
+def slow_test
+  if ENV['ENABLE_SLOW_TESTS']
+    yield
+  end
+end
+
 def platform_is_not(_)
   yield
 end


### PR DESCRIPTION
The test is still quite naive and only generates around 50k test cases and those are all very short arrays, so it is quite biased. Regardless it is still nice to have and see that we actually outperform MRI in this scenario (0.9190165737176968% vs 11.5%), which implies that this is 'good enough' for ruby and in theory won't need any further improvement in the foreseeable future. With this we should be able to close #188 