### PR TITLE
Try to detect crashed specs better

### DIFF
--- a/spec/support/ruby_spec_runner.rb
+++ b/spec/support/ruby_spec_runner.rb
@@ -90,7 +90,7 @@ Dir[specs].each do |path|
     status = $?
     # If the process did not exit normally it was probably shut down by the
     # `Process.kill` call when timeouting a spec
-    if status.exited? && !status.success?
+    if !status.success? && !current[:timeouted]
       puts "Spec #{path} crashed"
       current[:crashed] = true
       crashed_count += 1


### PR DESCRIPTION
Beforehand, we were checking if the spec process exited normally. If not
we assumed that it would have timeouted.

However, some specs exit with an SIGABRT, which means they did not exit
normally. This led to them not being marked as crashed.

With this patch, instead of relying on the status, we use the current
spec details to determine whether the process timed out.