### PR TITLE
Speed up `args_to_array()`

### DIFF
--- a/include/natalie/array_object.hpp
+++ b/include/natalie/array_object.hpp
@@ -20,6 +20,11 @@ public:
     ArrayObject()
         : Object { Object::Type::Array, GlobalEnv::the()->Array() } { }
 
+    ArrayObject(size_t initial_capacity)
+        : ArrayObject {} {
+        m_vector.set_capacity(initial_capacity);
+    }
+
     ArrayObject(std::initializer_list<Value> list)
         : ArrayObject {} {
         m_vector.set_capacity(list.size());

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -458,7 +458,7 @@ Value kwarg_value_by_name(Env *env, ArrayObject *args, const char *name, Value d
 }
 
 ArrayObject *args_to_array(Env *env, size_t argc, Value *args) {
-    ArrayObject *ary = new ArrayObject {};
+    ArrayObject *ary = new ArrayObject { argc };
     for (size_t i = 0; i < argc; i++) {
         ary->push(args[i]);
     }


### PR DESCRIPTION
Cool project! Was playing around with the fib example and noticed that it was taking a while to run. I profiled it and found that most of the time was being spent in the `args_to_array()` method. It seems like there's a lot of GC traffic because of the allocations/frees when resizing the array. I didn't dig too deep into the root cause for that but figured giving the array an initial size would mitigate it for now.

Before:
```
ohadrau@SurfaceBook2:~/projects/lang/natalie$ time ./fib.old
75025
real    0m0.632s
user    0m0.602s
sys     0m0.030s
```
After:
```
ohadrau@SurfaceBook2:~/projects/lang/natalie$ time ./fib
75025
real    0m0.173s
user    0m0.135s
sys     0m0.038s
```