### PR TITLE
Make `Integer#size` (mostly) spec compliant

### DIFF
--- a/include/natalie/integer_object.hpp
+++ b/include/natalie/integer_object.hpp
@@ -60,6 +60,7 @@ public:
     Value bitwise_and(Env *, Value) const;
     Value bitwise_or(Env *, Value) const;
     Value pred(Env *);
+    Value size(Env *);
     Value succ(Env *);
     Value coerce(Env *, Value);
     Value floor(Env *, Value);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -564,6 +564,7 @@ gen.binding('Integer', 'magnitude', 'IntegerObject', 'abs', argc: 0, pass_env: t
 gen.binding('Integer', 'next', 'IntegerObject', 'succ', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Integer', 'odd?', 'IntegerObject', 'is_odd', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
 gen.binding('Integer', 'ord', 'IntegerObject', 'ord', argc: 0, pass_env: false, pass_block: false, return_type: :Object)
+gen.binding('Integer', 'size', 'IntegerObject', 'size', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Integer', 'succ', 'IntegerObject', 'succ', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Integer', 'pred', 'IntegerObject', 'pred', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Integer', 'times', 'IntegerObject', 'times', argc: 0, pass_env: true, pass_block: true, return_type: :Object)

--- a/spec/core/integer/size_spec.rb
+++ b/spec/core/integer/size_spec.rb
@@ -1,0 +1,34 @@
+require_relative '../../spec_helper'
+
+describe "Integer#size" do
+  platform_is wordsize: 32 do
+    it "returns the number of bytes in the machine representation of self" do
+      -1.size.should == 4
+      0.size.should == 4
+      4091.size.should == 4
+    end
+  end
+
+  platform_is wordsize: 64 do
+    it "returns the number of bytes in the machine representation of self" do
+      -1.size.should == 8
+      0.size.should == 8
+      4091.size.should == 8
+    end
+  end
+
+  context "bignum" do
+    it "returns the number of bytes required to hold the unsigned bignum data" do
+      # that is, n such that 256 * n <= val.abs < 256 * (n+1)
+      (256**7).size.should == 8
+      (256**8).size.should == 9
+      (256**9).size.should == 10
+      (256**10).size.should == 11
+      (256**10-1).size.should == 10
+      (256**11).size.should == 12
+      (256**12).size.should == 13
+      (256**20-1).size.should == 20
+      (256**40-1).size.should == 40
+    end
+  end
+end

--- a/spec/core/integer/size_spec.rb
+++ b/spec/core/integer/size_spec.rb
@@ -18,7 +18,8 @@ describe "Integer#size" do
   end
 
   context "bignum" do
-    it "returns the number of bytes required to hold the unsigned bignum data" do
+    # NATFIXME: add Bignum support.
+    xit "returns the number of bytes required to hold the unsigned bignum data" do
       # that is, n such that 256 * n <= val.abs < 256 * (n+1)
       (256**7).size.should == 8
       (256**8).size.should == 9

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -408,7 +408,7 @@ Value IntegerObject::pred(Env *env) {
 }
 
 Value IntegerObject::size(Env *env) {
-    return this;
+    return Value::integer(sizeof m_integer);
 }
 
 Value IntegerObject::succ(Env *env) {

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -407,6 +407,10 @@ Value IntegerObject::pred(Env *env) {
     return sub(env, Value::integer(1));
 }
 
+Value IntegerObject::size(Env *env) {
+    return this;
+}
+
 Value IntegerObject::succ(Env *env) {
     return add(env, Value::integer(1));
 }

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -408,6 +408,7 @@ Value IntegerObject::pred(Env *env) {
 }
 
 Value IntegerObject::size(Env *env) {
+    // NATFIXME: add Bignum support.
     return Value::integer(sizeof m_integer);
 }
 


### PR DESCRIPTION
> **NOTE:** Skipping over Bignums for now. We won't likely be able to match the spec for `Integer#size` since it's an internal implementation detail.