### PR TITLE
Implement `odd?` for the `Integer`

### DIFF
--- a/include/natalie/bignum_value.hpp
+++ b/include/natalie/bignum_value.hpp
@@ -23,6 +23,16 @@ public:
         if (m_bignum) delete m_bignum;
     }
 
+    bool is_odd() override {
+        if (m_bignum->to_string().length() != 0) {
+            int last_digit = m_bignum->to_string().last_char() - '0';
+            bool is_odd = last_digit % 2 != 0;
+            return is_odd;
+        }
+        
+        return true;
+    }
+
     ValuePtr add(Env *, ValuePtr) override;
     ValuePtr to_s(Env *, ValuePtr = nullptr) override;
 

--- a/include/natalie/integer_value.hpp
+++ b/include/natalie/integer_value.hpp
@@ -27,7 +27,7 @@ public:
         return m_integer == 0;
     }
 
-    bool is_odd() {
+    virtual bool is_odd() {
         return m_integer % 2 != 0;
     }
 

--- a/spec/core/integer/odd_spec.rb
+++ b/spec/core/integer/odd_spec.rb
@@ -10,7 +10,6 @@ describe "Integer#odd?" do
       1.odd?.should be_true
       2.odd?.should be_false
 
-      puts bignum_value(0)
       bignum_value(0).odd?.should be_false
       bignum_value(1).odd?.should be_true
 

--- a/spec/core/integer/odd_spec.rb
+++ b/spec/core/integer/odd_spec.rb
@@ -1,0 +1,39 @@
+require_relative '../../spec_helper'
+
+describe "Integer#odd?" do
+  context "fixnum" do
+    it "returns true when self is an odd number" do
+      (-2).odd?.should be_false
+      (-1).odd?.should be_true
+
+      0.odd?.should be_false
+      1.odd?.should be_true
+      2.odd?.should be_false
+
+      puts bignum_value(0)
+      bignum_value(0).odd?.should be_false
+      bignum_value(1).odd?.should be_true
+
+      (-bignum_value(0)).odd?.should be_false
+      (-bignum_value(1)).odd?.should be_true
+    end
+  end
+
+  context "bignum" do
+    it "returns true if self is odd and positive" do
+      (987279**19).odd?.should be_true
+    end
+
+    it "returns true if self is odd and negative" do
+      (-9873389**97).odd?.should be_true
+    end
+
+    it "returns false if self is even and positive" do
+      (10000000**10).odd?.should be_false
+    end
+
+    it "returns false if self is even and negative" do
+      (-1000000**100).odd?.should be_false
+    end
+  end
+end

--- a/spec/core/integer/odd_spec.rb
+++ b/spec/core/integer/odd_spec.rb
@@ -19,21 +19,22 @@ describe "Integer#odd?" do
     end
   end
 
-  context "bignum" do
-    it "returns true if self is odd and positive" do
-      (987279**19).odd?.should be_true
-    end
-
-    it "returns true if self is odd and negative" do
-      (-9873389**97).odd?.should be_true
-    end
-
-    it "returns false if self is even and positive" do
-      (10000000**10).odd?.should be_false
-    end
-
-    it "returns false if self is even and negative" do
-      (-1000000**100).odd?.should be_false
-    end
-  end
+#   NATFIXME: need to work on IntegerValue::pow() so it handles Bignum
+#   context "bignum" do
+#     it "returns true if self is odd and positive" do
+#       (987_279**19).odd?.should be_true
+#     end
+#
+#     it "returns true if self is odd and negative" do
+#       (-9_873_389**97).odd?.should be_true
+#     end
+#
+#     it "returns false if self is even and positive" do
+#       (10_000_000**10).odd?.should be_false
+#     end
+#
+#     it "returns false if self is even and negative" do
+#       (-1_000_000**100).odd?.should be_false
+#     end
+#   end
 end

--- a/spec/core/integer/odd_spec.rb
+++ b/spec/core/integer/odd_spec.rb
@@ -2,8 +2,7 @@ require_relative '../../spec_helper'
 
 describe "Integer#odd?" do
   context "fixnum" do
-    # NATFIXME: need to work on IntegerValue::negate so it handles Bignum
-    xit "returns true when self is an odd number" do
+    it "returns true when self is an odd number" do
       (-2).odd?.should be_false
       (-1).odd?.should be_true
 
@@ -14,26 +13,27 @@ describe "Integer#odd?" do
       bignum_value(0).odd?.should be_false
       bignum_value(1).odd?.should be_true
 
-      (-bignum_value(0)).odd?.should be_false
-      (-bignum_value(1)).odd?.should be_true
+      # NATFIXME: need to work on IntegerValue::negate so it handles Bignum
+      #(-bignum_value(0)).odd?.should be_false
+      #(-bignum_value(1)).odd?.should be_true
     end
   end
 
   # NATFIXME: need to work on IntegerValue::pow() so it handles Bignum
-  context "bignum" do
-    xit "returns true if self is odd and positive" do
+  xcontext "bignum" do
+    it "returns true if self is odd and positive" do
       (987_279**19).odd?.should be_true
     end
 
-    xit "returns true if self is odd and negative" do
+    it "returns true if self is odd and negative" do
       (-9_873_389**97).odd?.should be_true
     end
 
-    xit "returns false if self is even and positive" do
+    it "returns false if self is even and positive" do
       (10_000_000**10).odd?.should be_false
     end
 
-    xit "returns false if self is even and negative" do
+    it "returns false if self is even and negative" do
       (-1_000_000**100).odd?.should be_false
     end
   end

--- a/spec/core/integer/odd_spec.rb
+++ b/spec/core/integer/odd_spec.rb
@@ -2,7 +2,8 @@ require_relative '../../spec_helper'
 
 describe "Integer#odd?" do
   context "fixnum" do
-    it "returns true when self is an odd number" do
+    # NATFIXME: need to work on IntegerValue::negate so it handles Bignum
+    xit "returns true when self is an odd number" do
       (-2).odd?.should be_false
       (-1).odd?.should be_true
 
@@ -13,28 +14,27 @@ describe "Integer#odd?" do
       bignum_value(0).odd?.should be_false
       bignum_value(1).odd?.should be_true
 
-      # NATFIXME: need to work on IntegerValue::negate so it handles Bignum
-      # (-bignum_value(0)).odd?.should be_false
-      # (-bignum_value(1)).odd?.should be_true
+      (-bignum_value(0)).odd?.should be_false
+      (-bignum_value(1)).odd?.should be_true
     end
   end
 
-#   NATFIXME: need to work on IntegerValue::pow() so it handles Bignum
-#   context "bignum" do
-#     it "returns true if self is odd and positive" do
-#       (987_279**19).odd?.should be_true
-#     end
-#
-#     it "returns true if self is odd and negative" do
-#       (-9_873_389**97).odd?.should be_true
-#     end
-#
-#     it "returns false if self is even and positive" do
-#       (10_000_000**10).odd?.should be_false
-#     end
-#
-#     it "returns false if self is even and negative" do
-#       (-1_000_000**100).odd?.should be_false
-#     end
-#   end
+  # NATFIXME: need to work on IntegerValue::pow() so it handles Bignum
+  context "bignum" do
+    xit "returns true if self is odd and positive" do
+      (987_279**19).odd?.should be_true
+    end
+
+    xit "returns true if self is odd and negative" do
+      (-9_873_389**97).odd?.should be_true
+    end
+
+    xit "returns false if self is even and positive" do
+      (10_000_000**10).odd?.should be_false
+    end
+
+    xit "returns false if self is even and negative" do
+      (-1_000_000**100).odd?.should be_false
+    end
+  end
 end

--- a/spec/core/integer/odd_spec.rb
+++ b/spec/core/integer/odd_spec.rb
@@ -13,8 +13,9 @@ describe "Integer#odd?" do
       bignum_value(0).odd?.should be_false
       bignum_value(1).odd?.should be_true
 
-      (-bignum_value(0)).odd?.should be_false
-      (-bignum_value(1)).odd?.should be_true
+      # NATFIXME: need to work on IntegerValue::negate so it handles Bignum
+      # (-bignum_value(0)).odd?.should be_false
+      # (-bignum_value(1)).odd?.should be_true
     end
   end
 


### PR DESCRIPTION
This should tick one more box in #201. @TheGrizzlyDev I've decided to open this PR just so we don't pollute the issue thread. Like I said in discord, this is all quite new to me.

I'm also making this a draft just to make it clear this is not ready for reviewing and merging.

That being said, I did try to lookup how to make odd work for Bignums by looking at the MRI, but I don't think I'm actually implementing odd right even for a simple Fixnum

~Basing myself on the other methods, I added and IntegerValue argument to odd, in order to test wether it's a bignum, but I'm unsure if that's the correct thing to do.~

~I've not actually implemented an `odd` method for Bignum because I'm still trying to understand what a Bignum is and what does it mean to ask wether it is an odd number or not, in the context of computing: from the MRI it would seem that I need to take a specific digit (the left most, apparently) from the number and `&` it with 1 and that would mean it's odd. Is that really it?~

EDIT: I've since done some research and I believe I found what could be the right way to test wether a bignum is odd or not. What I do is take the bignum string, get the last char, convert it to an int and I mod that with 2 and test wether it is different from 0.

Not sure if this is right, but it seemed to be what MRI does and bignums seem to be the complement of a value, at least in the case of the fixnum specs.

The case for the bignum context I'll add in a comment below, as it's quite lengthy