### PR TITLE
Make Integer#<=> spec compliant

### DIFF
--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -106,7 +106,12 @@ ArrayObject *block_args_to_array(Env *env, size_t signature_size, size_t argc, V
 
 void arg_spread(Env *env, size_t argc, Value *args, const char *arrangement, ...);
 
-std::pair<Value, Value> coerce(Env *, Value, Value);
+enum class CoerceInvalidReturnValueMode {
+    Raise,
+    Allow,
+};
+
+std::pair<Value, Value> coerce(Env *, Value, Value, CoerceInvalidReturnValueMode = CoerceInvalidReturnValueMode::Raise);
 
 char *zero_string(int);
 

--- a/spec/core/integer/comparison_spec.rb
+++ b/spec/core/integer/comparison_spec.rb
@@ -1,0 +1,177 @@
+require_relative '../../spec_helper'
+
+describe "Integer#<=>" do
+  context "fixnum" do
+    it "returns -1 when self is less than the given argument" do
+      (-3 <=> -1).should == -1
+      (-5 <=> 10).should == -1
+      (-5 <=> -4.5).should == -1
+    end
+
+    it "returns 0 when self is equal to the given argument" do
+      (0 <=> 0).should == 0
+      (954 <=> 954).should == 0
+      (954 <=> 954.0).should == 0
+    end
+
+    it "returns 1 when self is greater than the given argument" do
+      (496 <=> 5).should == 1
+      (200 <=> 100).should == 1
+      (51 <=> 50.5).should == 1
+    end
+
+    it "returns nil when the given argument is not an Integer" do
+      (3 <=> mock('x')).should == nil
+      (3 <=> 'test').should == nil
+    end
+  end
+
+  context "bignum" do
+    describe "with a Fixnum" do
+      it "returns -1 when other is larger" do
+        (-bignum_value <=> 2).should == -1
+      end
+
+      it "returns 1 when other is smaller" do
+        (bignum_value <=> 2).should == 1
+      end
+    end
+
+    describe "with a Bignum" do
+      describe "when other is negative" do
+        it "returns -1 when self is negative and other is larger" do
+          (-bignum_value(42) <=> -bignum_value).should == -1
+        end
+
+        it "returns 0 when other is equal" do
+          (-bignum_value <=> -bignum_value).should == 0
+        end
+
+        it "returns 1 when self is negative and other is smaller" do
+          (-bignum_value <=> -bignum_value(94)).should == 1
+        end
+
+        it "returns 1 when self is positive" do
+          (bignum_value <=> -bignum_value).should == 1
+        end
+      end
+
+      describe "when other is positive" do
+        it "returns -1 when self is negative" do
+          (-bignum_value <=> bignum_value).should == -1
+        end
+
+        it "returns -1 when self is positive and other is larger" do
+          (bignum_value <=> bignum_value(38)).should == -1
+        end
+
+        it "returns 0 when other is equal" do
+          (bignum_value <=> bignum_value).should == 0
+        end
+
+        it "returns 1 when other is smaller" do
+          (bignum_value(56) <=> bignum_value).should == 1
+        end
+      end
+    end
+
+    describe "with a Float" do
+      describe "when other is negative" do
+        it "returns -1 when self is negative and other is larger" do
+          (-bignum_value(0xffff) <=> -bignum_value.to_f).should == -1
+        end
+
+        it "returns 0 when other is equal" do
+          (-bignum_value <=> -bignum_value.to_f).should == 0
+        end
+
+        it "returns 1 when self is negative and other is smaller" do
+          (-bignum_value <=> -bignum_value(0xffef).to_f).should == 1
+        end
+
+        it "returns 1 when self is positive" do
+          (bignum_value <=> -bignum_value.to_f).should == 1
+        end
+      end
+
+      describe "when other is positive" do
+        it "returns -1 when self is negative" do
+          (-bignum_value <=> bignum_value.to_f).should == -1
+        end
+
+        it "returns -1 when self is positive and other is larger" do
+          (bignum_value <=> bignum_value(0xfffe).to_f).should == -1
+        end
+
+        it "returns 0 when other is equal" do
+          (bignum_value <=> bignum_value.to_f).should == 0
+        end
+
+        it "returns 1 when other is smaller" do
+          (bignum_value(0xfeff) <=> bignum_value.to_f).should == 1
+        end
+      end
+    end
+
+    describe "with an Object" do
+      before :each do
+        @big = bignum_value
+        @num = mock("value for Integer#<=>")
+      end
+
+      it "calls #coerce on other" do
+        @num.should_receive(:coerce).with(@big).and_return([@big.to_f, 2.5])
+        @big <=> @num
+      end
+
+      it "lets the exception go through if #coerce raises an exception" do
+        @num.should_receive(:coerce).with(@big).and_raise(RuntimeError.new("my error"))
+        -> {
+          @big <=> @num
+        }.should raise_error(RuntimeError, "my error")
+      end
+
+      it "raises an exception if #coerce raises a non-StandardError exception" do
+        @num.should_receive(:coerce).with(@big).and_raise(Exception)
+        -> { @big <=> @num }.should raise_error(Exception)
+      end
+
+      it "returns nil if #coerce does not return an Array" do
+        @num.should_receive(:coerce).with(@big).and_return(nil)
+        (@big <=> @num).should be_nil
+      end
+
+      it "returns -1 if the coerced value is larger" do
+        @num.should_receive(:coerce).with(@big).and_return([@big, bignum_value(10)])
+        (@big <=> @num).should == -1
+      end
+
+      it "returns 0 if the coerced value is equal" do
+        @num.should_receive(:coerce).with(@big).and_return([@big, bignum_value])
+        (@big <=> @num).should == 0
+      end
+
+      it "returns 1 if the coerced value is smaller" do
+        @num.should_receive(:coerce).with(@big).and_return([@big, 22])
+        (@big <=> @num).should == 1
+      end
+    end
+
+    # The tests below are taken from matz's revision 23730 for Ruby trunk
+    it "returns 1 when self is Infinity and other is a Bignum" do
+      (infinity_value <=> Float::MAX.to_i*2).should == 1
+    end
+
+    it "returns -1 when self is negative and other is Infinity" do
+      (-Float::MAX.to_i*2 <=> infinity_value).should == -1
+    end
+
+    it "returns 1 when self is negative and other is -Infinity" do
+      (-Float::MAX.to_i*2 <=> -infinity_value).should == 1
+    end
+
+    it "returns -1 when self is -Infinity and other is negative" do
+      (-infinity_value <=> -Float::MAX.to_i*2).should == -1
+    end
+  end
+end

--- a/src/big_int.cpp
+++ b/src/big_int.cpp
@@ -641,6 +641,8 @@ bool BigInt::operator>=(const int &num) const {
 */
 
 bool BigInt::operator==(const double &num) const {
+    if (isinf(num)) return false;
+
     return *this == BigInt(floor(num));
 }
 
@@ -659,6 +661,8 @@ bool BigInt::operator!=(const double &num) const {
 */
 
 bool BigInt::operator<(const double &num) const {
+    if (isinf(num)) return num > 0;
+
     return *this < BigInt(floor(num));
 }
 

--- a/src/big_int.cpp
+++ b/src/big_int.cpp
@@ -227,7 +227,7 @@ BigInt::BigInt(const int &num) {
 BigInt::BigInt(const double &num) {
     assert(floor(num) == num);
 
-    value = Natalie::String(num, 1);
+    value = Natalie::String(std::abs(num), 1);
     value.truncate(value.size() - 2);
     if (num < 0)
         sign = '-';

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -226,11 +226,13 @@ Value IntegerObject::pow(Env *env, Value arg) const {
 }
 
 Value IntegerObject::cmp(Env *env, Value arg) {
-    if (!arg.is_fast_integer()) {
-        arg.unguard();
-        if (!arg->is_integer() && !arg->is_float())
-            return NilObject::the();
-    }
+    // Check if we might want to coerce the value
+    if (!arg.is_fast_integer() && !arg->is_integer() && !arg->is_float())
+        arg = Natalie::coerce(env, arg, this, Natalie::CoerceInvalidReturnValueMode::Allow).second;
+
+    // Check if compareable
+    if (!arg.is_fast_integer() && !arg->is_integer() && !arg->is_float())
+        return NilObject::the();
 
     if (lt(env, arg)) {
         return Value::integer(-1);

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -226,12 +226,16 @@ Value IntegerObject::pow(Env *env, Value arg) const {
 }
 
 Value IntegerObject::cmp(Env *env, Value arg) {
+    auto is_comparable_with = [](Value arg) -> bool {
+        return arg.is_fast_integer() || arg->is_integer() || arg->is_float();
+    };
+
     // Check if we might want to coerce the value
-    if (!arg.is_fast_integer() && !arg->is_integer() && !arg->is_float())
+    if (!is_comparable_with(arg))
         arg = Natalie::coerce(env, arg, this, Natalie::CoerceInvalidReturnValueMode::Allow).second;
 
     // Check if compareable
-    if (!arg.is_fast_integer() && !arg->is_integer() && !arg->is_float())
+    if (!is_comparable_with(arg))
         return NilObject::the();
 
     if (lt(env, arg)) {

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -536,12 +536,15 @@ void arg_spread(Env *env, size_t argc, Value *args, const char *arrangement, ...
     va_end(va_args);
 }
 
-std::pair<Value, Value> coerce(Env *env, Value lhs, Value rhs) {
+std::pair<Value, Value> coerce(Env *env, Value lhs, Value rhs, CoerceInvalidReturnValueMode invalid_return_value_mode) {
     auto coerce_symbol = "coerce"_s;
     if (lhs->respond_to(env, coerce_symbol)) {
         Value coerced = lhs.send(env, coerce_symbol, { rhs });
         if (!coerced->is_array()) {
-            env->raise("TypeError", "coerce must return [x, y]");
+            if (invalid_return_value_mode == CoerceInvalidReturnValueMode::Raise)
+                env->raise("TypeError", "coerce must return [x, y]");
+            else
+                return { rhs, lhs };
         }
         lhs = (*coerced->as_array())[0];
         rhs = (*coerced->as_array())[1];


### PR DESCRIPTION
I do not like the way I have to use the same if-condition twice in IntegerObject::cmp. Does somebody have an idea how this code could be done in a nicer way? 🤔 

[#201]