### PR TITLE
Make purpose of our spec runner clearer

### DIFF
--- a/.github/workflows/run_all_specs.yml
+++ b/.github/workflows/run_all_specs.yml
@@ -2,7 +2,7 @@ name: Run all specs from ruby/spec
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 env:
@@ -12,20 +12,20 @@ jobs:
   specs:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: ruby/setup-ruby@v1
-      with:
-        bundler-cache: true
-    - run: rake
-    - uses: actions/checkout@v2
-      with:
-        repository: ruby/spec
-        path: ruby_spec
-    - run: mv spec/support ruby_spec
-    - run: rm -rf spec/*/
-    - run: mv ruby_spec/*/ spec
-    - run: bundle exec ruby spec/support/ruby_spec_runner.rb
-      env:
-        STATS_API_SECRET: ${{ secrets.STATS_API_SECRET }}
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: rake
+      - uses: actions/checkout@v2
+        with:
+          repository: ruby/spec
+          path: ruby_spec
+      - run: mv spec/support ruby_spec
+      - run: rm -rf spec/*/
+      - run: mv ruby_spec/*/ spec
+      - run: bundle exec ruby spec/support/nightly_ruby_spec_runner.rb
+        env:
+          STATS_API_SECRET: ${{ secrets.STATS_API_SECRET }}

--- a/spec/support/nightly_ruby_spec_runner.rb
+++ b/spec/support/nightly_ruby_spec_runner.rb
@@ -1,3 +1,8 @@
+# This file is used to run the whole ruby/spec suite against Natalie. The results are
+# published on natalie-lang.org.
+#
+# Do not use this script to run specs locally.
+
 require 'concurrent'
 require 'yaml'
 require 'json'


### PR DESCRIPTION
This patch renames the spec runner to make it clearer that this file is used in CI. It also adds a comment on top of the file to document that further.

I'm obviously open to other names for the runner but I think this one would make it clear enough already.

Also my editor seemed to auto-re-format the github workflow file. Hope that's fine...