### PR TITLE
Raise an error if a focused spec is running in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   DOCKER_FLAGS: ""
+  CI: 1
 
 jobs:
   gcc:

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -70,6 +70,10 @@ class ScratchPad
   end
 end
 
+def ci?
+  !!ENV['CI']
+end
+
 def describe(description, shared: false, &block)
   if shared
     @shared[description] = block
@@ -97,6 +101,9 @@ def it(test, &block)
 end
 
 def fit(test, &block)
+  if ci?
+    raise 'Focused spec in CI detected. Please remove it!'
+  end
   @specs << [@context.dup, test, block, :focus]
 end
 


### PR DESCRIPTION
And here it is: My own little helper to prevent mistakes with focused specs 😅 