### PR TITLE
Use Hashmap to store Allocator blocks instead of Vector

### DIFF
--- a/include/natalie/gc/allocator.hpp
+++ b/include/natalie/gc/allocator.hpp
@@ -101,7 +101,7 @@ private:
     HeapBlock *add_heap_block() {
         auto *block = reinterpret_cast<HeapBlock *>(aligned_alloc(HEAP_BLOCK_SIZE, HEAP_BLOCK_SIZE));
         new (block) HeapBlock(m_cell_size);
-        m_blocks.put(block, block);
+        m_blocks.set(block);
         add_free_block(block);
         m_free_cells += cell_count_per_block();
         return block;
@@ -109,7 +109,7 @@ private:
 
     size_t m_cell_size;
     size_t m_free_cells { 0 };
-    Hashmap<HeapBlock *, HeapBlock *> m_blocks;
+    Hashmap<HeapBlock *> m_blocks;
     Vector<HeapBlock *> m_free_blocks;
 };
 

--- a/src/gc.cpp
+++ b/src/gc.cpp
@@ -82,7 +82,8 @@ void Heap::collect() {
 
 void Heap::sweep() {
     for (auto allocator : m_allocators) {
-        for (auto block : *allocator) {
+        for (auto block_pair : *allocator) {
+            auto *block = block_pair.first;
             for (auto cell : *block) {
                 if (!cell->is_marked() && cell->is_collectible()) {
                     bool had_free = block->has_free();


### PR DESCRIPTION
Heap::collect() previously spent a lot of its time checking
whether a candidate block was a member of an allocator (when
collecting roots). This was an O(n) operation, where n is the
number of blocks in the allocator. To speed this up, we can
use a Hashmap as a set to quickly check in O(1). This brings
Heap::collect() down from 27.71% of dynamic instrs to 10.47%
in examples/boardslam.rb and probably benefits other code as
well.

The new code is a little funky and could benefit from a
Hashset class instead of a Hashmap in a future change.