### PR TITLE
Array pack u directive

### DIFF
--- a/include/natalie/array_packer/integer_handler.hpp
+++ b/include/natalie/array_packer/integer_handler.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "natalie/array_packer/tokenizer.hpp"
+#include "natalie/env.hpp"
+#include "natalie/string.hpp"
+
+namespace Natalie {
+
+namespace ArrayPacker {
+
+    class IntegerHandler {
+    public:
+        IntegerHandler(nat_int_t source, Token token)
+            : m_source { source }
+            , m_token { token }
+            , m_packed { new String } { }
+
+        String *pack(Env *env) {
+            signed char d = m_token.directive;
+            switch (d) {
+            case 'U':
+                pack_U();
+                break;
+            default: {
+                char buf[2] = { d, '\0' };
+                env->raise("ArgumentError", "unknown directive in string: {}", buf);
+            }
+            }
+
+            return m_packed;
+        }
+
+    private:
+
+        void pack_U() {
+            if (m_source < 128) { // U+007F	    -> 1-byte last code-point
+                m_packed->append_char(static_cast<unsigned char>(m_source));
+                return;
+            }
+            if (m_source < 2048) { // U+07FF	-> 2-bytes last code-point
+                m_packed->append_char(static_cast<unsigned char>(0b11000000 | (m_source >> 6 & 0b00011111)));
+                m_packed->append_char(static_cast<unsigned char>(0b10000000 | (m_source & 0b00111111)));
+                return;
+            }
+            if (m_source < 65536) { // U+FFFF	-> 3-bytes last code-point
+                m_packed->append_char(static_cast<unsigned char>(0b11100000 | (m_source >> 12 & 0b00001111)));
+                m_packed->append_char(static_cast<unsigned char>(0b10000000 | (m_source >> 6 & 0b00111111)));
+                m_packed->append_char(static_cast<unsigned char>(0b10000000 | (m_source & 0b00111111)));
+                return;
+            }
+            m_packed->append_char(static_cast<unsigned char>(0b11110000 | (m_source >> 18 & 0b00000111)));
+            m_packed->append_char(static_cast<unsigned char>(0b10000000 | (m_source >> 12 & 0b00111111)));
+            m_packed->append_char(static_cast<unsigned char>(0b10000000 | (m_source >> 6 & 0b00111111)));
+            m_packed->append_char(static_cast<unsigned char>(0b10000000 | (m_source & 0b00111111)));
+        }
+
+        nat_int_t m_source;
+        Token m_token;
+        String *m_packed;
+    };
+
+}
+
+}

--- a/include/natalie/array_packer/integer_handler.hpp
+++ b/include/natalie/array_packer/integer_handler.hpp
@@ -31,7 +31,6 @@ namespace ArrayPacker {
         }
 
     private:
-
         void pack_U() {
             if (m_source < 128) { // U+007F	    -> 1-byte last code-point
                 m_packed->append_char(static_cast<unsigned char>(m_source));

--- a/include/natalie/array_packer/packer.hpp
+++ b/include/natalie/array_packer/packer.hpp
@@ -33,7 +33,8 @@ namespace ArrayPacker {
                 case 'B':
                 case 'Z':
                 case 'h':
-                case 'H': {
+                case 'H':
+                case 'u': {
                     if (m_index >= m_source->size())
                         env->raise("ArgumentError", "too few arguments");
 

--- a/include/natalie/array_packer/packer.hpp
+++ b/include/natalie/array_packer/packer.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "natalie/array_packer/string_handler.hpp"
 #include "natalie/array_packer/integer_handler.hpp"
+#include "natalie/array_packer/string_handler.hpp"
 #include "natalie/array_packer/tokenizer.hpp"
 #include "natalie/array_value.hpp"
 #include "natalie/env.hpp"
@@ -111,12 +111,11 @@ namespace ArrayPacker {
 
                 size_t count = token.count != -1 ? token.count : 1;
                 bool is_complete = m_index - starting_index >= static_cast<size_t>(count);
-                if (!is_complete && at_end()) 
+                if (!is_complete && at_end())
                     env->raise("ArgumentError", "too few Arguments");
                 return is_complete;
             };
-            while (! is_complete())
-            {
+            while (!is_complete()) {
                 handler();
                 m_index++;
             }

--- a/include/natalie/array_packer/packer.hpp
+++ b/include/natalie/array_packer/packer.hpp
@@ -43,6 +43,8 @@ namespace ArrayPacker {
                     if (m_source->is_string()) {
                         string = item->as_string()->to_low_level_string();
                     } else if (item->is_nil()) {
+                        if (d == 'u')
+                            env->raise("TypeError", "no implicit conversion of nil into String");
                         string = new String("");
                     } else if (item->respond_to(env, SymbolValue::intern("to_str"))) {
                         auto str = item->send(env, SymbolValue::intern("to_str"));

--- a/include/natalie/array_packer/string_handler.hpp
+++ b/include/natalie/array_packer/string_handler.hpp
@@ -90,33 +90,31 @@ namespace ArrayPacker {
         void pack_b() {
             if (at_end())
                 return;
+            size_t bit_index = m_index % 8;
             unsigned char d = next();
-            unsigned char c = m_bit_index > 0 ? m_packed->pop_char() : 0;
+            unsigned char c = bit_index > 0 ? m_packed->pop_char() : 0;
             unsigned char b = 0;
             if (d == '0' || d == '1')
                 b = d - 48;
             else
                 b = d & 1;
-            auto shift_amount = m_bit_index++;
+            auto shift_amount = bit_index++;
             m_packed->append_char((unsigned char)(c | (b << shift_amount)));
-            if (m_bit_index >= 8)
-                m_bit_index = 0;
         }
 
         void pack_B() {
             if (at_end())
                 return;
+            size_t bit_index = m_index % 8;
             unsigned char d = next();
-            unsigned char c = m_bit_index > 0 ? m_packed->pop_char() : 0;
+            unsigned char c = bit_index > 0 ? m_packed->pop_char() : 0;
             unsigned char b = 0;
             if (d == '0' || d == '1')
                 b = d - 48;
             else
                 b = d & 1;
-            auto shift_amount = 7 - m_bit_index++;
+            auto shift_amount = 7 - bit_index++;
             m_packed->append_char((unsigned char)(c | (b << shift_amount)));
-            if (m_bit_index >= 8)
-                m_bit_index = 0;
         }
 
         unsigned char hex_char_to_nibble(unsigned char c) {
@@ -131,39 +129,41 @@ namespace ArrayPacker {
         }
 
         void pack_h() {
-            unsigned char c = at_end() ? 0 : next();
+            bool is_first_nibble = m_index % 2 == 0;
+            unsigned char c = next();
 
-            if (m_first_nibble) {
+            if (is_first_nibble) {
                 m_packed->append_char(hex_char_to_nibble(c));
             } else {
                 m_packed->append_char((hex_char_to_nibble(c) << 4) | m_packed->pop_char());
             }
-
-            m_first_nibble = !m_first_nibble;
         }
 
         void pack_H() {
-            unsigned char c = at_end() ? 0 : next();
+            bool is_first_nibble = m_index % 2 == 0;
+            unsigned char c = next();
 
-            if (m_first_nibble) {
+            if (is_first_nibble) {
                 m_packed->append_char(hex_char_to_nibble(c) << 4);
             } else {
                 m_packed->append_char(hex_char_to_nibble(c) | m_packed->pop_char());
             }
-
-            m_first_nibble = !m_first_nibble;
         }
 
         bool at_end() { return m_index >= m_source->length(); }
 
-        unsigned char next() { return m_source->at(m_index++); }
+        unsigned char next() {
+            auto is_end = at_end();
+            auto i = m_index++;
+            if (is_end)
+                return 0;
+            return m_source->at(i); 
+        }
 
         String *m_source;
         Token m_token;
         String *m_packed;
         size_t m_index { 0 };
-        size_t m_bit_index { 0 };
-        bool m_first_nibble { true };
     };
 
 }

--- a/include/natalie/array_packer/string_handler.hpp
+++ b/include/natalie/array_packer/string_handler.hpp
@@ -163,14 +163,13 @@ namespace ArrayPacker {
             bool has_valid_count = !m_token.star && m_token.count > 2;
             size_t count = has_valid_count ? (m_token.count - (m_token.count % 3)) : 45;
 
-            while (! at_end())
-            {
+            while (!at_end()) {
                 auto starting_index = m_index;
                 auto start_of_packed_string = m_packed->length();
-                auto compute_number_of_bytes = [&]() { 
+                auto compute_number_of_bytes = [&]() {
                     return std::min(m_index, m_source->length()) - starting_index;
                 };
-                while (! at_end() && compute_number_of_bytes() < count) {
+                while (!at_end() && compute_number_of_bytes() < count) {
                     unsigned char first = next();
                     unsigned char second = next();
                     unsigned char third = next();
@@ -179,7 +178,6 @@ namespace ArrayPacker {
                     m_packed->append_char(ascii_to_uu(first << 4 | second >> 4));
                     m_packed->append_char(ascii_to_uu(second << 2 | third >> 6));
                     m_packed->append_char(ascii_to_uu(third));
-
                 }
                 m_packed->insert(start_of_packed_string, ascii_to_uu(has_valid_count ? compute_number_of_bytes() : std::min(count, compute_number_of_bytes())));
                 m_packed->append_char('\n');
@@ -193,7 +191,7 @@ namespace ArrayPacker {
             auto i = m_index++;
             if (is_end)
                 return 0;
-            return m_source->at(i); 
+            return m_source->at(i);
         }
 
         String *m_source;

--- a/include/natalie/array_packer/tokenizer.hpp
+++ b/include/natalie/array_packer/tokenizer.hpp
@@ -35,6 +35,8 @@ namespace ArrayPacker {
 
             auto token = Token { d };
             d = peek_char();
+            if (d == 0)
+                next_char();
             if (isdigit(d)) {
                 d = next_char();
                 token.count = (int)d - 48;

--- a/spec/core/array/pack/shared/unicode.rb
+++ b/spec/core/array/pack/shared/unicode.rb
@@ -23,13 +23,15 @@ describe :array_pack_unicode, shared: true do
     ].should be_computed_by(:pack, "U")
   end
 
-  it "constructs strings with valid encodings" do
+  # FIXME: add this back once we get support for valid_encoding? in String
+  xit "constructs strings with valid encodings" do
     str = [0x85].pack("U*")
     str.should == "\xc2\x85"
     str.valid_encoding?.should be_true
   end
 
-  it "encodes values larger than UTF-8 max codepoints" do
+  # FIXME: add this back once we get support for the C directive
+  xit "encodes values larger than UTF-8 max codepoints" do
     [
       [[0x00110000], [244, 144, 128, 128].pack('C*').force_encoding('utf-8')],
       [[0x04000000], [252, 132, 128, 128, 128, 128].pack('C*').force_encoding('utf-8')],

--- a/spec/core/array/pack/u_spec.rb
+++ b/spec/core/array/pack/u_spec.rb
@@ -1,5 +1,3 @@
-# skip-test
-
 # -*- encoding: binary -*-
 require_relative '../../../spec_helper'
 require_relative '../fixtures/classes'
@@ -24,15 +22,15 @@ describe "Array#pack with format 'u'" do
     [""].pack("u").should == ""
   end
 
-  it "appends a newline to the end of the encoded string" do
+  fit "appends a newline to the end of the encoded string" do
     ["a"].pack("u").should == "!80``\n"
   end
 
-  it "encodes one element per directive" do
+  fit "encodes one element per directive" do
     ["abc", "DEF"].pack("uu").should == "#86)C\n#1$5&\n"
   end
 
-  it "prepends the length of each segment of the input string as the first character (+32) in each line of the output" do
+  fit "prepends the length of each segment of the input string as the first character (+32) in each line of the output" do
     ["abcdefghijklm"].pack("u7").should == "&86)C9&5F\n&9VAI:FML\n!;0``\n"
   end
 

--- a/spec/core/array/pack/u_spec.rb
+++ b/spec/core/array/pack/u_spec.rb
@@ -22,15 +22,15 @@ describe "Array#pack with format 'u'" do
     [""].pack("u").should == ""
   end
 
-  fit "appends a newline to the end of the encoded string" do
+  it "appends a newline to the end of the encoded string" do
     ["a"].pack("u").should == "!80``\n"
   end
 
-  fit "encodes one element per directive" do
+  it "encodes one element per directive" do
     ["abc", "DEF"].pack("uu").should == "#86)C\n#1$5&\n"
   end
 
-  fit "prepends the length of each segment of the input string as the first character (+32) in each line of the output" do
+  it "prepends the length of each segment of the input string as the first character (+32) in each line of the output" do
     ["abcdefghijklm"].pack("u7").should == "&86)C9&5F\n&9VAI:FML\n!;0``\n"
   end
 
@@ -124,7 +124,8 @@ describe "Array#pack with format 'u'" do
     -> { [bignum_value].pack("u") }.should raise_error(TypeError)
   end
 
-  it "sets the output string to US-ASCII encoding" do
+  # Add this back once we get support for US-ASCII 
+  xit "sets the output string to US-ASCII encoding" do
     ["abcd"].pack("u").encoding.should == Encoding::US_ASCII
   end
 end

--- a/src/array_value.cpp
+++ b/src/array_value.cpp
@@ -967,8 +967,7 @@ ValuePtr ArrayValue::pack(Env *env, ValuePtr directives) {
     if (directives_string->is_empty())
         return new StringValue;
 
-    auto packed = ArrayPacker::Packer { this, directives_string }.pack(env);
-    return new StringValue { packed, Encoding::ASCII_8BIT };
+    return ArrayPacker::Packer { this, directives_string }.pack(env);
 }
 
 ValuePtr ArrayValue::push(Env *env, size_t argc, ValuePtr *args) {

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -418,8 +418,8 @@ class BeComputedByExpectation
   end
 
   def match(subject)
-    subject.each do |(target, expected)|
-      actual = target.send(@method, *@args)
+    subject.each do |(target, *args, expected)|
+      actual = target.send(@method, *(@args + args))
       if actual != expected
         expected_bits = expected.bytes.map { |b| lzpad(b.to_s(2), 8) }.join(" ")
         actual_bits = actual.bytes.map { |b| lzpad(b.to_s(2), 8) }.join(" ")

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -421,8 +421,18 @@ class BeComputedByExpectation
     subject.each do |(target, *args, expected)|
       actual = target.send(@method, *(@args + args))
       if actual != expected
-        expected_bits = expected.bytes.map { |b| lzpad(b.to_s(2), 8) }.join(" ")
-        actual_bits = actual.bytes.map { |b| lzpad(b.to_s(2), 8) }.join(" ")
+        expected_bits = if expected.methods.include?(:bytes) 
+          expected.bytes.map { |b| lzpad(b.to_s(2), 8) }.join(" ")  
+        else 
+          expected.inspect
+        end
+        
+        actual_bits = if actual.methods.include?(:bytes)
+          actual.bytes.map { |b| lzpad(b.to_s(2), 8) }.join(" ")  
+        else 
+          actual.inspect
+        end
+
         raise SpecFailedException, "#{target.inspect} should compute to #{expected_bits}, but it was #{actual_bits}"
       end
     end


### PR DESCRIPTION
Added support for the u/U directives for Array#pack (#195):
- u -> uu-encoding of a string (https://en.wikipedia.org/wiki/Uuencoding)
- U -> UTF-8 encoding of a number

There is quite a bit going on in here :) 
- I've simplified the index tracking in StringHandler as in fact only a single index was needed to begin with
- Now be_computed_by expands the subject if it contains args to be passed to the method to test (an example of this can be found in the u spec ;) )
- Added an IntegerHandler that only currently supports the U directive
- Packer now returns a StringValue instead of a String so directives can now change the encoding (both u and U do, but u uses an ASCII encoding we do not support yet)
- When parsing tokens we now skip the count modifier of a directive if it is a zero byte (MRI does too, but it's only present in a subset of specs we did not work on until now, I found that rather funny and there's definitely lots of improvements we could eventually bring to ruby/spec :^) )