### PR TITLE
Make Comparable spec compliant

### DIFF
--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -238,8 +238,6 @@ public:
 
     bool neq(Env *env, ValuePtr other);
 
-    ValuePtr cmp(Env *, ValuePtr);
-
     ValuePtr instance_eval(Env *, ValuePtr, Block *);
 
     void assert_type(Env *, Value::Type, const char *);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -657,7 +657,6 @@ gen.binding('NilClass', 'to_s', 'NilValue', 'to_s', argc: 0, pass_env: true, pas
 
 gen.binding('Object', 'nil?', 'Value', 'is_nil', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
 gen.binding('Object', 'itself', 'Value', 'itself', argc: 0, pass_env: false, pass_block: false, return_type: :Value)
-gen.binding('Object', '<=>', 'Value', 'cmp', argc: 1, pass_env: true, pass_block: false, return_type: :Value)
 
 gen.singleton_binding('Parser', 'parse', 'ParserValue', 'parse', argc: 1..2, pass_env: true, pass_block: false, return_type: :Value)
 gen.singleton_binding('Parser', 'tokens', 'ParserValue', 'tokens', argc: 1..2, pass_env: true, pass_block: false, return_type: :Value)

--- a/spec/core/comparable/between_spec.rb
+++ b/spec/core/comparable/between_spec.rb
@@ -1,0 +1,25 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Comparable#between?" do
+  it "returns true if self is greater than or equal to the first and less than or equal to the second argument" do
+    a = ComparableSpecs::Weird.new(-1)
+    b = ComparableSpecs::Weird.new(0)
+    c = ComparableSpecs::Weird.new(1)
+    d = ComparableSpecs::Weird.new(2)
+
+    a.between?(a, a).should == true
+    a.between?(a, b).should == true
+    a.between?(a, c).should == true
+    a.between?(a, d).should == true
+    c.between?(c, d).should == true
+    d.between?(d, d).should == true
+    c.between?(a, d).should == true
+
+    a.between?(b, b).should == false
+    a.between?(b, c).should == false
+    a.between?(b, d).should == false
+    c.between?(a, a).should == false
+    c.between?(a, b).should == false
+  end
+end

--- a/spec/core/comparable/clamp_spec.rb
+++ b/spec/core/comparable/clamp_spec.rb
@@ -1,0 +1,88 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe 'Comparable#clamp' do
+  ruby_version_is ""..."2.7" do
+    it 'raises an Argument error unless given 2 parameters' do
+      c = ComparableSpecs::Weird.new(0)
+      -> { c.clamp(c) }.should raise_error(ArgumentError)
+      -> { c.clamp(c, c, c) }.should raise_error(ArgumentError)
+    end
+  end
+
+  it 'raises an Argument error unless the 2 parameters are correctly ordered' do
+    one = ComparableSpecs::WithOnlyCompareDefined.new(1)
+    two = ComparableSpecs::WithOnlyCompareDefined.new(2)
+    c = ComparableSpecs::Weird.new(3)
+
+    -> { c.clamp(two, one) }.should raise_error(ArgumentError)
+    one.should_receive(:<=>).any_number_of_times.and_return(nil)
+    -> { c.clamp(one, two) }.should raise_error(ArgumentError)
+  end
+
+  it 'returns self if within the given parameters' do
+    one = ComparableSpecs::WithOnlyCompareDefined.new(1)
+    two = ComparableSpecs::WithOnlyCompareDefined.new(2)
+    three = ComparableSpecs::WithOnlyCompareDefined.new(3)
+    c = ComparableSpecs::Weird.new(2)
+
+    c.clamp(one, two).should equal(c)
+    c.clamp(two, two).should equal(c)
+    c.clamp(one, three).should equal(c)
+    c.clamp(two, three).should equal(c)
+  end
+
+  it 'returns the min parameter if smaller than it' do
+    one = ComparableSpecs::WithOnlyCompareDefined.new(1)
+    two = ComparableSpecs::WithOnlyCompareDefined.new(2)
+    c = ComparableSpecs::Weird.new(0)
+
+    c.clamp(one, two).should equal(one)
+  end
+
+  it 'returns the max parameter if greater than it' do
+    one = ComparableSpecs::WithOnlyCompareDefined.new(1)
+    two = ComparableSpecs::WithOnlyCompareDefined.new(2)
+    c = ComparableSpecs::Weird.new(3)
+
+    c.clamp(one, two).should equal(two)
+  end
+
+  ruby_version_is "2.7" do
+    it 'returns self if within the given range parameters' do
+      one = ComparableSpecs::WithOnlyCompareDefined.new(1)
+      two = ComparableSpecs::WithOnlyCompareDefined.new(2)
+      three = ComparableSpecs::WithOnlyCompareDefined.new(3)
+      c = ComparableSpecs::Weird.new(2)
+
+      c.clamp(one..two).should equal(c)
+      c.clamp(two..two).should equal(c)
+      c.clamp(one..three).should equal(c)
+      c.clamp(two..three).should equal(c)
+    end
+
+    it 'returns the minimum value of the range parameters if smaller than it' do
+      one = ComparableSpecs::WithOnlyCompareDefined.new(1)
+      two = ComparableSpecs::WithOnlyCompareDefined.new(2)
+      c = ComparableSpecs::Weird.new(0)
+
+      c.clamp(one..two).should equal(one)
+    end
+
+    it 'returns the maximum value of the range parameters if greater than it' do
+      one = ComparableSpecs::WithOnlyCompareDefined.new(1)
+      two = ComparableSpecs::WithOnlyCompareDefined.new(2)
+      c = ComparableSpecs::Weird.new(3)
+
+      c.clamp(one..two).should equal(two)
+    end
+
+    it 'raises an Argument error if the range parameter is exclusive' do
+      one = ComparableSpecs::WithOnlyCompareDefined.new(1)
+      two = ComparableSpecs::WithOnlyCompareDefined.new(2)
+      c = ComparableSpecs::Weird.new(3)
+
+      -> { c.clamp(one...two) }.should raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/core/comparable/equal_value_spec.rb
+++ b/spec/core/comparable/equal_value_spec.rb
@@ -1,0 +1,114 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Comparable#==" do
+  a = b = nil
+  before :each do
+    a = ComparableSpecs::Weird.new(0)
+    b = ComparableSpecs::Weird.new(10)
+  end
+
+  it "returns true if other is the same as self" do
+    (a == a).should == true
+    (b == b).should == true
+  end
+
+  it "calls #<=> on self with other and returns true if #<=> returns 0" do
+    a.should_receive(:<=>).once.and_return(0)
+    (a == b).should == true
+  end
+
+  it "calls #<=> on self with other and returns true if #<=> returns 0.0" do
+    a.should_receive(:<=>).once.and_return(0.0)
+    (a == b).should == true
+  end
+
+  it "returns false if calling #<=> on self returns a positive Integer" do
+    a.should_receive(:<=>).once.and_return(1)
+    (a == b).should == false
+  end
+
+  it "returns false if calling #<=> on self returns a negative Integer" do
+    a.should_receive(:<=>).once.and_return(-1)
+    (a == b).should == false
+  end
+
+  context "when #<=> returns nil" do
+    before :each do
+      a.should_receive(:<=>).once.and_return(nil)
+    end
+
+    it "returns false" do
+      (a == b).should be_false
+    end
+  end
+
+  context "when #<=> returns nor nil neither an Integer" do
+    before :each do
+      a.should_receive(:<=>).once.and_return("abc")
+    end
+
+    it "raises an ArgumentError" do
+      -> { (a == b) }.should raise_error(ArgumentError)
+    end
+  end
+
+  context "when #<=> raises an exception" do
+    context "if it is a StandardError" do
+      before :each do
+        a.should_receive(:<=>).once.and_raise(StandardError)
+      end
+
+      it "lets it go through" do
+        -> { (a == b) }.should raise_error(StandardError)
+      end
+    end
+
+    context "if it is a subclass of StandardError" do
+      # TypeError < StandardError
+      before :each do
+        a.should_receive(:<=>).once.and_raise(TypeError)
+      end
+
+      it "lets it go through" do
+        -> { (a == b) }.should raise_error(TypeError)
+      end
+    end
+
+    it "lets it go through if it is not a StandardError" do
+      a.should_receive(:<=>).once.and_raise(Exception)
+      -> { (a == b) }.should raise_error(Exception)
+    end
+  end
+
+  context "when #<=> is not defined" do
+    before :each do
+      @a = ComparableSpecs::WithoutCompareDefined.new
+      @b = ComparableSpecs::WithoutCompareDefined.new
+    end
+
+    it "returns true for identical objects" do
+      @a.should == @a
+    end
+
+    it "returns false and does not recurse infinitely" do
+      @a.should_not == @b
+    end
+  end
+
+  context "when #<=> calls super" do
+    before :each do
+      @a = ComparableSpecs::CompareCallingSuper.new
+      @b = ComparableSpecs::CompareCallingSuper.new
+    end
+
+    it "returns true for identical objects" do
+      @a.should == @a
+    end
+
+    it "calls the defined #<=> only once for different objects" do
+      @a.should_not == @b
+      @a.calls.should == 1
+    end
+  end
+end

--- a/spec/core/comparable/fixtures/classes.rb
+++ b/spec/core/comparable/fixtures/classes.rb
@@ -1,0 +1,36 @@
+module ComparableSpecs
+  class WithOnlyCompareDefined
+    attr_reader :value
+
+    def initialize(value)
+      @value = value
+    end
+
+    def <=>(other)
+      self.value <=> other.value
+    end
+  end
+
+  class Weird < WithOnlyCompareDefined
+    include Comparable
+  end
+
+  class WithoutCompareDefined
+    include Comparable
+  end
+
+  class CompareCallingSuper
+    include Comparable
+
+    attr_reader :calls
+
+    def initialize
+      @calls = 0
+    end
+
+    def <=>(other)
+      @calls += 1
+      super(other)
+    end
+  end
+end

--- a/spec/core/comparable/gt_spec.rb
+++ b/spec/core/comparable/gt_spec.rb
@@ -1,0 +1,43 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Comparable#>" do
+  it "calls #<=> on self with other and returns true if #<=> returns any Integer greater than 0" do
+    a = ComparableSpecs::Weird.new(0)
+    b = ComparableSpecs::Weird.new(20)
+
+    a.should_receive(:<=>).any_number_of_times.and_return(1)
+    (a > b).should == true
+
+    a.should_receive(:<=>).any_number_of_times.and_return(0.1)
+    (a > b).should == true
+
+    a.should_receive(:<=>).any_number_of_times.and_return(10000000)
+    (a > b).should == true
+  end
+
+  it "returns false if calling #<=> on self returns 0 or any Integer less than 0" do
+    a = ComparableSpecs::Weird.new(0)
+    b = ComparableSpecs::Weird.new(10)
+
+    a.should_receive(:<=>).any_number_of_times.and_return(0)
+    (a > b).should == false
+
+    a.should_receive(:<=>).any_number_of_times.and_return(0.0)
+    (a > b).should == false
+
+    a.should_receive(:<=>).any_number_of_times.and_return(-1.0)
+    (a > b).should == false
+
+    a.should_receive(:<=>).any_number_of_times.and_return(-10000000)
+    (a > b).should == false
+  end
+
+  it "raises an ArgumentError if calling #<=> on self returns nil" do
+    a = ComparableSpecs::Weird.new(0)
+    b = ComparableSpecs::Weird.new(20)
+
+    a.should_receive(:<=>).any_number_of_times.and_return(nil)
+    -> { (a > b) }.should raise_error(ArgumentError)
+  end
+end

--- a/spec/core/comparable/gte_spec.rb
+++ b/spec/core/comparable/gte_spec.rb
@@ -1,0 +1,47 @@
+require_relative 'fixtures/classes'
+require_relative '../../spec_helper'
+
+describe "Comparable#>=" do
+  it "calls #<=> on self with other and returns true if #<=> returns 0 or any Integer greater than 0" do
+    a = ComparableSpecs::Weird.new(0)
+    b = ComparableSpecs::Weird.new(20)
+
+    a.should_receive(:<=>).any_number_of_times.and_return(0)
+    (a >= b).should == true
+
+    a.should_receive(:<=>).any_number_of_times.and_return(0.0)
+    (a >= b).should == true
+
+    a.should_receive(:<=>).any_number_of_times.and_return(1)
+    (a >= b).should == true
+
+    a.should_receive(:<=>).any_number_of_times.and_return(0.1)
+    (a >= b).should == true
+
+    a.should_receive(:<=>).any_number_of_times.and_return(10000000)
+    (a >= b).should == true
+  end
+
+  it "returns false if calling #<=> on self returns any Integer less than 0" do
+    a = ComparableSpecs::Weird.new(0)
+    b = ComparableSpecs::Weird.new(10)
+
+
+    a.should_receive(:<=>).any_number_of_times.and_return(-0.1)
+    (a >= b).should == false
+
+    a.should_receive(:<=>).any_number_of_times.and_return(-1.0)
+    (a >= b).should == false
+
+    a.should_receive(:<=>).any_number_of_times.and_return(-10000000)
+    (a >= b).should == false
+  end
+
+  it "raises an ArgumentError if calling #<=> on self returns nil" do
+    a = ComparableSpecs::Weird.new(0)
+    b = ComparableSpecs::Weird.new(20)
+
+    a.should_receive(:<=>).any_number_of_times.and_return(nil)
+    -> { (a >= b) }.should raise_error(ArgumentError)
+  end
+end

--- a/spec/core/comparable/lt_spec.rb
+++ b/spec/core/comparable/lt_spec.rb
@@ -1,0 +1,49 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Comparable#<" do
+  it "calls #<=> on self with other and returns true if #<=> returns any Integer less than 0" do
+    a = ComparableSpecs::Weird.new(0)
+    b = ComparableSpecs::Weird.new(20)
+
+    a.should_receive(:<=>).any_number_of_times.and_return(-1)
+    (a < b).should == true
+
+    a.should_receive(:<=>).any_number_of_times.and_return(-0.1)
+    (a < b).should == true
+
+    a.should_receive(:<=>).any_number_of_times.and_return(-10000000)
+    (a < b).should == true
+  end
+
+  it "returns false if calling #<=> on self returns 0 or any Integer greater than 0" do
+    a = ComparableSpecs::Weird.new(0)
+    b = ComparableSpecs::Weird.new(10)
+
+    a.should_receive(:<=>).any_number_of_times.and_return(0)
+    (a < b).should == false
+
+    a.should_receive(:<=>).any_number_of_times.and_return(0.0)
+    (a < b).should == false
+
+    a.should_receive(:<=>).any_number_of_times.and_return(1.0)
+    (a < b).should == false
+
+    a.should_receive(:<=>).any_number_of_times.and_return(10000000)
+    (a < b).should == false
+  end
+
+  it "raises an ArgumentError if calling #<=> on self returns nil" do
+    a = ComparableSpecs::Weird.new(0)
+    b = ComparableSpecs::Weird.new(20)
+
+    a.should_receive(:<=>).any_number_of_times.and_return(nil)
+    -> { (a < b) }.should raise_error(ArgumentError)
+  end
+
+  it "raises an argument error with a message containing the value" do
+    -> { ("foo" < 7) }.should raise_error(ArgumentError) { |e|
+      e.message.should == "comparison of String with 7 failed"
+    }
+  end
+end

--- a/spec/core/comparable/lte_spec.rb
+++ b/spec/core/comparable/lte_spec.rb
@@ -1,0 +1,46 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Comparable#<=" do
+  it "calls #<=> on self with other and returns true if #<=> returns 0 or any Integer less than 0" do
+    a = ComparableSpecs::Weird.new(0)
+    b = ComparableSpecs::Weird.new(20)
+
+    a.should_receive(:<=>).any_number_of_times.and_return(0)
+    (a <= b).should == true
+
+    a.should_receive(:<=>).any_number_of_times.and_return(0.0)
+    (a <= b).should == true
+
+    a.should_receive(:<=>).any_number_of_times.and_return(-1)
+    (a <= b).should == true
+
+    a.should_receive(:<=>).any_number_of_times.and_return(-0.1)
+    (a <= b).should == true
+
+    a.should_receive(:<=>).any_number_of_times.and_return(-10000000)
+    (a <= b).should == true
+  end
+
+  it "returns false if calling #<=> on self returns any Integer greater than 0" do
+    a = ComparableSpecs::Weird.new(0)
+    b = ComparableSpecs::Weird.new(10)
+
+    a.should_receive(:<=>).any_number_of_times.and_return(0.1)
+    (a <= b).should == false
+
+    a.should_receive(:<=>).any_number_of_times.and_return(1.0)
+    (a <= b).should == false
+
+    a.should_receive(:<=>).any_number_of_times.and_return(10000000)
+    (a <= b).should == false
+  end
+
+  it "raises an ArgumentError if calling #<=> on self returns nil" do
+    a = ComparableSpecs::Weird.new(0)
+    b = ComparableSpecs::Weird.new(20)
+
+    a.should_receive(:<=>).any_number_of_times.and_return(nil)
+    -> { (a <= b) }.should raise_error(ArgumentError)
+  end
+end

--- a/src/comparable.rb
+++ b/src/comparable.rb
@@ -1,25 +1,56 @@
 module Comparable
   def ==(other)
-    (self <=> other) == 0
-  end
-
-  def !=(other)
-    (self <=> other) != 0
+    result = self <=> other
+    raise ArgumentError, "comparison of #{result.class} with 0 failed" if !result.is_a?(Numeric) && !result.nil?
+    result == 0
   end
 
   def <(other)
-    (self <=> other) < 0
+    result = (self <=> other)
+    raise ArgumentError, "comparison of #{self.class} with #{other.class} failed" if result.nil?
+    result < 0
   end
 
   def <=(other)
-    (self <=> other) <= 0
+    result = (self <=> other)
+    raise ArgumentError, "comparison of #{self.class} with #{other.class} failed" if result.nil?
+    result <= 0
   end
 
   def >(other)
-    (self <=> other) > 0
+    !(self <= other)
   end
 
   def >=(other)
-    (self <=> other) >= 0
+    !(self < other)
+  end
+
+  def between?(min, max)
+    self >= min && self <= max
+  end
+
+  def clamp(*args)
+    if args.length == 2
+      min, max = args
+
+      compared = min <=> max
+      raise ArgumentError, 'min argument must be smaller than max argument' if compared.nil? || compared > 0
+
+      if self < min
+        min
+      elsif self > max
+        max
+      else
+        self
+      end
+    elsif args.first.is_a?(Range)
+      range = args.first
+      raise ArgumentError, 'cannot clamp with an exclusive range' if range.exclude_end?
+      clamp(range.begin, range.end)
+    elsif args.length == 1
+      raise TypeError, "wrong argument type #{args.first.inspect} (expected Range)"
+    else
+      raise ArgumentError, "wrong number of arguments (given #{args.length.size}, expected 1..2)"
+    end
   end
 end

--- a/src/kernel.rb
+++ b/src/kernel.rb
@@ -1,4 +1,10 @@
 module Kernel
+  def <=>(other)
+    if other.object_id == self.object_id || (!is_a?(Comparable) && self == other)
+      0
+    end
+  end
+
   def enum_for(method = :each, *args)
     size = block_given? ? yield : nil
     Enumerator.new(size) do |yielder|

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -569,15 +569,6 @@ ProcValue *Value::to_proc(Env *env) {
     }
 }
 
-// FIXME: this should actually live in the Kernel module which gets mixed into Object
-ValuePtr Value::cmp(Env *env, ValuePtr other) {
-    if (send(env, SymbolValue::intern("=="), { other })->is_truthy()) {
-        return ValuePtr::integer(0);
-    } else {
-        return NilValue::the();
-    }
-}
-
 ValuePtr Value::instance_eval(Env *env, ValuePtr string, Block *block) {
     if (string || !block) {
         env->raise("ArgumentError", "Natalie only supports instance_eval with a block");

--- a/test/natalie/comparable_test.rb
+++ b/test/natalie/comparable_test.rb
@@ -1,0 +1,9 @@
+require_relative '../spec_helper'
+
+describe 'comparable' do
+  describe '#clamp' do
+    it 'raises an Argument error if the range parameter is exclusive' do
+      -> { 1.clamp(1...2) }.should raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
This also moves `Kernel#<=>` from Object to the Kernel module and makes it spec compliant as well. I'm not sure about the `!is_a?(Comparable)` but I do not know how to prevent the possible infinite recursion otherwise.