### PR TITLE
Try to fix keyword argument processing

### DIFF
--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -75,7 +75,7 @@ void handle_top_level_exception(Env *, ExceptionValue *, bool);
 
 ArrayValue *to_ary(Env *env, ValuePtr obj, bool raise_for_non_array);
 
-ValuePtr arg_value_by_path(Env *env, ValuePtr value, ValuePtr default_value, bool splat, int total_count, int default_count, bool defaults_on_right, int offset_from_end, size_t path_size, ...);
+ValuePtr arg_value_by_path(Env *env, ValuePtr value, ValuePtr default_value, bool splat, bool has_kwargs, int total_count, int default_count, bool defaults_on_right, int offset_from_end, size_t path_size, ...);
 ValuePtr array_value_by_path(Env *env, ValuePtr value, ValuePtr default_value, bool splat, int offset_from_end, size_t path_size, ...);
 
 HashValue *kwarg_hash(ValuePtr args);

--- a/lib/natalie/compiler/method_args.rb
+++ b/lib/natalie/compiler/method_args.rb
@@ -65,9 +65,10 @@ module Natalie
         @args = masgn_paths(s(:masgn, s(:array, *names))).map do |name, path_details|
           path = path_details[:path]
           if name.is_a?(Sexp)
+            has_kwargs = names.any? { |name| name.sexp_type == :kwarg || name.sexp_type == :kwsplat }
             case name.sexp_type
             when :splat
-              value = s(:arg_value_by_path, :env, @value_name, 'nullptr', :true, names.size, defaults.size, defaults_on_right ? :true : :false, path_details[:offset_from_end], path.size, *path)
+              value = s(:arg_value_by_path, :env, @value_name, 'nullptr', :true, has_kwargs ? :true : :false, names.size, defaults.size, defaults_on_right ? :true : :false, path_details[:offset_from_end], path.size, *path)
               masgn_set(name.last, value)
             when :kwsplat
               value = s(:kwarg_hash, @value_name)
@@ -88,7 +89,7 @@ module Natalie
                 default_value = 'nullptr'
               end
               total_argument_count = names.reject { |name| name.sexp_type == :kwarg || name.sexp_type == :splat }.size
-              value = s(:arg_value_by_path, :env, @value_name, default_value, :false, total_argument_count, defaults.size, defaults_on_right ? :true : :false, 0, path.size, *path)
+              value = s(:arg_value_by_path, :env, @value_name, default_value, :false, has_kwargs ? :true : :false, total_argument_count, defaults.size, defaults_on_right ? :true : :false, 0, path.size, *path)
               masgn_set(name, value)
             end
           else

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -281,13 +281,13 @@ static ValuePtr splat_value(Env *env, ValuePtr value, size_t index, size_t offse
     return splat;
 }
 
-ValuePtr arg_value_by_path(Env *env, ValuePtr value, ValuePtr default_value, bool splat, int total_count, int default_count, bool defaults_on_right, int offset_from_end, size_t path_size, ...) {
+ValuePtr arg_value_by_path(Env *env, ValuePtr value, ValuePtr default_value, bool splat, bool has_kwargs, int total_count, int default_count, bool defaults_on_right, int offset_from_end, size_t path_size, ...) {
     va_list args;
     va_start(args, path_size);
     bool has_default = !!default_value;
     if (!default_value) default_value = NilValue::the();
     bool defaults_on_left = !defaults_on_right;
-    int required_count = total_count - default_count;
+    int required_count = total_count - default_count; // 0
     ValuePtr return_value = value;
     for (size_t i = 0; i < path_size; i++) {
         int index = va_arg(args, int);
@@ -297,7 +297,6 @@ ValuePtr arg_value_by_path(Env *env, ValuePtr value, ValuePtr default_value, boo
             return splat_value(env, return_value, index, offset_from_end);
         } else {
             if (return_value->is_array()) {
-
                 assert(return_value->as_array()->size() <= NAT_INT_MAX);
                 nat_int_t ary_len = return_value->as_array()->size();
 
@@ -339,6 +338,12 @@ ValuePtr arg_value_by_path(Env *env, ValuePtr value, ValuePtr default_value, boo
                 } else if (index < ary_len) {
                     // value available, yay!
                     return_value = (*return_value->as_array())[index];
+
+                    if (has_default && has_kwargs && i == path_size - 1) {
+                        if (return_value->is_hash()) {
+                            return_value = default_value;
+                        }
+                    }
 
                 } else {
                     // index past the end of the array, so use default

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -435,7 +435,7 @@ HashValue *kwarg_hash(ArrayValue *args) {
 
 ValuePtr kwarg_value_by_name(Env *env, ArrayValue *args, const char *name, ValuePtr default_value) {
     auto hash = kwarg_hash(args);
-    ValuePtr value = hash->as_hash()->get(env, SymbolValue::intern(name));
+    ValuePtr value = hash->as_hash()->remove(env, SymbolValue::intern(name));
     if (!value) {
         if (default_value) {
             return default_value;

--- a/test/natalie/method_test.rb
+++ b/test/natalie/method_test.rb
@@ -442,9 +442,9 @@ describe 'method with keyword args' do
     method_with_kwargs9('a', b: 'b').should == ['a', 'b']
     method_with_kwargs10(b: 'b').should == [1]
 
+    method_with_kwargs9(b: 'b').should == [1, 'b']
     # FIXME: failing:
-    #method_with_kwargs9(b: 'b').should == [1, 'b']
-    #method_with_kwargs11(a: 'a', b: 'b').should == ['a', { b: 'b' }]
+    # method_with_kwargs11(a: 'a', b: 'b').should == ['a', { b: 'b' }]
   end
 
   xit 'raises an error when there are too many positional arguments' do

--- a/test/natalie/method_test.rb
+++ b/test/natalie/method_test.rb
@@ -439,10 +439,9 @@ describe 'method with keyword args' do
     method_with_kwargs8(a: 1).should == [1, nil]
     method_with_kwargs9.should == [1, 2]
     method_with_kwargs9('a').should == ['a', 2]
+    method_with_kwargs9(b: 'b').should == [1, 'b']
     method_with_kwargs9('a', b: 'b').should == ['a', 'b']
     method_with_kwargs10(b: 'b').should == [1]
-
-    method_with_kwargs9(b: 'b').should == [1, 'b']
     method_with_kwargs11(a: 'a', b: 'b').should == ['a', { b: 'b' }]
   end
 

--- a/test/natalie/method_test.rb
+++ b/test/natalie/method_test.rb
@@ -443,8 +443,7 @@ describe 'method with keyword args' do
     method_with_kwargs10(b: 'b').should == [1]
 
     method_with_kwargs9(b: 'b').should == [1, 'b']
-    # FIXME: failing:
-    # method_with_kwargs11(a: 'a', b: 'b').should == ['a', { b: 'b' }]
+    method_with_kwargs11(a: 'a', b: 'b').should == ['a', { b: 'b' }]
   end
 
   xit 'raises an error when there are too many positional arguments' do


### PR DESCRIPTION
Fix "FIXMEs" of natalie's method test. This contains fixes for the following scenarios:

When passed a Hash to a method that has default arguments, we would assign the hash to the default argument even if it has keyword arguments that should be matched to the hash.

```ruby
def foo(a, b = 'b', **c)
  [a, b, c]
end
foo(1, c: 'c', d: 'd').should == [1, 'b', { c: 'c', d: 'd' }
```

The second scenario is that keyword arguments that were successfully extracted from the keyword hash, should not be present in the "rest" (when using double-splats).

```ruby
def foo(a: 'a', **b)
  [a, b]
end
foo(a: 1, b: 2, c: 3).should == [1, { b: 2, c: 3 }] 
```