### PR TITLE
Add Array::uniq to Array

### DIFF
--- a/include/natalie/array_value.hpp
+++ b/include/natalie/array_value.hpp
@@ -182,6 +182,7 @@ public:
     ValuePtr sum(Env *, size_t, ValuePtr *, Block *);
     ValuePtr union_of(Env *, ValuePtr);
     ValuePtr union_of(Env *, size_t, ValuePtr *);
+    ValuePtr uniq(Env *, Block *);
     ValuePtr uniq_in_place(Env *, Block *);
     ValuePtr unshift(Env *, size_t, ValuePtr *);
     ValuePtr to_h(Env *, Block *);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -383,6 +383,7 @@ gen.binding('Array', 'to_h', 'ArrayValue', 'to_h', argc: 0, pass_env: true, pass
 gen.binding('Array', 'to_s', 'ArrayValue', 'inspect', argc: 0, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Array', 'union', 'ArrayValue', 'union_of', argc: :any, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Array', 'uniq!', 'ArrayValue', 'uniq_in_place', argc: 0, pass_env: true, pass_block: true, return_type: :Value)
+gen.binding('Array', 'uniq', 'ArrayValue', 'uniq', argc: 0, pass_env: true, pass_block: true, return_type: :Value)
 gen.binding('Array', 'unshift', 'ArrayValue', 'unshift', argc: :any, pass_env: true, pass_block: false, return_type: :Value)
 gen.binding('Array', 'zip', 'ArrayValue', 'zip', argc: 0.., pass_env: true, pass_block: true, return_type: :Value)
 gen.binding('Array', 'values_at', 'ArrayValue', 'values_at', argc: 0.., pass_env: true, pass_block: false, return_type: :Value)

--- a/src/array_value.cpp
+++ b/src/array_value.cpp
@@ -1378,6 +1378,12 @@ ValuePtr ArrayValue::cycle(Env *env, ValuePtr count, Block *block) {
     return none_method->call(env, this, 1, &count, block);
 }
 
+ValuePtr ArrayValue::uniq(Env *env, Block *block) {
+    ArrayValue *copy = new ArrayValue(*this);
+    copy->uniq_in_place(env, block);
+    return copy;
+}
+
 ValuePtr ArrayValue::uniq_in_place(Env *env, Block *block) {
     this->assert_not_frozen(env);
 


### PR DESCRIPTION
Previously we only had the in-place variant and said difference might have been overlooked by the specs, so I have the non-in-place version which just uses uniq! under the hood.