### PR TITLE
make Array::clone spec compliant

### DIFF
--- a/spec/core/array/clone_spec.rb
+++ b/spec/core/array/clone_spec.rb
@@ -1,0 +1,31 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/clone'
+
+describe "Array#clone" do
+  it_behaves_like :array_clone, :clone
+
+  it "copies frozen status from the original" do
+    a = [1, 2, 3, 4]
+    b = [1, 2, 3, 4]
+    a.freeze
+    aa = a.clone
+    bb = b.clone
+
+    aa.should.frozen?
+    bb.should_not.frozen?
+  end
+
+  it "copies singleton methods" do
+    a = [1, 2, 3, 4]
+    b = [1, 2, 3, 4]
+    def a.a_singleton_method; end
+    aa = a.clone
+    bb = b.clone
+
+    a.respond_to?(:a_singleton_method).should be_true
+    b.respond_to?(:a_singleton_method).should be_false
+    aa.respond_to?(:a_singleton_method).should be_true
+    bb.respond_to?(:a_singleton_method).should be_false
+  end
+end

--- a/spec/core/array/shared/clone.rb
+++ b/spec/core/array/shared/clone.rb
@@ -1,0 +1,45 @@
+describe :array_clone, shared: true do
+  it "returns an Array or a subclass instance" do
+    [].send(@method).should be_an_instance_of(Array)
+    ArraySpecs::MyArray[1, 2].send(@method).should be_an_instance_of(ArraySpecs::MyArray)
+  end
+
+  it "produces a shallow copy where the references are directly copied" do
+    a = [mock('1'), mock('2')]
+    b = a.send @method
+    b.first.should equal a.first
+    b.last.should equal a.last
+  end
+
+  #FIXME add back once __id__ has been properly implemented
+  xit "creates a new array containing all elements or the original" do
+    a = [1, 2, 3, 4]
+    b = a.send @method
+    b.should == a
+    b.__id__.should_not == a.__id__
+  end
+
+  ruby_version_is ''...'2.7' do
+    it "copies taint status from the original" do
+      a = [1, 2, 3, 4]
+      b = [1, 2, 3, 4]
+      a.taint
+      aa = a.send @method
+      bb = b.send @method
+
+      aa.should.tainted?
+      bb.should_not.tainted?
+    end
+
+    it "copies untrusted status from the original" do
+      a = [1, 2, 3, 4]
+      b = [1, 2, 3, 4]
+      a.untrust
+      aa = a.send @method
+      bb = b.send @method
+
+      aa.should.untrusted?
+      bb.should_not.untrusted?
+    end
+  end
+end

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -40,7 +40,22 @@ ValuePtr KernelModule::binding(Env *env) {
 }
 
 ValuePtr KernelModule::clone(Env *env) {
-    return this->dup(env);
+    auto duplicate = this->dup(env);
+    auto s_class = singleton_class();
+    if (s_class) {
+        auto singleton_methods = new ArrayValue {};
+        s_class->methods(env, singleton_methods);
+
+        for (auto &method_name : *singleton_methods) {
+            auto m = s_class->find_method(env, method_name->as_symbol());
+            duplicate->singleton_class()->define_method(
+                m->env(),
+                SymbolValue::intern(m->name()),
+                m->fn(),
+                m->arity());
+        }
+    }
+    return duplicate;
 }
 
 ValuePtr KernelModule::cur_dir(Env *env) {


### PR DESCRIPTION
Added spec for Array::clone from #39 and added the 'copy singleton methods' behaviour MRI has. Since this does not look restricted to just Array, I've done that in Kernel itself and said behaviour does not exist with dup, so it's just for clone :) 