### PR TITLE
Fix wrong require_relative path

### DIFF
--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -1,5 +1,5 @@
 require 'tempfile'
-require './lib/sexp_processor'
+require_relative '../sexp_processor'
 require_relative './compiler/pass1'
 require_relative './compiler/pass1b'
 require_relative './compiler/pass1r'


### PR DESCRIPTION
Trying to use Natalie in different directory then one with project was raising an error:
```console
$ ~/repos/natalie/bin/natalie
/home/robert/repos/natalie/lib/natalie/compiler.rb:2:in `require': cannot load such file -- ./lib/sexp_processor (LoadError)
    from /home/robert/repos/natalie/lib/natalie/compiler.rb:2:in `<top (required)>'
    from /home/robert/repos/natalie/lib/natalie.rb:1:in `require_relative'
    from /home/robert/repos/natalie/lib/natalie.rb:1:in `<top (required)>'
    from /home/robert/repos/natalie/bin/natalie:12:in `require_relative'
    from /home/robert/repos/natalie/bin/natalie:12:in `<main>'
 ```
 
 This changed fixed this isssue, but I'm not Ruby developer so this may be wrong solution