### PR TITLE
Handle behaviours of Integer over when swapping between fixnum/bignum

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -187,14 +187,14 @@ file 'build/generated/numbers.rb' do |t|
   f2 = Tempfile.create('numbers')
   f2.close
   begin
-    f1.puts "#include <limits.h>"
     f1.puts "#include <stdio.h>"
+    f1.puts "#include \"natalie/constants.hpp\""
     f1.puts "int main() {"
-    f1.puts "  printf(\"NAT_MAX_FIXNUM = %lli\\n\", LLONG_MAX);"
-    f1.puts "  printf(\"NAT_MIN_FIXNUM = %lli - 1\\n\", LLONG_MIN + 1);"
+    f1.puts "  printf(\"NAT_MAX_FIXNUM = %lli\\n\", NAT_MAX_FIXNUM);"
+    f1.puts "  printf(\"NAT_MIN_FIXNUM = %lli\\n\", NAT_MIN_FIXNUM);"
     f1.puts "}"
     f1.close
-    sh "#{cc} -x c -o #{f2.path} #{f1.path}"
+    sh "#{cc} -Iinclude -x c -o #{f2.path} #{f1.path}"
     sh "#{f2.path} > #{t.name}"
   ensure
     File.unlink(f1.path)

--- a/include/natalie/constants.hpp
+++ b/include/natalie/constants.hpp
@@ -1,0 +1,5 @@
+// This is used at build time as well in order to generate numbers.rb
+#include <limits.h>
+
+#define NAT_MAX_FIXNUM LLONG_MAX
+#define NAT_MIN_FIXNUM LLONG_MIN + 1

--- a/src/integer_value.cpp
+++ b/src/integer_value.cpp
@@ -115,25 +115,26 @@ ValuePtr IntegerValue::mul(Env *env, ValuePtr arg) {
     } else if (!arg.is_integer()) {
         arg = Natalie::coerce(env, arg, this).second;
     }
+
     arg.assert_type(env, Value::Type::Integer, "Integer");
 
-    if (is_zero() || arg->as_integer()->is_zero())
-        return new IntegerValue { 0 };
+    if (to_nat_int_t() == 0 || arg.to_nat_int_t() == 0)
+        return ValuePtr::integer(0);
 
-    if (arg.is_bignum()) {
-        auto other = arg->as_integer();
-        auto result = to_bignum() * other->to_bignum();
-        return new BignumValue { result };
-    }
+    if (arg.is_bignum())
+        return (BignumValue { to_bignum() }).mul(env, arg);
 
     auto ll_this = to_nat_int_t();
     auto ll_arg = arg.to_nat_int_t();
 
-    auto min_fraction = (NAT_MIN_FIXNUM - (NAT_MIN_FIXNUM % ll_arg)) / ll_arg;
-    auto max_fraction = (NAT_MAX_FIXNUM - (NAT_MAX_FIXNUM % ll_arg)) / ll_arg;
-    if (
-        (ll_this > 0 && ll_arg > 0 && max_fraction <= ll_this) || (ll_this > 0 && ll_arg < 0 && min_fraction <= ll_this) || (ll_this < 0 && ll_arg > 0 && min_fraction >= ll_this) || (ll_this < 0 && ll_arg < 0 && max_fraction >= ll_this)) {
-        return (new BignumValue { to_bignum() })->mul(env, arg);
+    auto min_fraction = (NAT_MIN_FIXNUM) / ll_arg;
+    auto max_fraction = (NAT_MAX_FIXNUM) / ll_arg;
+
+    if ((ll_this > 0 && ll_arg > 0 && max_fraction <= ll_this)
+        || (ll_this > 0 && ll_arg < 0 && min_fraction <= ll_this)
+        || (ll_this < 0 && ll_arg > 0 && min_fraction >= ll_this)
+        || (ll_this < 0 && ll_arg < 0 && max_fraction >= ll_this)) {
+        return (BignumValue { to_bignum() }).mul(env, arg);
     }
 
     return ValuePtr::integer(ll_this * ll_arg);

--- a/test/natalie/integer_test.rb
+++ b/test/natalie/integer_test.rb
@@ -36,10 +36,10 @@ describe 'integer' do
     end
 
     it 'detect overflows correctly' do
-      (fixnum_max * 2).should > fixnum_max
-      (2 * fixnum_max).should > fixnum_max
-      (-fixnum_max * 2).should < -fixnum_max
-      (-2 * fixnum_max).should < -fixnum_max
+      (fixnum_max * fixnum_max).should > fixnum_max
+      (fixnum_max * -fixnum_max).should < -fixnum_max
+      (-fixnum_max * fixnum_max).should < -fixnum_max
+      (-fixnum_max * -fixnum_max).should > fixnum_max
     end
   end
 


### PR DESCRIPTION
By moving the checks before the actual overflow can happen when doing multiplications. This pattern could be applied more extensively and will also be needed for pow when we do implement it.

I've also updated the constants for min and max finums in Natalie.