### PR TITLE
Optimize Range's include? method for numeric values

### DIFF
--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -142,6 +142,13 @@ Value RangeObject::include(Env *env, Value arg) {
         if (begin <= i && i <= end)
             return TrueObject::the();
         return FalseObject::the();
+    } else if (m_begin->is_numeric() && m_end->is_numeric()) {
+        const auto leq = "<="_s, geq = ">="_s;
+        const auto larger_than_begin = arg.send(env, geq, { m_begin })->is_truthy();
+        const auto smaller_than_end = arg.send(env, leq, { m_end })->is_truthy();
+        if (larger_than_begin && smaller_than_end)
+            return TrueObject::the();
+        return FalseObject::the();
     }
 
     auto eqeq = "=="_s;

--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -139,13 +139,16 @@ Value RangeObject::include(Env *env, Value arg) {
         const auto begin = m_begin.get_fast_integer();
         const auto end = m_end.get_fast_integer();
         const auto i = arg.get_fast_integer();
-        if (begin <= i && i <= end)
+
+        const auto larger_than_begin = begin <= i;
+        const auto smaller_than_end = m_exclude_end ? i < end : i <= end;
+        if (larger_than_begin && smaller_than_end)
             return TrueObject::the();
         return FalseObject::the();
     } else if (m_begin->is_numeric() && m_end->is_numeric()) {
-        const auto leq = "<="_s, geq = ">="_s;
+        const auto lt = "<"_s, leq = "<="_s, geq = ">="_s;
         const auto larger_than_begin = arg.send(env, geq, { m_begin })->is_truthy();
-        const auto smaller_than_end = arg.send(env, leq, { m_end })->is_truthy();
+        const auto smaller_than_end = arg.send(env, m_exclude_end ? lt : leq, { m_end })->is_truthy();
         if (larger_than_begin && smaller_than_end)
             return TrueObject::the();
         return FalseObject::the();

--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -135,6 +135,15 @@ Value RangeObject::eqeqeq(Env *env, Value arg) {
 }
 
 Value RangeObject::include(Env *env, Value arg) {
+    if (arg.is_fast_integer() && m_begin.is_fast_integer() && m_end.is_fast_integer()) {
+        const auto begin = m_begin.get_fast_integer();
+        const auto end = m_end.get_fast_integer();
+        const auto i = arg.get_fast_integer();
+        if (begin <= i && i <= end)
+            return TrueObject::the();
+        return FalseObject::the();
+    }
+
     auto eqeq = "=="_s;
     Value found_item = iterate_over_range(env, [&](Value item) -> Value {
         if (arg.send(env, eqeq, { item })->is_truthy())

--- a/test/natalie/range_test.rb
+++ b/test/natalie/range_test.rb
@@ -221,5 +221,25 @@ describe 'range' do
       r.include?('z').should == false
       r.include?('aa').should == false
     end
+
+    it 'returns true if the given number is in the range with end' do
+      r = 1..10
+      r.include?(9).should == true
+      r.include?(9.9).should == true
+      r.include?(10).should == true
+      r.include?(10.0).should == true
+      r.include?(11).should == false
+      r.include?(10.1).should == false
+    end
+
+    it 'returns true if the given number is in the range without' do
+      r = 1...10
+      r.include?(9).should == true
+      r.include?(9.9).should == true
+      r.include?(10).should == false
+      r.include?(10.0).should == false
+      r.include?(11).should == false
+      r.include?(10.1).should == false
+    end
   end
 end


### PR DESCRIPTION
This is a small optimization for Range#include? when operating on numeric values. Previously, the method would iterate over all values from begin to end and compare them to the argument. Thankfully, the [Ruby spec](https://ruby-doc.org/core-3.0.3/Range.html#include-3F-method) allows us to implement this as equivalent to Range#cover? for numbers. In other words, we're able to simply do `arg >= begin && arg <= end`, which is a lot faster :) This PR also goes a little further and optimizes for fast integers whenever possible