### PR TITLE
Don't allocate copies of compile-time c-strings in Symbol

### DIFF
--- a/include/natalie/symbol_object.hpp
+++ b/include/natalie/symbol_object.hpp
@@ -67,13 +67,6 @@ public:
 private:
     inline static TM::Hashmap<const char *, SymbolObject *> s_symbols { TM::HashType::String, 1000 };
 
-    SymbolObject(Env *env, const char *name)
-        : Object { Object::Type::Symbol, GlobalEnv::the()->Symbol() }
-        , m_should_free { true }
-        , m_name { strdup(name) } {
-        assert(m_name);
-    }
-
     SymbolObject(const char *name, bool owned_string = false)
         : Object { Object::Type::Symbol, GlobalEnv::the()->Symbol() }
         , m_owned_string { owned_string }

--- a/include/natalie/symbol_object.hpp
+++ b/include/natalie/symbol_object.hpp
@@ -21,7 +21,7 @@ public:
     };
 
     static SymbolObject *intern(const char *, Ownedness ownedness = Ownedness::DuplicatedString);
-    static SymbolObject *intern(const String *, Ownedness ownedness = Ownedness::DuplicatedString);
+    static SymbolObject *intern(const String *);
 
     virtual ~SymbolObject() {
         if (m_owned_string) free(const_cast<char *>(m_name));

--- a/src/symbol_object.cpp
+++ b/src/symbol_object.cpp
@@ -2,29 +2,19 @@
 
 namespace Natalie {
 
-SymbolObject *SymbolObject::intern(const char *name) {
+SymbolObject *SymbolObject::intern(const char *name, Ownedness ownedness) {
     assert(name);
     SymbolObject *symbol = s_symbols.get(name);
     if (symbol)
         return symbol;
-    symbol = new SymbolObject { name };
+    symbol = new SymbolObject { name, ownedness };
     s_symbols.put(name, symbol);
     return symbol;
 }
 
-SymbolObject *SymbolObject::intern_static_string(const char *name, size_t) {
+SymbolObject *SymbolObject::intern(const String *name, Ownedness ownedness) {
     assert(name);
-    SymbolObject *symbol = s_symbols.get(name);
-    if (symbol)
-        return symbol;
-    symbol = new SymbolObject { name, true };
-    s_symbols.put(name, symbol);
-    return symbol;
-}
-
-SymbolObject *SymbolObject::intern(const String *name) {
-    assert(name);
-    return intern(name->c_str());
+    return intern(name->c_str(), ownedness);
 }
 
 StringObject *SymbolObject::inspect(Env *env) {

--- a/src/symbol_object.cpp
+++ b/src/symbol_object.cpp
@@ -12,9 +12,9 @@ SymbolObject *SymbolObject::intern(const char *name, Ownedness ownedness) {
     return symbol;
 }
 
-SymbolObject *SymbolObject::intern(const String *name, Ownedness ownedness) {
+SymbolObject *SymbolObject::intern(const String *name) {
     assert(name);
-    return intern(name->c_str(), ownedness);
+    return intern(name->c_str(), Ownedness::DuplicatedString);
 }
 
 StringObject *SymbolObject::inspect(Env *env) {

--- a/src/symbol_object.cpp
+++ b/src/symbol_object.cpp
@@ -12,6 +12,16 @@ SymbolObject *SymbolObject::intern(const char *name) {
     return symbol;
 }
 
+SymbolObject *SymbolObject::intern_static_string(const char *name, size_t) {
+    assert(name);
+    SymbolObject *symbol = s_symbols.get(name);
+    if (symbol)
+        return symbol;
+    symbol = new SymbolObject { name, true };
+    s_symbols.put(name, symbol);
+    return symbol;
+}
+
 SymbolObject *SymbolObject::intern(const String *name) {
     assert(name);
     return intern(name->c_str());


### PR DESCRIPTION
I am not yet satisfied with the semantics of the constructor, but as a first draft this should suffice.

The impact on performance of the tests seems to be small.