### PR TITLE
Fix bugs walking captured variables from stack-allocated Envs

### DIFF
--- a/include/natalie/env.hpp
+++ b/include/natalie/env.hpp
@@ -7,10 +7,10 @@
 #include "natalie/gc.hpp"
 #include "natalie/global_env.hpp"
 #include "natalie/local_jump_error_type.hpp"
+#include "natalie/managed_vector.hpp"
 #include "natalie/string.hpp"
 #include "natalie/value.hpp"
 #include "tm/shared_ptr.hpp"
-#include "tm/vector.hpp"
 
 namespace Natalie {
 
@@ -119,7 +119,7 @@ public:
     }
 
 private:
-    SharedPtr<Vector<Value>> m_vars {};
+    ManagedVector<Value> *m_vars { nullptr };
     Env *m_outer { nullptr };
     Block *m_block { nullptr };
     Block *m_this_block { nullptr };

--- a/include/natalie/fiber_object.hpp
+++ b/include/natalie/fiber_object.hpp
@@ -98,8 +98,8 @@ public:
         // x86-64: rbx, rbp, r12, r13, r14, r15
         static const int NUM_REGISTERS = 6;
 #elif defined(__aarch64__)
-        // aarch64: x9-x15 and x30
-        static const int NUM_REGISTERS = 8;
+        // aarch64: x9-x28
+        static const int NUM_REGISTERS = 20;
 #else
         // x86: ebx, ebp, edi, esi
         static const int NUM_REGISTERS = 4;

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -8,7 +8,7 @@ namespace Natalie {
 using namespace TM;
 
 void Env::build_vars(size_t size) {
-    m_vars = new Vector<Value>(size, NilObject::the());
+    m_vars = new ManagedVector<Value>(size, NilObject::the());
 }
 
 Value Env::global_get(SymbolObject *name) {
@@ -174,11 +174,7 @@ Env *Env::non_block_env() {
 }
 
 void Env::visit_children(Visitor &visitor) {
-    if (m_vars) {
-        for (auto &val : *m_vars) {
-            visitor.visit(val);
-        }
-    }
+    visitor.visit(m_vars);
     visitor.visit(m_outer);
     visitor.visit(m_block);
     visitor.visit(m_this_block);

--- a/src/fiber_object.cpp
+++ b/src/fiber_object.cpp
@@ -224,6 +224,12 @@ asm(".globl " NAT_ASM_PREFIX "fiber_asm_switch\n" NAT_ASM_PREFIX "fiber_asm_swit
     "\tstp x12, x11, [sp, #-16]!\n"
     "\tstp x14, x13, [sp, #-16]!\n"
     "\tstp x16, x15, [sp, #-16]!\n"
+    "\tstp x18, x17, [sp, #-16]!\n"
+    "\tstp x20, x19, [sp, #-16]!\n"
+    "\tstp x22, x21, [sp, #-16]!\n"
+    "\tstp x24, x23, [sp, #-16]!\n"
+    "\tstp x26, x25, [sp, #-16]!\n"
+    "\tstp x28, x27, [sp, #-16]!\n"
 
     // save current stack pointer into fiber struct
     "\tmov x15, sp\n"
@@ -239,6 +245,12 @@ asm(".globl " NAT_ASM_PREFIX "fiber_asm_switch\n" NAT_ASM_PREFIX "fiber_asm_swit
     "\tmov sp, x14\n"
 
     // restore registers from new stack
+    "\tldp x28, x27, [sp], #16\n"
+    "\tldp x26, x25, [sp], #16\n"
+    "\tldp x24, x23, [sp], #16\n"
+    "\tldp x22, x21, [sp], #16\n"
+    "\tldp x20, x19, [sp], #16\n"
+    "\tldp x18, x17, [sp], #16\n"
     "\tldp x16, x15, [sp], #16\n"
     "\tldp x14, x13, [sp], #16\n"
     "\tldp x12, x11, [sp], #16\n"

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -27,9 +27,14 @@ Value Value::send(Env *env, SymbolObject *name, size_t argc, Value *args, Block 
 void Value::hydrate() {
     switch (m_type) {
     case Type::Integer: {
+        // Running GC while we're in the processes of hydrating this Value makes
+        // debugging VERY confusing. Maybe someday we can remove this GC stuff...
+        bool was_gc_enabled = Heap::the().gc_enabled();
+        Heap::the().gc_disable();
         m_type = Type::Pointer;
         m_object = new IntegerObject { m_integer };
         m_integer = 0;
+        if (was_gc_enabled) Heap::the().gc_enable();
         break;
     }
     case Type::Pointer:


### PR DESCRIPTION
This bug was discovered as a result of layout/size change of `Value` in #296. Something about that PR exposed a flaw in our GC, when compiler optimizations are enabled, that resulted in some variables being collected too early.

I wrote up a more detailed explanation in the commit b64f58a7d8f408b08b2eda9521adeafaa23faf74.

As a bonus, I also found and fixed [a bug](6a211b67062b74eedf8aa32e835f719d87bd2dbd) in our Fiber aarch64 assembly when compiler optimizations are enabled.