### PR TITLE
Add String#to_s and String#to_str specs

### DIFF
--- a/spec/core/string/shared/to_s.rb
+++ b/spec/core/string/shared/to_s.rb
@@ -1,0 +1,20 @@
+describe :string_to_s, shared: true do
+  it "returns self when self.class == String" do
+    a = "a string"
+    a.should equal(a.send(@method))
+  end
+
+  it "returns a new instance of String when called on a subclass" do
+    a = StringSpecs::MyString.new("a string")
+    s = a.send(@method)
+    s.should == "a string"
+    s.should be_an_instance_of(String)
+  end
+
+  ruby_version_is ''...'2.7' do
+    it "taints the result when self is tainted" do
+      "x".taint.send(@method).should.tainted?
+      StringSpecs::MyString.new("x").taint.send(@method).should.tainted?
+    end
+  end
+end

--- a/spec/core/string/to_s_spec.rb
+++ b/spec/core/string/to_s_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/to_s'
+
+describe "String#to_s" do
+  it_behaves_like :string_to_s, :to_s
+end

--- a/spec/core/string/to_str_spec.rb
+++ b/spec/core/string/to_str_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/to_s'
+
+describe "String#to_str" do
+  it_behaves_like :string_to_s, :to_str
+end


### PR DESCRIPTION
Bit of a cheeky contribution since these are already spec-compliant but were missing, figured I'd add them in :)

Related to #217.