### PR TITLE
Make `String#concat` (mostly) spec compliant

### DIFF
--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -145,6 +145,7 @@ public:
     Value add(Env *, Value) const;
     Value bytes(Env *) const;
     Value cmp(Env *, Value) const;
+    Value concat(Env *env, size_t argc, Value *args);
     Value downcase(Env *);
     Value encode(Env *, Value);
     Value encoding(Env *);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -750,6 +750,7 @@ gen.binding('String', '=~', 'StringObject', 'eqtilde', argc: 1, pass_env: true, 
 gen.binding('String', '[]', 'StringObject', 'ref', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('String', 'bytes', 'StringObject', 'bytes', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('String', 'chars', 'StringObject', 'chars', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('String', 'concat', 'StringObject', 'concat', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('String', 'downcase', 'StringObject', 'downcase', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('String', 'each_char', 'StringObject', 'each_char', argc: 0, pass_env: true, pass_block: true, return_type: :Object)
 gen.binding('String', 'empty?', 'StringObject', 'is_empty', argc: 0, pass_env: false, pass_block: false, return_type: :bool)

--- a/spec/core/string/concat_spec.rb
+++ b/spec/core/string/concat_spec.rb
@@ -1,0 +1,26 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/concat'
+
+describe "String#concat" do
+  it_behaves_like :string_concat, :concat
+  it_behaves_like :string_concat_encoding, :concat
+
+  it "takes multiple arguments" do
+    str = "hello "
+    str.concat "wo", "", "rld"
+    str.should == "hello world"
+  end
+
+  it "concatenates the initial value when given arguments contain 2 self" do
+    str = "hello"
+    str.concat str, str
+    str.should == "hellohellohello"
+  end
+
+  it "returns self when given no arguments" do
+    str = "hello"
+    str.concat.should equal(str)
+    str.should == "hello"
+  end
+end

--- a/spec/core/string/shared/concat.rb
+++ b/spec/core/string/shared/concat.rb
@@ -1,0 +1,162 @@
+describe :string_concat, shared: true do
+  it "concatenates the given argument to self and returns self" do
+    str = 'hello '
+    str.send(@method, 'world').should equal(str)
+    str.should == "hello world"
+  end
+
+  it "converts the given argument to a String using to_str" do
+    obj = mock('world!')
+    obj.should_receive(:to_str).and_return("world!")
+    a = 'hello '.send(@method, obj)
+    a.should == 'hello world!'
+  end
+
+  it "raises a TypeError if the given argument can't be converted to a String" do
+    -> { 'hello '.send(@method, [])        }.should raise_error(TypeError)
+    -> { 'hello '.send(@method, mock('x')) }.should raise_error(TypeError)
+  end
+
+  it "raises a FrozenError when self is frozen" do
+    a = "hello"
+    a.freeze
+
+    -> { a.send(@method, "")     }.should raise_error(FrozenError)
+    -> { a.send(@method, "test") }.should raise_error(FrozenError)
+  end
+
+  it "returns a String when given a subclass instance" do
+    a = "hello"
+    a.send(@method, StringSpecs::MyString.new(" world"))
+    a.should == "hello world"
+    a.should be_an_instance_of(String)
+  end
+
+  it "returns an instance of same class when called on a subclass" do
+    str = StringSpecs::MyString.new("hello")
+    str.send(@method, " world")
+    str.should == "hello world"
+    str.should be_an_instance_of(StringSpecs::MyString)
+  end
+
+  ruby_version_is ''...'2.7' do
+    it "taints self if other is tainted" do
+      "x".send(@method, "".taint).should.tainted?
+      "x".send(@method, "y".taint).should.tainted?
+    end
+
+    it "untrusts self if other is untrusted" do
+      "x".send(@method, "".untrust).should.untrusted?
+      "x".send(@method, "y".untrust).should.untrusted?
+    end
+  end
+
+  describe "with Integer" do
+    it "concatenates the argument interpreted as a codepoint" do
+      b = "".send(@method, 33)
+      b.should == "!"
+
+      b.encode!(Encoding::UTF_8)
+      b.send(@method, 0x203D)
+      b.should == "!\u203D"
+    end
+
+    # #5855
+    it "returns a BINARY string if self is US-ASCII and the argument is between 128-255 (inclusive)" do
+      a = ("".encode(Encoding::US_ASCII).send(@method, 128))
+      a.encoding.should == Encoding::BINARY
+      a.should == 128.chr
+
+      a = ("".encode(Encoding::US_ASCII).send(@method, 255))
+      a.encoding.should == Encoding::BINARY
+      a.should == 255.chr
+    end
+
+    it "raises RangeError if the argument is an invalid codepoint for self's encoding" do
+      -> { "".encode(Encoding::US_ASCII).send(@method, 256) }.should raise_error(RangeError)
+      -> { "".encode(Encoding::EUC_JP).send(@method, 0x81)  }.should raise_error(RangeError)
+    end
+
+    it "raises RangeError if the argument is negative" do
+      -> { "".send(@method, -200)          }.should raise_error(RangeError)
+      -> { "".send(@method, -bignum_value) }.should raise_error(RangeError)
+    end
+
+    it "doesn't call to_int on its argument" do
+      x = mock('x')
+      x.should_not_receive(:to_int)
+
+      -> { "".send(@method, x) }.should raise_error(TypeError)
+    end
+
+    it "raises a FrozenError when self is frozen" do
+      a = "hello"
+      a.freeze
+
+      -> { a.send(@method, 0)  }.should raise_error(FrozenError)
+      -> { a.send(@method, 33) }.should raise_error(FrozenError)
+    end
+  end
+end
+
+describe :string_concat_encoding, shared: true do
+  describe "when self is in an ASCII-incompatible encoding incompatible with the argument's encoding" do
+    it "uses self's encoding if both are empty" do
+      "".encode("UTF-16LE").send(@method, "").encoding.should == Encoding::UTF_16LE
+    end
+
+    it "uses self's encoding if the argument is empty" do
+      "x".encode("UTF-16LE").send(@method, "").encoding.should == Encoding::UTF_16LE
+    end
+
+    it "uses the argument's encoding if self is empty" do
+      "".encode("UTF-16LE").send(@method, "x".encode("UTF-8")).encoding.should == Encoding::UTF_8
+    end
+
+    it "raises Encoding::CompatibilityError if neither are empty" do
+      -> { "x".encode("UTF-16LE").send(@method, "y".encode("UTF-8")) }.should raise_error(Encoding::CompatibilityError)
+    end
+  end
+
+  describe "when the argument is in an ASCII-incompatible encoding incompatible with self's encoding" do
+    it "uses self's encoding if both are empty" do
+      "".encode("UTF-8").send(@method, "".encode("UTF-16LE")).encoding.should == Encoding::UTF_8
+    end
+
+    it "uses self's encoding if the argument is empty" do
+      "x".encode("UTF-8").send(@method, "".encode("UTF-16LE")).encoding.should == Encoding::UTF_8
+    end
+
+    it "uses the argument's encoding if self is empty" do
+      "".encode("UTF-8").send(@method, "x".encode("UTF-16LE")).encoding.should == Encoding::UTF_16LE
+    end
+
+    it "raises Encoding::CompatibilityError if neither are empty" do
+      -> { "x".encode("UTF-8").send(@method, "y".encode("UTF-16LE")) }.should raise_error(Encoding::CompatibilityError)
+    end
+  end
+
+  describe "when self and the argument are in different ASCII-compatible encodings" do
+    it "uses self's encoding if both are ASCII-only" do
+      "abc".encode("UTF-8").send(@method, "123".encode("SHIFT_JIS")).encoding.should == Encoding::UTF_8
+    end
+
+    it "uses self's encoding if the argument is ASCII-only" do
+      "\u00E9".encode("UTF-8").send(@method, "123".encode("ISO-8859-1")).encoding.should == Encoding::UTF_8
+    end
+
+    it "uses the argument's encoding if self is ASCII-only" do
+      "abc".encode("UTF-8").send(@method, "\u00E9".encode("ISO-8859-1")).encoding.should == Encoding::ISO_8859_1
+    end
+
+    it "raises Encoding::CompatibilityError if neither are ASCII-only" do
+      -> { "\u00E9".encode("UTF-8").send(@method, "\u00E9".encode("ISO-8859-1")) }.should raise_error(Encoding::CompatibilityError)
+    end
+  end
+
+  describe "when self is BINARY and argument is US-ASCII" do
+    it "uses BINARY encoding" do
+      "abc".encode("BINARY").send(@method, "123".encode("US-ASCII")).encoding.should == Encoding::BINARY
+    end
+  end
+end

--- a/spec/core/string/shared/concat.rb
+++ b/spec/core/string/shared/concat.rb
@@ -62,18 +62,20 @@ describe :string_concat, shared: true do
     end
 
     # #5855
-    it "returns a BINARY string if self is US-ASCII and the argument is between 128-255 (inclusive)" do
-      a = ("".encode(Encoding::US_ASCII).send(@method, 128))
-      a.encoding.should == Encoding::BINARY
-      a.should == 128.chr
+    # NATFIXME: Implement US-ASCII encoding
+    # it "returns a BINARY string if self is US-ASCII and the argument is between 128-255 (inclusive)" do
+    #   a = ("".encode(Encoding::US_ASCII).send(@method, 128))
+    #   a.encoding.should == Encoding::BINARY
+    #   a.should == 128.chr
 
-      a = ("".encode(Encoding::US_ASCII).send(@method, 255))
-      a.encoding.should == Encoding::BINARY
-      a.should == 255.chr
-    end
+    #   a = ("".encode(Encoding::US_ASCII).send(@method, 255))
+    #   a.encoding.should == Encoding::BINARY
+    #   a.should == 255.chr
+    # end
 
     it "raises RangeError if the argument is an invalid codepoint for self's encoding" do
-      -> { "".encode(Encoding::US_ASCII).send(@method, 256) }.should raise_error(RangeError)
+      # NATFIXME: Implement US-ASCII encoding
+      # -> { "".encode(Encoding::US_ASCII).send(@method, 256) }.should raise_error(RangeError)
       -> { "".encode(Encoding::EUC_JP).send(@method, 0x81)  }.should raise_error(RangeError)
     end
 
@@ -154,9 +156,10 @@ describe :string_concat_encoding, shared: true do
     end
   end
 
-  describe "when self is BINARY and argument is US-ASCII" do
-    it "uses BINARY encoding" do
-      "abc".encode("BINARY").send(@method, "123".encode("US-ASCII")).encoding.should == Encoding::BINARY
-    end
-  end
+  # NATFIXME: Implement US-ASCII encoding
+  # describe "when self is BINARY and argument is US-ASCII" do
+  #   it "uses BINARY encoding" do
+  #     "abc".encode("BINARY").send(@method, "123".encode("US-ASCII")).encoding.should == Encoding::BINARY
+  #   end
+  # end
 end

--- a/spec/core/string/shared/concat.rb
+++ b/spec/core/string/shared/concat.rb
@@ -56,9 +56,10 @@ describe :string_concat, shared: true do
       b = "".send(@method, 33)
       b.should == "!"
 
-      b.encode!(Encoding::UTF_8)
-      b.send(@method, 0x203D)
-      b.should == "!\u203D"
+      # NATFIXME: Add support for `encode!` method.
+      # b.encode!(Encoding::UTF_8)
+      # b.send(@method, 0x203D)
+      # b.should == "!\u203D"
     end
 
     # #5855

--- a/spec/core/string/shared/concat.rb
+++ b/spec/core/string/shared/concat.rb
@@ -63,19 +63,19 @@ describe :string_concat, shared: true do
 
     # #5855
     # NATFIXME: Implement US-ASCII encoding
-    # it "returns a BINARY string if self is US-ASCII and the argument is between 128-255 (inclusive)" do
-    #   a = ("".encode(Encoding::US_ASCII).send(@method, 128))
-    #   a.encoding.should == Encoding::BINARY
-    #   a.should == 128.chr
+    xit "returns a BINARY string if self is US-ASCII and the argument is between 128-255 (inclusive)" do
+      a = ("".encode(Encoding::US_ASCII).send(@method, 128))
+      a.encoding.should == Encoding::BINARY
+      a.should == 128.chr
 
-    #   a = ("".encode(Encoding::US_ASCII).send(@method, 255))
-    #   a.encoding.should == Encoding::BINARY
-    #   a.should == 255.chr
-    # end
+      a = ("".encode(Encoding::US_ASCII).send(@method, 255))
+      a.encoding.should == Encoding::BINARY
+      a.should == 255.chr
+    end
 
-    it "raises RangeError if the argument is an invalid codepoint for self's encoding" do
-      # NATFIXME: Implement US-ASCII encoding
-      # -> { "".encode(Encoding::US_ASCII).send(@method, 256) }.should raise_error(RangeError)
+    # NATFIXME: Implement US-ASCII and EUC_JP encoding
+    xit "raises RangeError if the argument is an invalid codepoint for self's encoding" do
+      -> { "".encode(Encoding::US_ASCII).send(@method, 256) }.should raise_error(RangeError)
       -> { "".encode(Encoding::EUC_JP).send(@method, 0x81)  }.should raise_error(RangeError)
     end
 
@@ -103,63 +103,75 @@ end
 
 describe :string_concat_encoding, shared: true do
   describe "when self is in an ASCII-incompatible encoding incompatible with the argument's encoding" do
-    it "uses self's encoding if both are empty" do
+    # NATFIXME: Implement UTF-16LE
+    xit "uses self's encoding if both are empty" do
       "".encode("UTF-16LE").send(@method, "").encoding.should == Encoding::UTF_16LE
     end
 
-    it "uses self's encoding if the argument is empty" do
+    # NATFIXME: Implement UTF-16LE
+    xit "uses self's encoding if the argument is empty" do
       "x".encode("UTF-16LE").send(@method, "").encoding.should == Encoding::UTF_16LE
     end
 
-    it "uses the argument's encoding if self is empty" do
+    # NATFIXME: Implement UTF-16LE
+    xit "uses the argument's encoding if self is empty" do
       "".encode("UTF-16LE").send(@method, "x".encode("UTF-8")).encoding.should == Encoding::UTF_8
     end
 
-    it "raises Encoding::CompatibilityError if neither are empty" do
+    # NATFIXME: Implement UTF-16LE
+    xit "raises Encoding::CompatibilityError if neither are empty" do
       -> { "x".encode("UTF-16LE").send(@method, "y".encode("UTF-8")) }.should raise_error(Encoding::CompatibilityError)
     end
   end
 
   describe "when the argument is in an ASCII-incompatible encoding incompatible with self's encoding" do
-    it "uses self's encoding if both are empty" do
+    # NATFIXME: Implement UTF-16LE
+    xit "uses self's encoding if both are empty" do
       "".encode("UTF-8").send(@method, "".encode("UTF-16LE")).encoding.should == Encoding::UTF_8
     end
 
-    it "uses self's encoding if the argument is empty" do
+    # NATFIXME: Implement UTF-16LE
+    xit "uses self's encoding if the argument is empty" do
       "x".encode("UTF-8").send(@method, "".encode("UTF-16LE")).encoding.should == Encoding::UTF_8
     end
 
-    it "uses the argument's encoding if self is empty" do
+    # NATFIXME: Implement UTF-16LE
+    xit "uses the argument's encoding if self is empty" do
       "".encode("UTF-8").send(@method, "x".encode("UTF-16LE")).encoding.should == Encoding::UTF_16LE
     end
 
-    it "raises Encoding::CompatibilityError if neither are empty" do
+    # NATFIXME: Implement UTF-16LE
+    xit "raises Encoding::CompatibilityError if neither are empty" do
       -> { "x".encode("UTF-8").send(@method, "y".encode("UTF-16LE")) }.should raise_error(Encoding::CompatibilityError)
     end
   end
 
   describe "when self and the argument are in different ASCII-compatible encodings" do
-    it "uses self's encoding if both are ASCII-only" do
+    # NATFIXME: Implement SHIFT_JIS
+    xit "uses self's encoding if both are ASCII-only" do
       "abc".encode("UTF-8").send(@method, "123".encode("SHIFT_JIS")).encoding.should == Encoding::UTF_8
     end
 
-    it "uses self's encoding if the argument is ASCII-only" do
+    # NATFIXME: Implement ISO-8859-1
+    xit "uses self's encoding if the argument is ASCII-only" do
       "\u00E9".encode("UTF-8").send(@method, "123".encode("ISO-8859-1")).encoding.should == Encoding::UTF_8
     end
 
-    it "uses the argument's encoding if self is ASCII-only" do
+    # NATFIXME: Implement ISO-8859-1
+    xit "uses the argument's encoding if self is ASCII-only" do
       "abc".encode("UTF-8").send(@method, "\u00E9".encode("ISO-8859-1")).encoding.should == Encoding::ISO_8859_1
     end
 
-    it "raises Encoding::CompatibilityError if neither are ASCII-only" do
+    # NATFIXME: Implement ISO-8859-1
+    xit "raises Encoding::CompatibilityError if neither are ASCII-only" do
       -> { "\u00E9".encode("UTF-8").send(@method, "\u00E9".encode("ISO-8859-1")) }.should raise_error(Encoding::CompatibilityError)
     end
   end
 
   # NATFIXME: Implement US-ASCII encoding
-  # describe "when self is BINARY and argument is US-ASCII" do
-  #   it "uses BINARY encoding" do
-  #     "abc".encode("BINARY").send(@method, "123".encode("US-ASCII")).encoding.should == Encoding::BINARY
-  #   end
-  # end
+  describe "when self is BINARY and argument is US-ASCII" do
+    xit "uses BINARY encoding" do
+      "abc".encode("BINARY").send(@method, "123".encode("US-ASCII")).encoding.should == Encoding::BINARY
+    end
+  end
 end

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -269,7 +269,7 @@ Value StringObject::concat(Env *env, size_t argc, Value *args) {
         } else if (arg->is_integer() && arg->as_integer()->to_nat_int_t() < 0) {
             env->raise("RangeError", "less than 0");
         } else if (arg->is_integer()) {
-            str_obj = arg->as_integer()->to_s(env)->as_string();
+            str_obj = arg.send(env, "chr"_s)->as_string();
         } else if (arg->respond_to(env, to_str)) {
             str_obj = arg.send(env, to_str)->as_string();
         } else {

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -266,12 +266,17 @@ Value StringObject::concat(Env *env, size_t argc, Value *args) {
         StringObject *str_obj;
         if (arg->is_string()) {
             str_obj = arg->as_string();
+        } else if (arg->is_integer() && arg->as_integer()->to_nat_int_t() < 0) {
+            env->raise("RangeError", "less than 0");
+        } else if (arg->is_integer()) {
+            str_obj = arg->as_integer()->to_s(env)->as_string();
         } else if (arg->respond_to(env, to_str)) {
             str_obj = arg.send(env, to_str)->as_string();
-            str_obj->assert_type(env, Object::Type::String, "String");
         } else {
             env->raise("TypeError", "cannot call to_str", arg->inspect_str(env));
         }
+
+        str_obj->assert_type(env, Object::Type::String, "String");
 
         append(env, str_obj->c_str());
     }


### PR DESCRIPTION
There's quite a few encodings being used here that we don't support at the moment so I'm skipping those and adding a `NATFIXME` comment above.

The rest of the spec is passing though. Not entirely sure what it takes to add support for other encodings.