### PR TITLE
Implement `::allocate` and `nil` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,9 @@ belongs to the respective owner:
 | file(s)                       | copyright                         | license           |
 | ----------------------------- | --------------------------------- | ----------------- |
 | `dtoa.c`                      | David M. Gay, Lucent Technologies | custom permissive |
-| `fiber_value.*`               | Evan Jones                        | MIT               |
+| `fiber_object.*`              | Evan Jones                        | MIT               |
 | `big_int.*`                   | Syed Faheel Ahmad                 | MIT               |
 | `spec/*` (see `spec/LICENSE`) | Engine Yard, Inc.                 | MIT               |
+| `version.rb`                  | Engine Yard, Inc.                 | MIT               |
 
 See each file above for full copyright and license text.

--- a/include/natalie/array_object.hpp
+++ b/include/natalie/array_object.hpp
@@ -59,8 +59,6 @@ public:
         return new ArrayObject { argc, args, klass };
     }
 
-    static Value allocate(Env *, size_t, Value *);
-
     Value to_ary_method() { return this; }
 
     size_t size() const { return m_vector.size(); }

--- a/include/natalie/class_object.hpp
+++ b/include/natalie/class_object.hpp
@@ -20,6 +20,12 @@ public:
     ClassObject(ClassObject *klass)
         : ModuleObject { Object::Type::Class, klass } { }
 
+    ClassObject *superclass(Env *env) override {
+        if (!m_is_initialized)
+            env->raise("TypeError", "uninitialized class");
+        return m_superclass;
+    }
+
     ClassObject *subclass(Env *env, const char *name) {
         return subclass(env, name, m_object_type);
     }
@@ -34,28 +40,14 @@ public:
 
     ClassObject *subclass(Env *, const String *, Type);
 
+    void initialize_subclass(ClassObject *, Env *, const String *, Type);
+
     static ClassObject *bootstrap_class_class(Env *);
     static ClassObject *bootstrap_basic_object(Env *, ClassObject *);
 
     Type object_type() { return m_object_type; }
 
     Value initialize(Env *, Value, Block *);
-
-    static Value new_method(Env *env, Value superclass, Block *block) {
-        if (superclass) {
-            if (!superclass->is_class()) {
-                env->raise("TypeError", "superclass must be a Class ({} given)", superclass->klass()->class_name_or_blank());
-            }
-        } else {
-            superclass = GlobalEnv::the()->Object();
-        }
-        Value klass = superclass->as_class()->subclass(env);
-        if (block) {
-            block->set_self(klass);
-            NAT_RUN_BLOCK_AND_POSSIBLY_BREAK(env, block, 0, nullptr, nullptr);
-        }
-        return klass;
-    }
 
     bool is_singleton() const { return m_is_singleton; }
     void set_is_singleton(bool is_singleton) { m_is_singleton = is_singleton; }
@@ -70,6 +62,7 @@ public:
 private:
     Type m_object_type { Type::Object };
     bool m_is_singleton { false };
+    bool m_is_initialized { false };
 };
 
 }

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -74,7 +74,7 @@ public:
         m_class_name = new String(name);
     }
 
-    ClassObject *superclass() { return m_superclass; }
+    virtual ClassObject *superclass(Env *) { return m_superclass; }
     void set_superclass_DANGEROUSLY(ClassObject *superclass) { m_superclass = superclass; }
 
     Value included_modules(Env *);

--- a/include/natalie/nil_object.hpp
+++ b/include/natalie/nil_object.hpp
@@ -22,9 +22,14 @@ public:
         return s_instance;
     }
 
+    bool and_method(Env *, Value);
+    bool or_method(Env *, Value);
+    bool eq(Env *, Value);
     Value eqtilde(Env *, Value);
     Value to_s(Env *);
     Value to_a(Env *);
+    Value to_h(Env *);
+    Value to_f(Env *);
     Value to_i(Env *);
     Value inspect(Env *);
 

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -76,7 +76,9 @@ public:
         m_type = ObjectType::Nil;
     }
 
+    static Value create(ClassObject *);
     static Value _new(Env *, Value, size_t, Value *, Block *);
+    static Value allocate(Env *, Value, size_t, Value *, Block *);
 
     Type type() { return m_type; }
     ClassObject *klass() const { return m_klass; }

--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -19,7 +19,8 @@ public:
     const int STRING_GROW_FACTOR = 2;
 
     StringObject(ClassObject *klass)
-        : Object { Object::Type::String, klass } { }
+        : Object { Object::Type::String, klass }
+        , m_encoding { Encoding::ASCII_8BIT } { }
 
     StringObject()
         : StringObject { "" } { }

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -632,6 +632,8 @@ gen.binding('Kernel', 'spawn', 'KernelModule', 'spawn', argc: 1.., pass_env: tru
 gen.binding('Kernel', 'tap', 'KernelModule', 'tap', argc: 0, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('Kernel', 'to_s', 'KernelModule', 'inspect', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 
+gen.undefine_singleton_method('MatchData', 'new')
+gen.undefine_singleton_method('MatchData', 'allocate')
 gen.binding('MatchData', 'size', 'MatchDataObject', 'size', argc: 0, pass_env: false, pass_block: false, return_type: :size_t)
 gen.binding('MatchData', 'length', 'MatchDataObject', 'size', argc: 0, pass_env: false, pass_block: false, return_type: :size_t)
 gen.binding('MatchData', 'to_s', 'MatchDataObject', 'to_s', argc: 0, pass_env: true, pass_block: false, return_type: :Object)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -395,8 +395,8 @@ gen.binding('BasicObject', 'equal?', 'Object', 'equal', argc: 1, pass_env: false
 gen.binding('BasicObject', '!=', 'Object', 'neq', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('BasicObject', 'instance_eval', 'Object', 'instance_eval', argc: 0..1, pass_env: true, pass_block: true, return_type: :Object)
 
-gen.static_binding('Class', 'new', 'ClassObject', 'new_method', argc: 0..1, pass_env: true, pass_block: true, return_type: :Object)
-gen.binding('Class', 'superclass', 'ClassObject', 'superclass', argc: 0, pass_env: false, pass_block: false, return_type: :NullableValue)
+gen.binding('Class', 'initialize', 'ClassObject', 'initialize', argc: 0..1, pass_env: true, pass_block: true, return_type: :Object, visibility: :private)
+gen.binding('Class', 'superclass', 'ClassObject', 'superclass', argc: 0, pass_env: true, pass_block: false, return_type: :NullableValue)
 gen.binding('Class', 'singleton_class?', 'ClassObject', 'is_singleton', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
 
 gen.static_binding('Encoding', 'aliases', 'EncodingObject', 'aliases', argc: 0, pass_env: true, pass_block: false, return_type: :Object)

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -666,9 +666,15 @@ gen.binding('Module', 'protected', 'ModuleObject', 'protected_method', argc: :an
 gen.binding('Module', 'public', 'ModuleObject', 'public_method', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
 
 gen.undefine_singleton_method('NilClass', 'new')
+gen.binding('NilClass', '&', 'NilObject', 'and_method', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
+gen.binding('NilClass', '|', 'NilObject', 'or_method', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
+gen.binding('NilClass', '^', 'NilObject', 'or_method', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
+gen.binding('NilClass', '===', 'NilObject', 'eq', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('NilClass', '=~', 'NilObject', 'eqtilde', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('NilClass', 'inspect', 'NilObject', 'inspect', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('NilClass', 'to_a', 'NilObject', 'to_a', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('NilClass', 'to_f', 'NilObject', 'to_f', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('NilClass', 'to_h', 'NilObject', 'to_h', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('NilClass', 'to_i', 'NilObject', 'to_i', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('NilClass', 'to_s', 'NilObject', 'to_s', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -289,7 +289,6 @@ puts
 gen = BindingGen.new
 
 gen.static_binding('Array', '[]', 'ArrayObject', 'square_new', argc: :any, pass_env: true, pass_block: false, pass_klass: true, return_type: :Object)
-gen.static_binding('Array', 'allocate', 'ArrayObject', 'allocate', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
 gen.static_binding('Array', 'try_convert', 'ArrayObject', 'try_convert', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Array', '+', 'ArrayObject', 'add', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Array', '-', 'ArrayObject', 'sub', argc: 1, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/array/element_set_spec.rb
+++ b/spec/core/array/element_set_spec.rb
@@ -488,7 +488,8 @@ end
 # end
 
 ruby_version_is "2.7" do
-  describe "Array#[]= with [..n] and [...n]" do
+  # NATFIXME: Array#[]= with [..n] and [...n]
+  xdescribe "Array#[]= with [..n] and [...n]" do
     it "just sets the section defined by range to nil even if the rhs is nil" do
       a = [1, 2, 3, 4, 5]
       a[eval("(..2)")] = nil

--- a/spec/core/array/fill_spec.rb
+++ b/spec/core/array/fill_spec.rb
@@ -325,7 +325,8 @@ describe "Array#fill with (filler, range)" do
   end
 
   ruby_version_is "2.7" do
-    it "works with beginless ranges" do
+    # NATFIXME: Array#fill with beginless ranges
+    xit "works with beginless ranges" do
       [1, 2, 3, 4].fill('x', eval("(..2)")).should == ["x", "x", "x", 4]
       [1, 2, 3, 4].fill(eval("(...2)")) { |x| x + 2 }.should == [2, 3, 3, 4]
     end

--- a/spec/core/array/shared/slice.rb
+++ b/spec/core/array/shared/slice.rb
@@ -748,7 +748,8 @@ describe :array_slice, shared: true do
   end
 
   ruby_version_is "2.7" do
-    it "can accept beginless ranges" do
+    # NATFIXME: Array slice with beginless range
+    xit "can accept beginless ranges" do
       a = [0, 1, 2, 3, 4, 5]
       a.send(@method, eval("(..3)")).should == [0, 1, 2, 3]
       a.send(@method, eval("(...3)")).should == [0, 1, 2]
@@ -762,7 +763,8 @@ describe :array_slice, shared: true do
       a.send(@method, eval("(...-9)")).should == []
     end
 
-    it "can accept nil...nil ranges" do
+    # NATFIXME: Array slice with nil...nil range
+    xit "can accept nil...nil ranges" do
       a = [0, 1, 2, 3, 4, 5]
       a.send(@method, eval("(nil...nil)")).should == a
       a.send(@method, eval("(...nil)")).should == a

--- a/spec/core/array/slice_spec.rb
+++ b/spec/core/array/slice_spec.rb
@@ -154,7 +154,6 @@ describe "Array#slice!" do
     -> { ArraySpecs.frozen_array.slice!(0, 0) }.should raise_error(FrozenError)
   end
 
-  # FIXME add back once eval gets implemented
   it "works with endless ranges" do
     a = [1, 2, 3]
     a.slice!(eval("(1..)")).should == [2, 3]
@@ -174,7 +173,8 @@ describe "Array#slice!" do
   end
 
   ruby_version_is "2.7" do
-    it "works with beginless ranges" do
+    # NATFIXME: Array#slice! with beginless ranges
+    xit "works with beginless ranges" do
       a = [0,1,2,3,4]
       a.slice!(eval("(..3)")).should == [0, 1, 2, 3]
       a.should == [4]

--- a/spec/core/class/allocate_spec.rb
+++ b/spec/core/class/allocate_spec.rb
@@ -1,0 +1,42 @@
+require_relative '../../spec_helper'
+
+describe "Class#allocate" do
+  it "returns an instance of self" do
+    klass = Class.new
+    klass.allocate.should be_an_instance_of(klass)
+  end
+
+  it "returns a fully-formed instance of Module" do
+    klass = Class.allocate
+    # NATFIXME: Implement Class#constants
+    # klass.constants.should_not == nil
+    klass.methods.should_not == nil
+  end
+
+  it "throws an exception when calling a method on a new instance" do
+    klass = Class.allocate
+    -> do
+      klass.new
+    end.should raise_error(Exception)
+  end
+
+  it "does not call initialize on the new instance" do
+    klass = Class.new do
+      def initialize(*args)
+        @initialized = true
+      end
+
+      def initialized?
+        @initialized || false
+      end
+    end
+
+    klass.allocate.should_not.initialized?
+  end
+
+  it "raises TypeError for #superclass" do
+    -> do
+      Class.allocate.superclass
+    end.should raise_error(TypeError)
+  end
+end

--- a/spec/core/hash/ruby2_keywords_hash_spec.rb
+++ b/spec/core/hash/ruby2_keywords_hash_spec.rb
@@ -2,7 +2,8 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
 ruby_version_is "2.7" do
-  describe "Hash.ruby2_keywords_hash?" do
+  # NATFIXME: Implement Hash::ruby2_keywords_hash?
+  xdescribe "Hash.ruby2_keywords_hash?" do
     it "returns false if the Hash is not a keywords Hash" do
       Hash.ruby2_keywords_hash?({}).should == false
     end
@@ -21,7 +22,8 @@ ruby_version_is "2.7" do
     end
   end
 
-  describe "Hash.ruby2_keywords_hash" do
+  # NATFIXME: Implement Hash::ruby2_keywords_hash
+  xdescribe "Hash.ruby2_keywords_hash" do
     it "returns a copy of a Hash and marks the copy as a keywords Hash" do
       h = {a: 1}.freeze
       kw = Hash.ruby2_keywords_hash(h)

--- a/spec/core/matchdata/allocate_spec.rb
+++ b/spec/core/matchdata/allocate_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../spec_helper'
+
+describe "MatchData.allocate" do
+  ruby_version_is "2.7" do
+    it "is undefined" do
+      # https://bugs.ruby-lang.org/issues/16294
+      -> { MatchData.allocate }.should raise_error(NoMethodError)
+    end
+  end
+end

--- a/spec/core/nil/and_spec.rb
+++ b/spec/core/nil/and_spec.rb
@@ -1,0 +1,11 @@
+require_relative '../../spec_helper'
+
+describe "NilClass#&" do
+  it "returns false" do
+    (nil & nil).should == false
+    (nil & true).should == false
+    (nil & false).should == false
+    (nil & "").should == false
+    (nil & mock('x')).should == false
+  end
+end

--- a/spec/core/nil/case_compare_spec.rb
+++ b/spec/core/nil/case_compare_spec.rb
@@ -1,0 +1,13 @@
+require_relative '../../spec_helper'
+
+describe "NilClass#===" do
+  it "returns true for nil" do
+    (nil === nil).should == true
+  end
+
+  it "returns false for non-nil object" do
+    (nil === 1).should == false
+    (nil === "").should == false
+    (nil === Object).should == false
+  end
+end

--- a/spec/core/nil/dup_spec.rb
+++ b/spec/core/nil/dup_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../spec_helper'
+
+describe "NilClass#dup" do
+  it "returns self" do
+    nil.dup.should equal(nil)
+  end
+end

--- a/spec/core/nil/inspect_spec.rb
+++ b/spec/core/nil/inspect_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../spec_helper'
+
+describe "NilClass#inspect" do
+  it "returns the string 'nil'" do
+    nil.inspect.should == "nil"
+  end
+end

--- a/spec/core/nil/match_spec.rb
+++ b/spec/core/nil/match_spec.rb
@@ -1,0 +1,18 @@
+require_relative '../../spec_helper'
+
+describe "NilClass#=~" do
+  # NATFIXME: bug in spec, see https://github.com/ruby/spec/pull/909
+  it "returns nil matching any object" do
+    (nil =~ /Object/).should   be_nil
+    (nil =~ 'Object').should   be_nil
+    (nil =~ Object).should     be_nil
+    (nil =~ Object.new).should be_nil
+    (nil =~ nil).should        be_nil
+    (nil =~ false).should      be_nil
+    (nil =~ true).should       be_nil
+  end
+
+  it "should not warn" do
+    -> { nil =~ /a/ }.should_not complain(verbose: true)
+  end
+end

--- a/spec/core/nil/nil_spec.rb
+++ b/spec/core/nil/nil_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../spec_helper'
+
+describe "NilClass#nil?" do
+  it "returns true" do
+    nil.should.nil?
+  end
+end

--- a/spec/core/nil/nilclass_spec.rb
+++ b/spec/core/nil/nilclass_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../spec_helper'
+
+describe "NilClass" do
+  it ".allocate raises a TypeError" do
+    -> do
+      NilClass.allocate
+    end.should raise_error(TypeError)
+  end
+
+  it ".new is undefined" do
+    -> do
+      NilClass.new
+    end.should raise_error(NoMethodError)
+  end
+end

--- a/spec/core/nil/or_spec.rb
+++ b/spec/core/nil/or_spec.rb
@@ -1,0 +1,11 @@
+require_relative '../../spec_helper'
+
+describe "NilClass#|" do
+  it "returns false if other is nil or false, otherwise true" do
+    (nil | nil).should == false
+    (nil | true).should == true
+    (nil | false).should == false
+    (nil | "").should == true
+    (nil | mock('x')).should == true
+  end
+end

--- a/spec/core/nil/to_a_spec.rb
+++ b/spec/core/nil/to_a_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../spec_helper'
+
+describe "NilClass#to_a" do
+  it "returns an empty array" do
+    nil.to_a.should == []
+  end
+end

--- a/spec/core/nil/to_f_spec.rb
+++ b/spec/core/nil/to_f_spec.rb
@@ -1,0 +1,11 @@
+require_relative '../../spec_helper'
+
+describe "NilClass#to_f" do
+  it "returns 0.0" do
+    nil.to_f.should == 0.0
+  end
+
+  it "does not cause NilClass to be coerced to Float" do
+    (0.0 == nil).should == false
+  end
+end

--- a/spec/core/nil/to_h_spec.rb
+++ b/spec/core/nil/to_h_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../spec_helper'
+
+describe "NilClass#to_h" do
+  it "returns an empty hash" do
+    nil.to_h.should == {}
+    nil.to_h.default.should == nil
+  end
+end

--- a/spec/core/nil/to_i_spec.rb
+++ b/spec/core/nil/to_i_spec.rb
@@ -1,0 +1,11 @@
+require_relative '../../spec_helper'
+
+describe "NilClass#to_i" do
+  it "returns 0" do
+    nil.to_i.should == 0
+  end
+
+  it "does not cause NilClass to be coerced to Integer" do
+    (0 == nil).should == false
+  end
+end

--- a/spec/core/nil/to_s_spec.rb
+++ b/spec/core/nil/to_s_spec.rb
@@ -1,0 +1,17 @@
+require_relative '../../spec_helper'
+
+describe "NilClass#to_s" do
+  it "returns the string ''" do
+    nil.to_s.should == ""
+  end
+
+  ruby_version_is "2.7" do
+    it "returns a frozen string" do
+      nil.to_s.should.frozen?
+    end
+
+    it "always returns the same string" do
+      nil.to_s.should equal(nil.to_s)
+    end
+  end
+end

--- a/spec/core/nil/to_s_spec.rb
+++ b/spec/core/nil/to_s_spec.rb
@@ -10,7 +10,8 @@ describe "NilClass#to_s" do
       nil.to_s.should.frozen?
     end
 
-    it "always returns the same string" do
+    # NATFIXME: NilClass#to_s should always return the same string
+    xit "always returns the same string" do
       nil.to_s.should equal(nil.to_s)
     end
   end

--- a/spec/core/nil/xor_spec.rb
+++ b/spec/core/nil/xor_spec.rb
@@ -1,0 +1,11 @@
+require_relative '../../spec_helper'
+
+describe "NilClass#^" do
+  it "returns false if other is nil or false, otherwise true" do
+    (nil ^ nil).should == false
+    (nil ^ true).should == true
+    (nil ^ false).should == false
+    (nil ^ "").should == true
+    (nil ^ mock('x')).should == true
+  end
+end

--- a/spec/core/proc/allocate_spec.rb
+++ b/spec/core/proc/allocate_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../../spec_helper'
+
+describe "Proc.allocate" do
+  it "raises a TypeError" do
+    -> {
+      Proc.allocate
+    }.should raise_error(TypeError)
+  end
+end

--- a/spec/core/string/allocate_spec.rb
+++ b/spec/core/string/allocate_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../../spec_helper'
+
+describe "String.allocate" do
+  it "returns an instance of String" do
+    str = String.allocate
+    str.should be_an_instance_of(String)
+  end
+
+  it "returns a fully-formed String" do
+    str = String.allocate
+    str.size.should == 0
+    str << "more"
+    str.should == "more"
+  end
+
+  # NATFIXME: bug in spec, see https://github.com/ruby/spec/pull/909
+  it "returns a binary String" do
+    String.allocate.encoding.should == Encoding::BINARY
+  end
+end

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -11,11 +11,6 @@
 
 namespace Natalie {
 
-Value ArrayObject::allocate(Env *env, size_t argc, Value *args) {
-    env->ensure_argc_is(argc, 0);
-    return new ArrayObject {};
-}
-
 Value ArrayObject::initialize(Env *env, Value size, Value value, Block *block) {
     this->assert_not_frozen(env);
 

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -423,7 +423,7 @@ Value IntegerObject::coerce(Env *env, Value arg) {
         ary->push(send(env, "to_f"_s));
         break;
     default:
-        if (!arg->is_float() && arg->respond_to(env, "to_f"_s)) {
+        if (!arg->is_nil() && !arg->is_float() && arg->respond_to(env, "to_f"_s)) {
             arg = arg.send(env, "to_f"_s);
         }
 

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -242,7 +242,7 @@ ArrayObject *ModuleObject::ancestors(Env *env) {
         for (ModuleObject *m : klass->included_modules()) {
             ancestors->push(m);
         }
-        klass = klass->superclass();
+        klass = klass->superclass(env);
     } while (klass);
     return ancestors;
 }

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -48,6 +48,7 @@ Env *build_top_env() {
     Object->const_set("Enumerable"_s, Enumerable);
 
     BasicObject->define_singleton_method(env, "new"_s, Object::_new, -1);
+    BasicObject->define_singleton_method(env, "allocate"_s, Object::allocate, -1);
 
     ClassObject *NilClass = Object->subclass(env, "NilClass", Object::Type::Nil);
     Object->const_set("NilClass"_s, NilClass);

--- a/src/nil_object.cpp
+++ b/src/nil_object.cpp
@@ -2,6 +2,18 @@
 
 namespace Natalie {
 
+bool NilObject::and_method(Env *env, Value) {
+    return false;
+}
+
+bool NilObject::or_method(Env *env, Value other) {
+    return other->is_truthy();
+}
+
+bool NilObject::eq(Env *env, Value other) {
+    return other->is_nil();
+}
+
 Value NilObject::eqtilde(Env *env, Value) {
     return NilObject::the();
 }
@@ -12,6 +24,14 @@ Value NilObject::to_s(Env *env) {
 
 Value NilObject::to_a(Env *env) {
     return new ArrayObject {};
+}
+
+Value NilObject::to_h(Env *env) {
+    return new HashObject {};
+}
+
+Value NilObject::to_f(Env *env) {
+    return new FloatObject { 0.0 };
 }
 
 Value NilObject::to_i(Env *env) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -109,7 +109,17 @@ Value Object::allocate(Env *env, Value klass_value, size_t argc, Value *args, Bl
     if (!klass->respond_to_method(env, "allocate"_s))
         env->raise("TypeError", "calling {}.allocate is prohibited", klass->class_name_or_blank());
 
-    Value obj = create(klass);
+    Value obj;
+    switch (klass->object_type()) {
+    case Object::Type::Proc:
+        obj = nullptr;
+        break;
+
+    default:
+        obj = create(klass);
+        break;
+    }
+
     if (!obj)
         env->raise("TypeError", "allocator undefined for {}", klass->class_name_or_blank());
 

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -223,8 +223,7 @@ Value StringObject::mul(Env *env, Value arg) const {
     if (arg->as_integer()->has_to_be_bignum())
         arg->as_integer()->assert_fixnum(env);
 
-    // TODO: copy encoding?
-    StringObject *new_string = new StringObject { "" };
+    StringObject *new_string = new StringObject { "", m_encoding };
     if (this->is_empty())
         return new_string;
 

--- a/test/natalie/dir_test.rb
+++ b/test/natalie/dir_test.rb
@@ -23,6 +23,7 @@ describe 'Dir' do
         'require_sub4.foo',
         'require_sub4.foo.rb',
         'spec.rb',
+        'version.rb',
       ]
     end
 
@@ -41,6 +42,7 @@ describe 'Dir' do
         'require_sub4.foo',
         'require_sub4.foo.rb',
         'spec.rb',
+        'version.rb',
       ]
     end
   end

--- a/test/natalie/string_test.rb
+++ b/test/natalie/string_test.rb
@@ -13,8 +13,8 @@ describe 'string' do
       "foo\nbar".inspect.should == "\"foo\\nbar\""
       "foo#bar".inspect.should == '"foo#bar"'
       'foo#{1+1}'.inspect.should == '"foo\\#{1+1}"'
-      "foo\x1f".inspect.should == '"foo\\u001F"'
-      "foo\x00\x04".inspect.should == '"foo\\u0000\\u0004"'
+      "foo\x1f".encode('utf-8').inspect.should == '"foo\\u001F"'
+      "foo\x00\x04".encode('utf-8').inspect.should == '"foo\\u0000\\u0004"'
       "foo\x00\x04".encode('ascii-8bit').inspect.should == '"foo\\x00\\x04"'
       unless RUBY_PLATFORM =~ /openbsd/
         "😉🤷".inspect.should == "\"😉🤷\""
@@ -24,14 +24,14 @@ describe 'string' do
 
   describe '#size' do
     it 'returns the number of characters in the string' do
-      '😉😉😉'.size.should == 3
+      '😉😉😉'.encode('utf-8').size.should == 3
       'foo bar'.size.should == 7
     end
   end
 
   describe '#length' do
     it 'returns the number of characters in the string' do
-      '😉😉😉'.size.should == 3
+      '😉😉😉'.encode('utf-8').size.should == 3
       'foo bar'.size.should == 7
     end
   end
@@ -80,10 +80,10 @@ describe 'string' do
       ' '.ord.should == 32
       'a'.ord.should == 97
       'abc'.ord.should == 97
-      'ă'.ord.should == 259
-      '”'.ord.should == 8221
-      '😉'.ord.should == 128521
-      '😉😉😉'.ord.should == 128521
+      'ă'.encode('utf-8').ord.should == 259
+      '”'.encode('utf-8').ord.should == 8221
+      '😉'.encode('utf-8').ord.should == 128521
+      '😉😉😉'.encode('utf-8').ord.should == 128521
     end
 
     it 'raises an error if the string is empty' do
@@ -93,7 +93,7 @@ describe 'string' do
 
   describe '#encode' do
     it 'changes the encoding while reinterpreting the characters' do
-      s = 'abc123'
+      s = 'abc123'.encode 'utf-8'
       s.encoding.should == Encoding::UTF_8
       s2 = s.encode 'ascii-8bit'
       s2.encoding.should == Encoding::ASCII_8BIT
@@ -104,23 +104,23 @@ describe 'string' do
     end
 
     it 'raises an error if a character cannot be converted to the new encoding' do
-      s = 'abc 😢'
+      s = 'abc 😢'.encode 'utf-8'
       s.encoding.should == Encoding::UTF_8
       -> { s.encode 'ascii-8bit' }.should raise_error(Encoding::UndefinedConversionError, 'U+1F622 from UTF-8 to ASCII-8BIT')
-      s = 'xyz 🥺'
+      s = 'xyz 🥺'.encode 'utf-8'
       s.encoding.should == Encoding::UTF_8
       -> { s.encode 'ascii-8bit' }.should raise_error(Encoding::UndefinedConversionError, 'U+1F97A from UTF-8 to ASCII-8BIT')
     end
 
     it 'raises an error if the encoding converter does not exist' do
-      s = 'abc 😢'
+      s = 'abc 😢'.encode 'utf-8'
       -> { s.encode 'bogus-fake-encoding' }.should raise_error(StandardError) # TODO: not actually the right error ;-)
     end
   end
 
   describe '#force_encoding' do
     it 'changes the encoding without reinterpreting the characters' do
-      s = ''
+      s = ''.encode 'utf-8'
       s.encoding.should == Encoding::UTF_8
       s.force_encoding 'ascii-8bit'
       s.encoding.should == Encoding::ASCII_8BIT
@@ -140,7 +140,7 @@ describe 'string' do
   describe '#chars' do
     it 'returns an array of characters' do
       'foo'.chars.should == ['f', 'o', 'o']
-      s = "😉”ăa"
+      s = "😉”ăa".encode 'utf-8'
       s.chars.should == ["😉", "”", "ă", "a"]
       s.force_encoding 'ascii-8bit'
       s.chars.map { |c| c.ord }.should == [240, 159, 152, 137, 226, 128, 157, 196, 131, 97]
@@ -149,7 +149,7 @@ describe 'string' do
 
   describe '#[]' do
     it 'returns the character at the given index' do
-      s = "😉”ăa"
+      s = "😉”ăa".encode 'utf-8'
       s[0].should == "😉"
       s[1].should == "”"
       s[2].should == "ă"
@@ -157,12 +157,12 @@ describe 'string' do
     end
 
     it 'returns nil if the index is past the end' do
-      s = "😉”ăa"
+      s = "😉”ăa".encode 'utf-8'
       s[4].should == nil
     end
 
     it 'returns the character from the end given a negative index' do
-      s = "😉”ăa"
+      s = "😉”ăa".encode 'utf-8'
       s[-1].should == "a"
       s[-2].should == "ă"
       s[-3].should == "”"
@@ -170,13 +170,13 @@ describe 'string' do
     end
 
     it 'returns nil if the negative index is too small' do
-      s = "😉”ăa"
+      s = "😉”ăa".encode 'utf-8'
       s[-5].should == nil
     end
 
     context 'given a range' do
       it 'returns a substring' do
-        s = "😉”ăa"
+        s = "😉”ăa".encode 'utf-8'
         s[1..-1].should == "”ăa"
         s = 'hello'
         s[1..-1].should == 'ello'
@@ -239,7 +239,7 @@ describe 'string' do
 
   describe '#index' do
     it 'returns the character index of the substring' do
-      s = 'tim is 😉 ok'
+      s = 'tim is 😉 ok'.encode 'utf-8'
       s.index('tim').should == 0
       s.index('is').should == 4
       s.index('😉').should == 7

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -1,5 +1,6 @@
 require_relative 'formatters/default_formatter'
 require_relative 'formatters/yaml_formatter'
+require_relative 'version'
 require 'tempfile'
 
 class SpecFailedException < StandardError; end
@@ -171,9 +172,17 @@ def min_long
 end
 
 def ruby_version_is(version)
-  without_patch_number = RUBY_VERSION.sub(/\.\d+$/, '')
-  if version === without_patch_number
-    yield
+  ruby_version = SpecVersion.new RUBY_VERSION
+  case version
+  when String
+    requirement = SpecVersion.new version
+    yield if ruby_version >= requirement
+  when Range
+    a = SpecVersion.new version.begin
+    b = SpecVersion.new version.end
+    yield if ruby_version >= a && (version.exclude_end? ? ruby_version < b : ruby_version <= b)
+  else
+    raise "version must be a String or Range but was a #{version.class}"
   end
 end
 

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -329,6 +329,7 @@ class Matcher
   def none?; method_missing(:none?); end
   def one?; method_missing(:one?); end
   def zero?; method_missing(:zero?); end
+  def initialized?; method_missing(:initialized?); end
 
   def method_missing(method, *args)
     if args.any?

--- a/test/support/version.rb
+++ b/test/support/version.rb
@@ -1,0 +1,91 @@
+#
+# Copyright (c) 2008 Engine Yard, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# ----
+#
+# This file is taken from https://github.com/ruby/mspec
+#
+
+class SpecVersion
+  # If beginning implementations have a problem with this include, we can
+  # manually implement the relational operators that are needed.
+  include Comparable
+
+  # SpecVersion handles comparison correctly for the context by filling in
+  # missing version parts according to the value of +ceil+. If +ceil+ is
+  # +false+, 0 digits fill in missing version parts. If +ceil+ is +true+, 9
+  # digits fill in missing parts. (See e.g. VersionGuard and BugGuard.)
+  def initialize(version, ceil = false)
+    @version = version
+    @ceil    = ceil
+    @integer = nil
+  end
+
+  def to_s
+    @version
+  end
+
+  def to_str
+    to_s
+  end
+
+  # Converts a string representation of a version major.minor.tiny
+  # to an integer representation so that comparisons can be made. For example,
+  # "2.2.10" < "2.2.2" would be false if compared as strings.
+  def to_i
+    unless @integer
+      major, minor, tiny = @version.split "."
+      if @ceil
+        tiny = 99 unless tiny
+      end
+      parts = [major, minor, tiny].map do |x|
+        x = x.to_i
+        x < 10 ? "0#{x}" : x.to_s
+      end
+      @integer = "1#{parts.join}".to_i
+      # NATFIXME: Implement String#%
+      # parts = [major, minor, tiny].map { |x| x.to_i }
+      # @integer = ("1%02d%02d%02d" % parts).to_i
+    end
+    @integer
+  end
+
+  def to_int
+    to_i
+  end
+
+  def <=>(other)
+    if other.respond_to? :to_int
+      other = other.to_int
+      # NATFIXME: Implement Kernel#Integer
+      # other = Integer(other.to_int)
+    else
+      other = SpecVersion.new(other.to_s).to_i
+      # NATFIXME: Implement Kernel#String
+      # other = SpecVersion.new(other.to_s).to_i
+    end
+
+    self.to_i <=> other
+  end
+end


### PR DESCRIPTION
Skipped `NilClass#to_c`, `#to_r`, and `#rationalize` because they require `Complex` and `Rational`

Ported mspec's [`SpecVersion`](https://github.com/ruby/mspec/blob/master/lib/mspec/utils/version.rb)