### PR TITLE
Make Integer#=== an alias to Integer#==

### DIFF
--- a/include/natalie/integer_object.hpp
+++ b/include/natalie/integer_object.hpp
@@ -52,7 +52,6 @@ public:
     Value mod(Env *, Value) const;
     Value pow(Env *, Value) const;
     Value cmp(Env *, Value);
-    bool eqeqeq(Env *, Value) const;
     virtual Value times(Env *, Block *);
     Value bitwise_and(Env *, Value) const;
     Value bitwise_or(Env *, Value) const;

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -551,7 +551,7 @@ gen.binding('Integer', '<=', 'IntegerObject', 'lte', argc: 1, pass_env: true, pa
 gen.binding('Integer', '>', 'IntegerObject', 'gt', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('Integer', '>=', 'IntegerObject', 'gte', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('Integer', '==', 'IntegerObject', 'eq', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
-gen.binding('Integer', '===', 'IntegerObject', 'eqeqeq', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
+gen.binding('Integer', '===', 'IntegerObject', 'eq', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('Integer', 'abs', 'IntegerObject', 'abs', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Integer', 'chr', 'IntegerObject', 'chr', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Integer', 'coerce', 'IntegerObject', 'coerce', argc: 1, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/integer/case_compare_spec.rb
+++ b/spec/core/integer/case_compare_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../spec_helper'
+require_relative 'shared/equal'
+
+describe "Integer#===" do
+  it_behaves_like :integer_equal, :===
+end

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -351,15 +351,6 @@ bool IntegerObject::gte(Env *env, Value other) {
     env->raise("ArgumentError", "comparison of Integer with {} failed", other->inspect_str(env));
 }
 
-bool IntegerObject::eqeqeq(Env *env, Value arg) const {
-    if (arg.is_fast_integer())
-        return m_integer == arg.get_fast_integer();
-
-    arg.unguard();
-
-    return arg->is_integer() && to_nat_int_t() == arg->as_integer()->to_nat_int_t();
-}
-
 Value IntegerObject::times(Env *env, Block *block) {
     auto val = to_nat_int_t();
     if (!block) {


### PR DESCRIPTION
According to ruby documentation and the specs the two methods are equivalent so we can remove the old implementation of Integer#===.

[#201]