### PR TITLE
Unionise Value

### DIFF
--- a/include/natalie/value.hpp
+++ b/include/natalie/value.hpp
@@ -113,8 +113,10 @@ private:
 
     Type m_type { Type::Pointer };
 
-    nat_int_t m_integer { 0 };
-    Object *m_object { nullptr };
+    union {
+        nat_int_t m_integer { 0 };
+        Object *m_object;
+    };
 };
 
 }

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -31,8 +31,9 @@ void Value::hydrate() {
         // debugging VERY confusing. Maybe someday we can remove this GC stuff...
         bool was_gc_enabled = Heap::the().gc_enabled();
         Heap::the().gc_disable();
+        auto i = m_integer;
+        m_object = new IntegerObject { i };
         m_type = Type::Pointer;
-        m_object = new IntegerObject { m_integer };
         if (was_gc_enabled) Heap::the().gc_enable();
         break;
     }

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -29,7 +29,6 @@ void Value::hydrate() {
     case Type::Integer: {
         m_type = Type::Pointer;
         m_object = new IntegerObject { m_integer };
-        m_integer = 0;
         break;
     }
     case Type::Pointer:


### PR DESCRIPTION
This decreases the size of Value by unionising the Object* and the fast_integer.
The test-performance does not seem to be affected significantly by this, but it
is still nice to decrease the memory footprint a bit.