### PR TITLE
Introduce a Ruby Specification Grabber tool

### DIFF
--- a/spec/grab
+++ b/spec/grab
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+require 'uri'
+require 'net/http'
+
+file = ARGV[0]
+uri = URI("https://raw.githubusercontent.com/ruby/spec/master/#{file}_spec.rb")
+res = Net::HTTP.get_response(uri)
+
+if res.code == '404'
+  abort("Spec file not found at #{uri}.")
+end
+
+path = "#{__dir__}/#{file}_spec.rb"
+
+if File.file?(path)
+  abort("Spec file already exists at #{path}.")
+end
+
+File.write(path, res.body)
+
+puts "Spec file created at #{path}."

--- a/spec/grab
+++ b/spec/grab
@@ -17,14 +17,14 @@ OptionParser.new do |opts|
 end.parse!
 
 file = ARGV[0]
-uri = URI("https://raw.githubusercontent.com/ruby/spec/master/#{file}_spec.rb")
+uri = URI("https://raw.githubusercontent.com/ruby/spec/master/#{file}")
 res = Net::HTTP.get_response(uri)
 
 if res.code == '404'
   abort("Spec file not found at #{uri}.")
 end
 
-path = "#{__dir__}/#{file}_spec.rb"
+path = "#{__dir__}/#{file}"
 
 if File.file?(path) && ! options[:force]
   abort("Spec file already exists at #{path}.")

--- a/spec/grab
+++ b/spec/grab
@@ -1,7 +1,20 @@
 #!/usr/bin/env ruby
 
+require_relative '../lib/optparse'
 require 'uri'
 require 'net/http'
+
+options = { force: false }
+OptionParser.new do |opts|
+  opts.banner = 'Usage: grab [options] spec'
+  
+  opts.program_name = 'Ruby Specification Grabber'
+  opts.version = '0.1'
+
+  opts.on('--force', 'Overwrite existing specification files.') do
+    options[:force] = true
+  end
+end.parse!
 
 file = ARGV[0]
 uri = URI("https://raw.githubusercontent.com/ruby/spec/master/#{file}_spec.rb")
@@ -13,7 +26,7 @@ end
 
 path = "#{__dir__}/#{file}_spec.rb"
 
-if File.file?(path)
+if File.file?(path) && ! options[:force]
   abort("Spec file already exists at #{path}.")
 end
 


### PR DESCRIPTION
This adds a small CLI app at `spec/grab` that can be used to quickly grab specification files from the `ruby/spec` repo.

Here's the basic usage:

```bash
./spec/grab core/integer/floor_spec.rb
```

This command will retrieve the `core/integer/floor_spec.rb` file from the repository and attempt to write to to `./spec/core/integer/floor_spec.rb`.

If the file already exists, it'll panic and fail. You can force the file to be created by providing a `--force` option, i.e. `./spec/grab core/integer/floor_spec.rb --force`.

If the spec can't be found, it'll panic too and show you the URL it was trying to hit.

> **NOTE:** This CLI requires system Ruby to be used because we're relying on the `net/http` and `uri` packages from the runtime library.