### PR TITLE
Don't look through all blocks when allocating new cells

### DIFF
--- a/src/gc.cpp
+++ b/src/gc.cpp
@@ -84,8 +84,13 @@ void Heap::sweep() {
     for (auto allocator : m_allocators) {
         for (auto block : *allocator) {
             for (auto cell : *block) {
-                if (!cell->is_marked() && cell->is_collectible())
+                if (!cell->is_marked() && cell->is_collectible()) {
+                    bool had_free = block->has_free();
                     block->return_cell_to_free_list(cell);
+                    if (!had_free) {
+                        allocator->add_free_block(block);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Previously we were looping through each block to find the next one with
a free cell. We had a early return but on some measurements I did the
loop ran on a average 60 iterations.

This patch introduces a list for keeping track which block has free
cells. Each time we want to allocate something we can just use the last
block of this list and do not have to iterate anymore.

Right now I use `push` and `pop` to add and remove from the vector. However, this means that a block newly pushed to the list will be picked first (LIFO). I made this decision because adding to and removing from the end of a vector is much more efficient but I'm not sure if the above is a problem for us. What do you think?

## Results:

I've looked at two scripts:

### Each:
```ruby
ary = []
(0..100_000).each { |n| ary << n + 1 }
```

#### master

Execution Time (lowest I got): 
```
real    0m0.184s
user    0m0.143s
sys     0m0.042s
```

This is the profile I got:

![master-each](https://user-images.githubusercontent.com/61323346/139724076-1df7405c-3c2a-44ed-98f3-98379e32d602.png)

As we can see 19% of the instruction were in Heap::allocate.

#### After the patch

Execution Time (lowest I got): 
```
real    0m0.093s
user    0m0.092s
sys     0m0.001s
```

This is the profile I got:

![new-each](https://user-images.githubusercontent.com/61323346/139724387-184e2696-9437-403c-8404-4c1466d1cb77.png)

As we can see the amount spent in Heap::allocate decreased significantly, which led to the speedup.

### Map:

```ruby
(0..100_000).map { |n| n + 1 }
```

I'm going to skip the profiles for this one. Basically it's the same but we spend even more time in Heap::allocate (53%) because this allocates much more objects.

#### master

Execution Time (lowest I got): 
```
real    0m2.248s
user    0m2.208s
sys     0m0.040s
```

#### After the patch

Execution Time (lowest I got): 
```
real    0m0.228s
user    0m0.178s
sys     0m0.050s
```

The last one shows the real benefit of this patch. The time it takes to allocate does not linearly scale with the amount of objects we already have allocated. This leads to this immense speedup 🎉 


