### PR TITLE
Make Integer#succ spec compliant

### DIFF
--- a/spec/core/integer/shared/next.rb
+++ b/spec/core/integer/shared/next.rb
@@ -1,0 +1,25 @@
+describe :integer_next, shared: true do
+  it "returns the next larger positive Fixnum" do
+    2.send(@method).should == 3
+  end
+
+  it "returns the next larger negative Fixnum" do
+    (-2).send(@method).should == -1
+  end
+
+  it "returns the next larger positive Bignum" do
+    bignum_value.send(@method).should == bignum_value(1)
+  end
+
+  it "returns the next larger negative Bignum" do
+    (-bignum_value(1)).send(@method).should == -bignum_value
+  end
+
+  it "overflows a Fixnum to a Bignum" do
+    fixnum_max.send(@method).should == fixnum_max + 1
+  end
+
+  it "underflows a Bignum to a Fixnum" do
+    (fixnum_min - 1).send(@method).should == fixnum_min
+  end
+end

--- a/spec/core/integer/succ_spec.rb
+++ b/spec/core/integer/succ_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../spec_helper'
+require_relative 'shared/next'
+
+describe "Integer#succ" do
+  it_behaves_like :integer_next, :succ
+end

--- a/src/integer_value.cpp
+++ b/src/integer_value.cpp
@@ -314,7 +314,7 @@ ValuePtr IntegerValue::bitwise_or(Env *env, ValuePtr arg) {
 }
 
 ValuePtr IntegerValue::succ(Env *env) {
-    return ValuePtr::integer(to_nat_int_t() + 1);
+    return add(env, ValuePtr::integer(1));
 }
 
 ValuePtr IntegerValue::coerce(Env *env, ValuePtr arg) {


### PR DESCRIPTION
Related to #201.

Looks like the `Bignum` related test cases don't appreciate the user of negative `Bignum`s, is this something has come across before (leaving as draft due to this) [related test case](https://github.com/seven1m/natalie/pull/274/files#diff-30318ffd0c8ee8a305d9881b674ebb39a69910b54cc6a74303478ff9edb991d6R14).