### PR TITLE
Parse method names with `[]` and `[]=`

### DIFF
--- a/include/natalie/lexer.hpp
+++ b/include/natalie/lexer.hpp
@@ -572,9 +572,23 @@ private:
             return new Token { Token::Type::LCurlyBrace, m_file, m_token_line, m_token_column };
         case '[': {
             advance();
-            auto token = new Token { Token::Type::LBracket, m_file, m_token_line, m_token_column };
-            token->set_whitespace_precedes(m_whitespace_precedes);
-            return token;
+            switch (current_char()) {
+            case ']':
+                advance();
+                switch (current_char()) {
+                case '=':
+                    advance();
+                    return new Token { Token::Type::LBracketRBracketEqual, m_file, m_token_line, m_token_column };
+                default:
+                    auto token = new Token { Token::Type::LBracketRBracket, m_file, m_token_line, m_token_column };
+                    token->set_whitespace_precedes(m_whitespace_precedes);
+                    return token;
+                }
+            default:
+                auto token = new Token { Token::Type::LBracket, m_file, m_token_line, m_token_column };
+                token->set_whitespace_precedes(m_whitespace_precedes);
+                return token;
+            }
         }
         case '(':
             advance();

--- a/include/natalie/parser.hpp
+++ b/include/natalie/parser.hpp
@@ -175,6 +175,7 @@ private:
         case Token::Type::DotDotDot:
             return RANGE;
         case Token::Type::LBracket:
+        case Token::Type::LBracketRBracket:
             if (left && treat_left_bracket_as_element_reference(left, current_token()))
                 return REF;
             break;

--- a/include/natalie/token.hpp
+++ b/include/natalie/token.hpp
@@ -87,6 +87,8 @@ public:
         Invalid,
         LCurlyBrace,
         LBracket,
+        LBracketRBracket,
+        LBracketRBracketEqual,
         LeftShift,
         LeftShiftEqual,
         LessThan,
@@ -374,6 +376,10 @@ public:
             return "{";
         case Type::LBracket:
             return "[";
+        case Type::LBracketRBracket:
+            return "[]";
+        case Type::LBracketRBracketEqual:
+            return "[]=";
         case Type::LeftShift:
             return "<<";
         case Type::LeftShiftEqual:
@@ -567,6 +573,8 @@ public:
         case Token::Type::Exponent:
         case Token::Type::GreaterThan:
         case Token::Type::GreaterThanOrEqual:
+        case Token::Type::LBracketRBracket:
+        case Token::Type::LBracketRBracketEqual:
         case Token::Type::LeftShift:
         case Token::Type::LessThan:
         case Token::Type::LessThanOrEqual:
@@ -705,6 +713,7 @@ public:
         case Token::Type::InterpolatedStringBegin:
         case Token::Type::LCurlyBrace:
         case Token::Type::LBracket:
+        case Token::Type::LBracketRBracket:
         case Token::Type::LINEKeyword:
         case Token::Type::LParen:
         case Token::Type::Multiply:

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -126,6 +126,10 @@ SymbolNode *Parser::parse_alias_arg(LocalsHashmap &locals, const char *expected_
 
 Node *Parser::parse_array(LocalsHashmap &locals) {
     auto array = new ArrayNode { current_token() };
+    if (current_token()->type() == Token::Type::LBracketRBracket) {
+        advance();
+        return array;
+    }
     advance();
     if (current_token()->type() != Token::Type::RBracket) {
         array->add_node(parse_expression(ARRAY, locals));
@@ -1450,6 +1454,8 @@ Node *Parser::parse_ref_expression(Node *left, LocalsHashmap &locals) {
         left,
         "[]",
     };
+    if (token->type() == Token::Type::LBracketRBracket)
+        return call_node;
     if (current_token()->type() != Token::Type::RBracket)
         parse_call_args(call_node, locals, false);
     expect(Token::Type::RBracket, "element reference right bracket");
@@ -1545,6 +1551,7 @@ Parser::parse_null_fn Parser::null_denotation(Token::Type type, Precedence prece
     case Type::AliasKeyword:
         return &Parser::parse_alias;
     case Type::LBracket:
+    case Type::LBracketRBracket:
         return &Parser::parse_array;
     case Type::BeginKeyword:
         return &Parser::parse_begin;
@@ -1711,6 +1718,7 @@ Parser::parse_left_fn Parser::left_denotation(Token *token, Node *left) {
     case Type::DotDotDot:
         return &Parser::parse_range_expression;
     case Type::LBracket:
+    case Type::LBracketRBracket:
         if (treat_left_bracket_as_element_reference(left, current_token()))
             return &Parser::parse_ref_expression;
         break;

--- a/test/natalie/parser_test.rb
+++ b/test/natalie/parser_test.rb
@@ -239,7 +239,7 @@ describe 'Parser' do
     end
 
     it 'parses operator method definitions' do
-      operators = %w[+ - * ** / % == === != =~ !~ > >= < <= <=> & | ^ ~ << >>]
+      operators = %w(+ - * ** / % == === != =~ !~ > >= < <= <=> & | ^ ~ << >> [] []=)
       operators.each do |operator|
         Parser.parse("def #{operator}; end").should == s(:block, s(:defn, operator.to_sym, s(:args), s(:nil)))
         Parser.parse("def self.#{operator}; end").should == s(:block, s(:defs, s(:self), operator.to_sym, s(:args), s(:nil)))


### PR DESCRIPTION
For example:

```rb
class Matrix
  def Matrix.[](*rows)
    rows
  end
end

Matrix[1,2,3] # => [1,2,3]
# is the same as
Matrix.[](1,2,3) # => [1,2,3]
```