### PR TITLE
Use the fact that equal Symbols have equal addresses for comparisons

### DIFF
--- a/src/symbol_object.cpp
+++ b/src/symbol_object.cpp
@@ -59,6 +59,8 @@ Value SymbolObject::to_proc_block_fn(Env *env, Value self_value, size_t argc, Va
 Value SymbolObject::cmp(Env *env, Value other_value) {
     if (!other_value->is_symbol()) return NilObject::the();
     SymbolObject *other = other_value->as_symbol();
+    if (this == other)
+        return Value::integer(0);
     int diff = strcmp(m_name, other->m_name);
     int result;
     if (diff < 0) {
@@ -66,7 +68,7 @@ Value SymbolObject::cmp(Env *env, Value other_value) {
     } else if (diff > 0) {
         result = 1;
     } else {
-        result = 0;
+        NAT_UNREACHABLE();
     }
     return Value::integer(result);
 }


### PR DESCRIPTION
This should avoid a strcmp for the equal case

This would be even better if we could avoid strcmp all along for most comparisons

There does not seem to be a significant impact on performance

With just the pointer compare only one test would fail, so there seems to be some more gains we can get from this:
```
Failed specs:
instance variables
  #instance_variables
    returns an array of all instance variable names
      [:@y, :@x] should be == to [:@x, :@y] (line 15)

6 spec(s) passed.
1 spec(s) failed.
0 spec(s) errored.
 FAIL Natalie tests::test/natalie/ivar_test.rb#test_0001_has the same output in ruby and natalie (417.22s)
        Expected #<Process::Status: pid 13758 exit 1> to be success?.
        /home/leon/natalie/test/support/compare_rubies.rb:9:in `run_nat'
        /home/leon/natalie/test/support/compare_rubies.rb:40:in `run_both_and_compare'
        /home/leon/natalie/test/ruby/natalie_test.rb:23:in `block (4 levels) in <top (required)>'
```