### PR TITLE
Clean up arguments to {arg,array}_value_by_path

### DIFF
--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -76,8 +76,19 @@ void handle_top_level_exception(Env *, ExceptionValue *, bool);
 
 ArrayValue *to_ary(Env *env, ValuePtr obj, bool raise_for_non_array);
 
-ValuePtr arg_value_by_path(Env *env, ValuePtr value, ValuePtr default_value, bool splat, bool has_kwargs, int total_count, int default_count, bool defaults_on_right, int offset_from_end, size_t path_size, ...);
-ValuePtr array_value_by_path(Env *env, ValuePtr value, ValuePtr default_value, bool splat, int offset_from_end, size_t path_size, ...);
+struct ValueByPathOptions {
+    ValuePtr value;
+    ValuePtr default_value;
+    bool splat;
+    bool has_kwargs;
+    int total_count;
+    int default_count;
+    bool defaults_on_right;
+    int offset_from_end;
+};
+
+ValuePtr arg_value_by_path(Env *env, ValueByPathOptions options, size_t path_size, ...);
+ValuePtr array_value_by_path(Env *env, ValueByPathOptions options, size_t path_size, ...);
 
 HashValue *kwarg_hash(ValuePtr args);
 HashValue *kwarg_hash(ArrayValue *args);

--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -76,7 +76,7 @@ void handle_top_level_exception(Env *, ExceptionValue *, bool);
 
 ArrayValue *to_ary(Env *env, ValuePtr obj, bool raise_for_non_array);
 
-struct ValueByPathOptions {
+struct ArgValueByPathOptions {
     ValuePtr value;
     ValuePtr default_value;
     bool splat;
@@ -86,9 +86,15 @@ struct ValueByPathOptions {
     bool defaults_on_right;
     int offset_from_end;
 };
+ValuePtr arg_value_by_path(Env *env, ArgValueByPathOptions options, size_t path_size, ...);
 
-ValuePtr arg_value_by_path(Env *env, ValueByPathOptions options, size_t path_size, ...);
-ValuePtr array_value_by_path(Env *env, ValueByPathOptions options, size_t path_size, ...);
+struct ArrayValueByPathOptions {
+    ValuePtr value;
+    ValuePtr default_value;
+    bool splat;
+    int offset_from_end;
+};
+ValuePtr array_value_by_path(Env *env, ArrayValueByPathOptions options, size_t path_size, ...);
 
 HashValue *kwarg_hash(ValuePtr args);
 HashValue *kwarg_hash(ArrayValue *args);

--- a/lib/natalie/compiler/base_pass.rb
+++ b/lib/natalie/compiler/base_pass.rb
@@ -33,6 +33,12 @@ module Natalie
           process(exp)
         when String, Symbol, Integer, Float, nil
           exp
+        when true, false
+          exp.inspect.to_sym
+        when Hash
+          exp.transform_values do |e|
+            process_atom(e)
+          end
         else
           raise "unknown node type: #{exp.inspect}"
         end

--- a/lib/natalie/compiler/method_args.rb
+++ b/lib/natalie/compiler/method_args.rb
@@ -68,7 +68,16 @@ module Natalie
             has_kwargs = names.any? { |name| name.sexp_type == :kwarg || name.sexp_type == :kwsplat }
             case name.sexp_type
             when :splat
-              value = s(:arg_value_by_path, :env, @value_name, 'nullptr', :true, has_kwargs ? :true : :false, names.size, defaults.size, defaults_on_right ? :true : :false, path_details[:offset_from_end], path.size, *path)
+              options = s(:struct,
+                          value: @value_name,
+                          default_value: 'nullptr',
+                          splat: true,
+                          has_kwargs: has_kwargs,
+                          total_count: names.size,
+                          default_count: defaults.size,
+                          defaults_on_right: defaults_on_right,
+                          offset_from_end: path_details[:offset_from_end])
+              value = s(:arg_value_by_path, :env, options, path.size, *path)
               masgn_set(name.last, value)
             when :kwsplat
               value = s(:kwarg_hash, @value_name)
@@ -89,7 +98,16 @@ module Natalie
                 default_value = 'nullptr'
               end
               total_argument_count = names.reject { |name| name.sexp_type == :kwarg || name.sexp_type == :splat }.size
-              value = s(:arg_value_by_path, :env, @value_name, default_value, :false, has_kwargs ? :true : :false, total_argument_count, defaults.size, defaults_on_right ? :true : :false, 0, path.size, *path)
+              options = s(:struct,
+                          value: @value_name,
+                          default_value: default_value,
+                          splat: false,
+                          has_kwargs: has_kwargs,
+                          total_count: total_argument_count,
+                          default_count: defaults.size,
+                          defaults_on_right: defaults_on_right,
+                          offset_from_end: 0)
+              value = s(:arg_value_by_path, :env, options, path.size, *path)
               masgn_set(name, value)
             end
           else

--- a/lib/natalie/compiler/multiple_assignment.rb
+++ b/lib/natalie/compiler/multiple_assignment.rb
@@ -27,12 +27,22 @@ module Natalie
               if name.size == 1 # nameless splat
                 s(:block)
               else
-                value = s(:array_value_by_path, :env, value_name, s(:nil), :true, path_details[:offset_from_end], path.size, *path)
+                options = s(:struct,
+                            value: value_name,
+                            default_value: s(:nil),
+                            splat: true,
+                            offset_from_end: path_details[:offset_from_end])
+                value = s(:array_value_by_path, :env, options, path.size, *path)
                 masgn_set(name.last, value)
               end
             else
               default_value = name.size == 3 ? name.pop : s(:nil)
-              value = s(:array_value_by_path, :env, value_name, default_value, :false, 0, path.size, *path)
+              options = s(:struct,
+                          value: value_name,
+                          default_value: default_value,
+                          splat: false,
+                          offset_from_end: 0)
+              value = s(:array_value_by_path, :env, options, path.size, *path)
               masgn_set(name, value)
             end
           else

--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -1,3 +1,4 @@
+require_relative './base_pass'
 require_relative './method_args'
 require_relative './multiple_assignment'
 require_relative '../../../build/generated/numbers'
@@ -5,14 +6,16 @@ require_relative '../../../build/generated/numbers'
 module Natalie
   class Compiler
     # Process S-expressions from the Ruby parser.
-    class Pass1 < NatSexpProcessor
+    class Pass1 < BasePass
       MAX_FIXNUM = NAT_MAX_FIXNUM
       MIN_FIXNUM = NAT_MIN_FIXNUM
 
       def initialize(compiler_context)
-        super()
+        super
+        self.default_method = nil
+        self.warn_on_default = true
         self.require_empty = false
-        @compiler_context = compiler_context
+        self.strict = false
         @retry_context = []
       end
 
@@ -743,6 +746,11 @@ module Natalie
       def process_str(exp)
         (_, str) = exp
         exp.new(:new, :StringValue, s(:s, str), str.bytes.size)
+      end
+
+      def process_struct(exp)
+        (_, hash) = exp
+        exp.new(:struct, process_atom(hash))
       end
 
       def process_super(exp)

--- a/lib/natalie/compiler/pass4.rb
+++ b/lib/natalie/compiler/pass4.rb
@@ -641,6 +641,13 @@ module Natalie
         end
       end
 
+      def process_struct(exp)
+        (_, hash) = exp
+        '{ ' +
+          hash.map { |k, v| ".#{k} = #{process_atom(v)}" }.join(', ') +
+          ' }'
+      end
+
       def process_var_alloc(exp)
         count = exp.last
         if count > 0

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -292,26 +292,26 @@ static ValuePtr splat_value(Env *env, ValuePtr value, size_t index, size_t offse
     return splat;
 }
 
-ValuePtr arg_value_by_path(Env *env, ValuePtr value, ValuePtr default_value, bool splat, bool has_kwargs, int total_count, int default_count, bool defaults_on_right, int offset_from_end, size_t path_size, ...) {
+ValuePtr arg_value_by_path(Env *env, ValueByPathOptions options, size_t path_size, ...) {
     va_list args;
     va_start(args, path_size);
-    bool has_default = !!default_value;
-    if (!default_value) default_value = NilValue::the();
-    bool defaults_on_left = !defaults_on_right;
-    int required_count = total_count - default_count; // 0
-    ValuePtr return_value = value;
+    bool has_default = !!options.default_value;
+    auto default_value = options.default_value ?: NilValue::the();
+    bool defaults_on_left = !options.defaults_on_right;
+    int required_count = options.total_count - options.default_count;
+    ValuePtr return_value = options.value;
     for (size_t i = 0; i < path_size; i++) {
         int index = va_arg(args, int);
 
-        if (splat && i == path_size - 1) {
+        if (options.splat && i == path_size - 1) {
             va_end(args);
-            return splat_value(env, return_value, index, offset_from_end, has_kwargs);
+            return splat_value(env, return_value, index, options.offset_from_end, options.has_kwargs);
         } else {
             if (return_value->is_array()) {
                 assert(return_value->as_array()->size() <= NAT_INT_MAX);
                 nat_int_t ary_len = return_value->as_array()->size();
 
-                int first_required = default_count;
+                int first_required = options.default_count;
                 int remain = ary_len - required_count;
 
                 if (has_default && index >= remain && index < first_required && defaults_on_left) {
@@ -324,21 +324,21 @@ ValuePtr arg_value_by_path(Env *env, ValuePtr value, ValuePtr default_value, boo
                 if (i == 0 && path_size == 1) {
                     // shift index left if needed
                     int extra_count = ary_len - required_count;
-                    if (defaults_on_left && extra_count > 0 && default_count >= extra_count && index >= extra_count) {
-                        index -= (default_count - extra_count);
+                    if (defaults_on_left && extra_count > 0 && options.default_count >= extra_count && index >= extra_count) {
+                        index -= (options.default_count - extra_count);
                     } else if (ary_len <= required_count && defaults_on_left) {
-                        index -= (default_count);
+                        index -= (options.default_count);
                     }
                 }
 
                 if (index < 0) {
                     // negative offset index should go from the right
-                    if (ary_len >= total_count) {
+                    if (ary_len >= options.total_count) {
                         index = ary_len + index;
                     } else {
                         // not enough values to fill from the right
                         // also, assume there is a splat prior to this index
-                        index = total_count + index;
+                        index = options.total_count + index;
                     }
                 }
 
@@ -350,7 +350,7 @@ ValuePtr arg_value_by_path(Env *env, ValuePtr value, ValuePtr default_value, boo
                     // value available, yay!
                     return_value = (*return_value->as_array())[index];
 
-                    if (has_default && has_kwargs && i == path_size - 1) {
+                    if (has_default && options.has_kwargs && i == path_size - 1) {
                         if (return_value->is_hash()) {
                             return_value = default_value;
                         }
@@ -375,15 +375,15 @@ ValuePtr arg_value_by_path(Env *env, ValuePtr value, ValuePtr default_value, boo
     return return_value;
 }
 
-ValuePtr array_value_by_path(Env *env, ValuePtr value, ValuePtr default_value, bool splat, int offset_from_end, size_t path_size, ...) {
+ValuePtr array_value_by_path(Env *env, ValueByPathOptions options, size_t path_size, ...) {
     va_list args;
     va_start(args, path_size);
-    ValuePtr return_value = value;
+    ValuePtr return_value = options.value;
     for (size_t i = 0; i < path_size; i++) {
         int index = va_arg(args, int);
-        if (splat && i == path_size - 1) {
+        if (options.splat && i == path_size - 1) {
             va_end(args);
-            return splat_value(env, return_value, index, offset_from_end, false);
+            return splat_value(env, return_value, index, options.offset_from_end, false);
         } else {
             if (return_value->is_array()) {
 
@@ -397,7 +397,7 @@ ValuePtr array_value_by_path(Env *env, ValuePtr value, ValuePtr default_value, b
 
                 if (index < 0) {
                     // not enough values in the array, so use default
-                    return_value = default_value;
+                    return_value = options.default_value;
 
                 } else if (index < ary_len) {
                     // value available, yay!
@@ -405,7 +405,7 @@ ValuePtr array_value_by_path(Env *env, ValuePtr value, ValuePtr default_value, b
 
                 } else {
                     // index past the end of the array, so use default
-                    return_value = default_value;
+                    return_value = options.default_value;
                 }
 
             } else if (index == 0) {
@@ -414,7 +414,7 @@ ValuePtr array_value_by_path(Env *env, ValuePtr value, ValuePtr default_value, b
 
             } else {
                 // not an array, and index isn't zero
-                return_value = default_value;
+                return_value = options.default_value;
             }
         }
     }

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -292,7 +292,7 @@ static ValuePtr splat_value(Env *env, ValuePtr value, size_t index, size_t offse
     return splat;
 }
 
-ValuePtr arg_value_by_path(Env *env, ValueByPathOptions options, size_t path_size, ...) {
+ValuePtr arg_value_by_path(Env *env, ArgValueByPathOptions options, size_t path_size, ...) {
     va_list args;
     va_start(args, path_size);
     bool has_default = !!options.default_value;
@@ -375,7 +375,7 @@ ValuePtr arg_value_by_path(Env *env, ValueByPathOptions options, size_t path_siz
     return return_value;
 }
 
-ValuePtr array_value_by_path(Env *env, ValueByPathOptions options, size_t path_size, ...) {
+ValuePtr array_value_by_path(Env *env, ArrayValueByPathOptions options, size_t path_size, ...) {
     va_list args;
     va_start(args, path_size);
     ValuePtr return_value = options.value;


### PR DESCRIPTION
This worked on clang, but not on gcc. Trying to get the syntax right...