### PR TITLE
Make `Integer#gcd` spec compliant

### DIFF
--- a/include/natalie/integer_object.hpp
+++ b/include/natalie/integer_object.hpp
@@ -65,6 +65,7 @@ public:
     Value ceil(Env *, Value);
     Value coerce(Env *, Value);
     Value floor(Env *, Value);
+    Value gcd(Env *, Value);
     virtual Value abs(Env *);
     Value chr(Env *) const;
     virtual Value negate(Env *);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -560,6 +560,7 @@ gen.binding('Integer', 'denominator', 'IntegerObject', 'denominator', argc: 0, p
 gen.binding('Integer', 'eql?', 'IntegerObject', 'eql', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('Integer', 'even?', 'IntegerObject', 'is_even', argc: 0, pass_env: false, pass_block: false, return_type: :bool)
 gen.binding('Integer', 'floor', 'IntegerObject', 'floor', argc: 0..1, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('Integer', 'gcd', 'IntegerObject', 'gcd', argc: 1, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Integer', 'inspect', 'IntegerObject', 'inspect', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Integer', 'magnitude', 'IntegerObject', 'abs', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Integer', 'next', 'IntegerObject', 'succ', argc: 0, pass_env: true, pass_block: false, return_type: :Object)

--- a/spec/core/integer/gcd_spec.rb
+++ b/spec/core/integer/gcd_spec.rb
@@ -1,0 +1,69 @@
+require_relative '../../spec_helper'
+
+describe "Integer#gcd" do
+  it "returns self if equal to the argument" do
+    1.gcd(1).should == 1
+    398.gcd(398).should == 398
+  end
+
+  it "returns an Integer" do
+    36.gcd(6).should be_kind_of(Integer)
+    4.gcd(20981).should be_kind_of(Integer)
+  end
+
+  it "returns the greatest common divisor of self and argument" do
+    10.gcd(5).should == 5
+    200.gcd(20).should == 20
+  end
+
+  it "returns a positive integer even if self is negative" do
+    -12.gcd(6).should == 6
+    -100.gcd(100).should == 100
+  end
+
+  it "returns a positive integer even if the argument is negative" do
+    12.gcd(-6).should == 6
+    100.gcd(-100).should == 100
+  end
+
+  it "returns a positive integer even if both self and argument are negative" do
+    -12.gcd(-6).should == 6
+    -100.gcd(-100).should == 100
+  end
+
+  it "accepts a Bignum argument" do
+    bignum = 9999**99
+    bignum.should be_kind_of(Integer)
+    99.gcd(bignum).should == 99
+  end
+
+  it "works if self is a Bignum" do
+    bignum = 9999**99
+    bignum.should be_kind_of(Integer)
+    bignum.gcd(99).should == 99
+  end
+
+  it "doesn't cause an integer overflow" do
+    [2 ** (1.size * 8 - 2), 0x8000000000000000].each do |max|
+      [max - 1, max, max + 1].each do |num|
+        num.gcd(num).should == num
+        (-num).gcd(num).should == num
+        (-num).gcd(-num).should == num
+        num.gcd(-num).should == num
+      end
+    end
+  end
+
+  it "raises an ArgumentError if not given an argument" do
+    -> { 12.gcd }.should raise_error(ArgumentError)
+  end
+
+  it "raises an ArgumentError if given more than one argument" do
+    -> { 12.gcd(30, 20) }.should raise_error(ArgumentError)
+  end
+
+  it "raises a TypeError unless the argument is an Integer" do
+    -> { 39.gcd(3.8)   }.should raise_error(TypeError)
+    -> { 45872.gcd([]) }.should raise_error(TypeError)
+  end
+end

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -2,6 +2,7 @@
 
 #include "natalie/constants.hpp"
 #include <math.h>
+#include "natalie/big_int.hpp"
 
 namespace Natalie {
 
@@ -477,8 +478,18 @@ Value IntegerObject::floor(Env *env, Value arg) {
 
 Value IntegerObject::gcd(Env *env, Value divisor) {
     divisor->assert_type(env, Object::Type::Integer, "Integer");
+
+    auto this_abs = ::abs(m_integer);
+    auto divisor_abs = ::abs(divisor->as_integer()->to_nat_int_t());
+    auto remainder = divisor_abs;
+
+    while (remainder != 0) {
+        remainder = this_abs % divisor_abs;
+        this_abs = divisor_abs;
+        divisor_abs = remainder;
+    }
     
-    return this;
+    return Value::integer(this_abs);
 }
 
 bool IntegerObject::eql(Env *env, Value other) {

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -476,6 +476,8 @@ Value IntegerObject::floor(Env *env, Value arg) {
 }
 
 Value IntegerObject::gcd(Env *env, Value divisor) {
+    divisor->assert_type(env, Object::Type::Integer, "Integer");
+    
     return this;
 }
 

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -475,6 +475,10 @@ Value IntegerObject::floor(Env *env, Value arg) {
     return Value::integer(result);
 }
 
+Value IntegerObject::gcd(Env *env, Value divisor) {
+    return this;
+}
+
 bool IntegerObject::eql(Env *env, Value other) {
     if (other.is_fast_integer())
         return m_integer == other.get_fast_integer();


### PR DESCRIPTION
As always, I need to do some bignum handling here. If I can figure out how to use the `gcd` functions provided by the BigInt include, that would be helpful. Really not sure why they're not working.