### PR TITLE
implement Hash::hash

### DIFF
--- a/include/natalie/hash_builder.hpp
+++ b/include/natalie/hash_builder.hpp
@@ -15,7 +15,7 @@ public:
     void append(nat_int_t hash) {
         if (m_does_order_matter)
             m_digest += (m_digest << 5) ^ hash;
-        else 
+        else
             m_digest ^= hash;
     }
 

--- a/include/natalie/hash_builder.hpp
+++ b/include/natalie/hash_builder.hpp
@@ -6,19 +6,24 @@ namespace Natalie {
 class HashBuilder {
 public:
     HashBuilder()
-        : HashBuilder { 100019 } { }
+        : HashBuilder { 100019, true } { }
 
-    HashBuilder(nat_int_t starting_digest)
-        : m_digest(starting_digest) { }
+    HashBuilder(nat_int_t starting_digest, bool does_order_matter)
+        : m_digest(starting_digest)
+        , m_does_order_matter(does_order_matter) { }
 
     void append(nat_int_t hash) {
-        m_digest += (m_digest << 5) ^ hash;
+        if (m_does_order_matter)
+            m_digest += (m_digest << 5) ^ hash;
+        else 
+            m_digest ^= hash;
     }
 
     nat_int_t digest() { return m_digest; }
 
 private:
     nat_int_t m_digest;
+    bool m_does_order_matter;
 };
 
 }

--- a/include/natalie/hash_value.hpp
+++ b/include/natalie/hash_value.hpp
@@ -152,6 +152,7 @@ public:
     ValuePtr except(Env *, size_t, ValuePtr *);
     ValuePtr fetch(Env *, ValuePtr, ValuePtr, Block *);
     ValuePtr fetch_values(Env *, size_t, ValuePtr *, Block *);
+    ValuePtr hash(Env *);
     ValuePtr has_key(Env *, ValuePtr);
     ValuePtr has_value(Env *, ValuePtr);
     ValuePtr initialize(Env *, ValuePtr, Block *);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -498,6 +498,7 @@ gen.binding('Hash', 'eql?', 'HashValue', 'eql', argc: 1, pass_env: true, pass_bl
 gen.binding('Hash', 'except', 'HashValue', 'except', argc: :any, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'fetch', 'HashValue', 'fetch', argc: 1..2, pass_env: true, pass_block: true, return_type: :Value)
 gen.binding('Hash', 'fetch_values', 'HashValue', 'fetch_values', argc: :any, pass_env: true, pass_block: true, return_type: :Value)
+gen.binding('Hash', 'hash', 'HashValue', 'hash', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'has_key?', 'HashValue', 'has_key', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'has_value?', 'HashValue', 'has_value', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Hash', 'initialize', 'HashValue', 'initialize', argc: 0..1, pass_env: true, pass_block: true, return_type: :Value, visibility: :private)

--- a/spec/core/hash/hash_spec.rb
+++ b/spec/core/hash/hash_spec.rb
@@ -1,0 +1,44 @@
+require_relative '../../spec_helper'
+
+describe "Hash" do
+  it "includes Enumerable" do
+    Hash.include?(Enumerable).should == true
+  end
+end
+
+describe "Hash#hash" do
+  it "returns a value which doesn't depend on the hash order" do
+    { 0=>2, 11=>1 }.hash.should == { 11=>1, 0=>2 }.hash
+  end
+
+  it "returns a value in which element values do not cancel each other out" do
+    { a: 2, b: 2 }.hash.should_not == { a: 7, b: 7 }.hash
+  end
+
+  it "returns a value in which element keys and values do not cancel each other out" do
+    { :a => :a }.hash.should_not == { :b => :b }.hash
+  end
+
+  it "generates a hash for recursive hash structures" do
+    h = {}
+    h[:a] = h
+    (h.hash == h[:a].hash).should == true
+  end
+
+  it "returns the same hash for recursive hashes" do
+    h = {} ; h[:x] = h
+    h.hash.should == {x: h}.hash
+    h.hash.should == {x: {x: h}}.hash
+    # This is because h.eql?(x: h)
+    # Remember that if two objects are eql?
+    # then the need to have the same hash.
+    # Check the Hash#eql? specs!
+  end
+
+  it "returns the same hash for recursive hashes through arrays" do
+    h = {} ; rec = [h] ; h[:x] = rec
+    h.hash.should == {x: rec}.hash
+    h.hash.should == {x: [h]}.hash
+    # Like above, because h.eql?(x: [h])
+  end
+end

--- a/spec/core/hash/hash_spec.rb
+++ b/spec/core/hash/hash_spec.rb
@@ -35,7 +35,7 @@ describe "Hash#hash" do
     # Check the Hash#eql? specs!
   end
 
-  it "returns the same hash for recursive hashes through arrays" do
+  xit "returns the same hash for recursive hashes through arrays" do
     h = {} ; rec = [h] ; h[:x] = rec
     h.hash.should == {x: rec}.hash
     h.hash.should == {x: [h]}.hash


### PR DESCRIPTION
Implement hash::hash from #96 . As per Array, we won't yet implement recursive hashes through arrays (test case "returns the same hash for recursive hashes through arrays"), but instead those will be separately tracked as they are both rather intertwined and may require some intervention on the eql? methods of both. 