### PR TITLE
Some more canary features [basic constant evaluation in p0c]

### DIFF
--- a/lib/natalie/compiler/pass0c.rb
+++ b/lib/natalie/compiler/pass0c.rb
@@ -2,7 +2,7 @@ require_relative './base_pass'
 
 module Natalie
   class Compiler
-    # A 'canary' pass that tries to simplify well-known ruby pattern which would 
+    # A 'canary' pass that tries to simplify well-known ruby pattern which would
     # normally cost allocating a data-structure
     # https://ruby-compilers.com/examples/#example-program-canaryrb
     class Pass0c < BasePass
@@ -12,6 +12,7 @@ module Natalie
         self.warn_on_default = true
         self.require_empty = false
         self.strict = false
+        @in_defined_statement = false
       end
 
       def process_iter(exp)
@@ -20,11 +21,20 @@ module Natalie
           :iter,
           process_call(call, block_fn=[args,body]),
           args,
-          *body.map {|inst| inst.is_a?(Sexp) ? process(inst) : inst}
+          *body.map { |e| process_atom(e) }
         )
       end
 
+      def process_defined(exp, block_with_args=nil)
+        # Note: This might fail on nested defined?s, but who's gonna do that
+        @in_defined_statement = true
+        exp = exp.new(*exp.map { |e| process_atom(e) })
+        @in_defined_statement = false
+        return exp
+      end
+
       def process_call(exp, block_with_args=nil)
+        exp = exp.new(*exp.map { |e| process_atom(e) })
         (_, receiver, method, *args) = exp
         if receiver && !receiver.empty?
           t, *values = receiver
@@ -34,9 +44,42 @@ module Natalie
             elsif method == :max && args.empty? && !block_with_args
               return process(canary_array_max(exp, values))
             end
+          elsif t == :lit && args.length == 1 && args[0][0] == :lit && !@in_defined_statement
+            # we cannot collapse these in defined? statements, because it changes the type
+            # from method to expression
+            class_arg1 = values[0].class
+            class_arg2 = args[0][1].class
+            if [Integer, Float].include?(class_arg1) && [Integer, Float].include?(class_arg2)
+              case method
+              when :+
+                return canary_const_addition(exp, values)
+              when :-
+                return canary_const_subtraction(exp, values)
+              when :*
+                return canary_const_multiplication(exp, values)
+              when :/
+                # FIXME: We could propagate NaNs and INFINITIES in the float case
+                return canary_const_division(exp, values) unless args[0][1] == 0
+              when :%
+                return canary_const_modulo(exp, values) unless args[0][1] == 0
+              # FIXME: This one makes String#* timeout
+              # when :**
+              #   return canary_const_exp(exp, values) unless values[0] < 0
+              when :&
+                return canary_const_and(exp, values) if [class_arg1, class_arg2].all? {|x| x == Integer}
+              when :|
+                return canary_const_or(exp, values) if [class_arg1, class_arg2].all? {|x| x == Integer}
+              when :^
+                return canary_const_xor(exp, values) if [class_arg1, class_arg2].all? {|x| x == Integer}
+              when :<<
+                return canary_const_shl(exp, values) if [class_arg1, class_arg2].all? {|x| x == Integer}
+              when :>>
+                return canary_const_shr(exp, values) if [class_arg1, class_arg2].all? {|x| x == Integer}
+              end
+            end
           end
         end
-        exp.new(*exp.map {|sub_exp| sub_exp.is_a?(Sexp) ? process(sub_exp) : sub_exp})
+        return exp
       end
 
       def canary_array_min(exp, values)
@@ -53,6 +96,50 @@ module Natalie
         return exp.new(:if, exp.new(:call, first, :>, second), canary_array_max(exp, [first, *rest]), canary_array_max(exp, [second, *rest]))
       end
 
+      def canary_const_addition(exp, values)
+        _, (_, summand1), op, (_, summand2) = exp
+        return s(:lit, summand1 + summand2)
+      end
+      def canary_const_subtraction(exp, values)
+        _, (_, minuend), op, (_, subtrahend) = exp
+        return s(:lit, minuend - subtrahend)
+      end
+      def canary_const_multiplication(exp, values)
+        _, (_, factor1), op, (_, factor2) = exp
+        return s(:lit, factor1 * factor2)
+      end
+      def canary_const_division(exp, values)
+        _, (_, numerator), op, (_, denominator) = exp
+        return s(:lit, numerator / denominator)
+      end
+      def canary_const_modulo(exp, values)
+        _, (_, numerator), op, (_, denominator) = exp
+        return s(:lit, numerator % denominator)
+      end
+      def canary_const_exp(exp, values)
+        _, (_, base), op, (_, power) = exp
+        return s(:lit, base ** power)
+      end
+      def canary_const_and(exp, values)
+        _, (_, arg1), op, (_, arg2) = exp
+        return s(:lit, arg1 & arg2)
+      end
+      def canary_const_or(exp, values)
+        _, (_, arg1), op, (_, arg2) = exp
+        return s(:lit, arg1 | arg2)
+      end
+      def canary_const_xor(exp, values)
+        _, (_, arg1), op, (_, arg2) = exp
+        return s(:lit, arg1 ^ arg2)
+      end
+      def canary_const_shl(exp, values)
+        _, (_, arg1), op, (_, arg2) = exp
+        return s(:lit, arg1 << arg2)
+      end
+      def canary_const_shr(exp, values)
+        _, (_, arg1), op, (_, arg2) = exp
+        return s(:lit, arg1 >> arg2)
+      end
     end
   end
 end

--- a/lib/natalie/compiler/pass0c.rb
+++ b/lib/natalie/compiler/pass0c.rb
@@ -33,6 +33,53 @@ module Natalie
         return exp
       end
 
+      def type_is_always_truthy(arg)
+        # FIXME: Are there any other types that are always truthy?
+        return [:true, :str, :lit, :array].include?(arg)
+      end
+      def type_is_always_falsey(arg)
+        return [:false, :nil].include?(arg)
+      end
+      def type_is_const_evaluable(arg)
+        return [:true, :str, :lit, :array, :false, :nil].include?(arg)
+      end
+
+      def process_if(exp, block_with_args=nil)
+        exp = exp.new(*exp.map { |e| process_atom(e) })
+        if exp.flatten.include?(:lasgn)
+          # This is required for now because
+          # ```rb
+          # x = 1 unless true # s(:if, s(:true), nil, s(:lasgn, :x, s(:lit, 1)))
+          # ```
+          # gets converted to an if-statement, that does not allocate x in the
+          # taken branch, which makes x undefined
+          return exp
+        end
+        (_, (boolean, *), true_case, false_case) = exp
+        return true_case  if type_is_always_truthy(boolean)
+        return false_case if type_is_always_falsey(boolean)
+
+        return exp
+      end
+
+      def process_or(exp, block_with_args=nil)
+        exp = exp.new(*exp.map { |e| process_atom(e) })
+        _, (t1, *arg1), (t2, *arg2) = exp
+        return exp.new(t2, *arg2) if type_is_always_falsey(t1)
+        return exp.new(t1, *arg1) if type_is_always_truthy(t1)
+
+        return exp
+      end
+
+      def process_and(exp, block_with_args=nil)
+        exp = exp.new(*exp.map { |e| process_atom(e) })
+        _, (t1, *arg1), (t2, *arg2) = exp
+        return s(t1, *arg1) if type_is_always_falsey(t1)
+        return exp          if !type_is_always_truthy(t1) # t1 is not const-evaluable
+        # t2 will be returned even if it is falsey, so we don't have to check it
+        return exp.new(t2, *arg2)
+      end
+
       def process_call(exp, block_with_args=nil)
         exp = exp.new(*exp.map { |e| process_atom(e) })
         (_, receiver, method, *args) = exp
@@ -75,7 +122,28 @@ module Natalie
                 return canary_const_shl(exp, values) if [class_arg1, class_arg2].all? {|x| x == Integer}
               when :>>
                 return canary_const_shr(exp, values) if [class_arg1, class_arg2].all? {|x| x == Integer}
+              when :==
+                return canary_const_eq(exp, values)
+              when :!=
+                return canary_const_neq(exp,values)
+              when :>
+                return canary_const_gt(exp, values)
+              when :>=
+                return canary_const_geq(exp, values)
+              when :<
+                return canary_const_lt(exp, values)
+              when :<=
+                return canary_const_leq(exp, values)
+              when :===
+                return canary_const_eqeq(exp, values)
+              when :<=>
+                return canary_const_cmp(exp, values)
               end
+            end
+          elsif args.length == 0
+            if method == :!
+              # This can fail and fallback, so we should not try to process it again
+              return canary_const_not(exp, values)
             end
           end
         end
@@ -96,6 +164,7 @@ module Natalie
         return exp.new(:if, exp.new(:call, first, :>, second), canary_array_max(exp, [first, *rest]), canary_array_max(exp, [second, *rest]))
       end
 
+      # FIXME: These are pretty repetitive, maybe do these with meta programming
       def canary_const_addition(exp, values)
         _, (_, summand1), op, (_, summand2) = exp
         return s(:lit, summand1 + summand2)
@@ -139,6 +208,52 @@ module Natalie
       def canary_const_shr(exp, values)
         _, (_, arg1), op, (_, arg2) = exp
         return s(:lit, arg1 >> arg2)
+      end
+      def canary_const_eq(exp,values)
+        _, (_, arg1), leq, (_, arg2) = exp
+        return s(:true) if arg1 == arg2
+        return s(:false)
+      end
+      def canary_const_neq(exp,values)
+        _, (_, arg1), leq, (_, arg2) = exp
+        return s(:true) if arg1 != arg2
+        return s(:false)
+      end
+      def canary_const_gt(exp,values)
+        _, (_, arg1), leq, (_, arg2) = exp
+        return s(:true) if arg1 > arg2
+        return s(:false)
+      end
+      def canary_const_geq(exp,values)
+        _, (_, arg1), leq, (_, arg2) = exp
+        return s(:true) if arg1 >= arg2
+        return s(:false)
+      end
+      def canary_const_lt(exp,values)
+        _, (_,arg1), leq, (_,arg2) = exp
+        return s(:true) if arg1 < arg2
+        return s(:false)
+      end
+      def canary_const_leq(exp,values)
+        _, (_, arg1), leq, (_, arg2) = exp
+        return s(:true) if arg1 <= arg2
+        return s(:false)
+      end
+      def canary_const_eqeq(exp,values)
+        _, (_, arg1), eqeq, (_, arg2) = exp
+        return s(:true) if arg1 === arg2
+        return s(:false)
+      end
+      def canary_const_cmp(exp,values)
+        _, (_, arg1), cmp, (_, arg2) = exp
+        return s(:lit, arg1 <=> arg2)
+      end
+
+      def canary_const_not(exp, values)
+        _, (type,*), _not = exp
+        return exp.new(:false) if type_is_always_truthy(type)
+        return exp.new(:true) if type_is_always_falsey(type)
+        return exp
       end
     end
   end

--- a/test/natalie/case_when_test.rb
+++ b/test/natalie/case_when_test.rb
@@ -129,4 +129,20 @@ describe 'case/when' do
              end
     result.should == 'yep'
   end
+
+  it 'does not compile the same when body more than once' do
+    # the compiler will error if we are compiling the when body twice
+    code = <<-END.gsub(/\n/, '; ')
+      x = 1
+      case x
+      when 1, 2
+        [1].each do
+          puts 'hi'
+        end
+      end
+    END
+    result = `bin/natalie -e #{code.inspect} 2>&1`
+    result.strip.should == "hi"
+    $?.to_i.should == 0
+  end
 end

--- a/test/natalie/compiler_test.rb
+++ b/test/natalie/compiler_test.rb
@@ -20,8 +20,14 @@ describe 'Natalie::Compiler' do
     path = File.expand_path('../../examples/boardslam.rb', __dir__)
     ast = Parser.parse(File.read(path), path)
 
+    pass0c = Natalie::Compiler::Pass0c.new(context)
+    ast0c = pass0c.go(ast)
+    actual = ast0c.inspect.gsub(/\s+/, "\n").strip
+    expected = `#{NAT_BINARY} -d p0c #{path}`.gsub(/\s+/, "\n").strip
+    actual.should == expected
+
     pass1 = Natalie::Compiler::Pass1.new(context)
-    ast1 = pass1.go(ast)
+    ast1 = pass1.go(ast0c)
     actual = ast1.inspect.gsub(/\s+/, "\n").strip
     expected = `#{NAT_BINARY} -d p1 #{path}`.gsub(/\s+/, "\n").strip
     actual.should == expected


### PR DESCRIPTION
This adds the ability to coalesce constant arithmetic and if-statements to pass0c
With this we should save some send calls on primitive data types

Here follows a quick demonstration

<details>
<summary>input</summary>

```ruby
x = 1 unless true

1 & 3
2 | 1
3 ^ 2

1 << 4
32 >> 3

[1, 2, 3].max
[-1,2,3].min

1 < 2
-1 < 1

defined?(1 + 1)

1 + 1 + 1
1 * 2
3 * 4
6 / 3
1.0 + 3
3.0 + 1.0
3.0 * 6
1.0 / 2
1.0 / 0
1.0 % 0.5
5 % 3
16 % 9
12.349 % 1

2 <=> 3
1 === 0.0

!false

if (1+1 == 0)
    do_something
elsif (1+1 == 2)
    do_something_else
else
    do_nothing
end
```

</details>

<details>
<summary>ast</summary>

```ruby
s(:block,
 s(:if, s(:true), nil, s(:lasgn, :x, s(:lit, 1))),
 s(:call, s(:lit, 1), :&, s(:lit, 3)),
 s(:call, s(:lit, 2), :|, s(:lit, 1)),
 s(:call, s(:lit, 3), :^, s(:lit, 2)),
 s(:call, s(:lit, 1), :<<, s(:lit, 4)),
 s(:call, s(:lit, 32), :>>, s(:lit, 3)),
 s(:call, s(:array, s(:lit, 1), s(:lit, 2), s(:lit, 3)), :max),
 s(:call, s(:array, s(:lit, -1), s(:lit, 2), s(:lit, 3)), :min),
 s(:call, s(:lit, 1), :<, s(:lit, 2)),
 s(:call, s(:lit, -1), :<, s(:lit, 1)),
 s(:defined, s(:call, s(:lit, 1), :+, s(:lit, 1))),
 s(:call, s(:call, s(:lit, 1), :+, s(:lit, 1)), :+, s(:lit, 1)),
 s(:call, s(:lit, 1), :*, s(:lit, 2)),
 s(:call, s(:lit, 3), :*, s(:lit, 4)),
 s(:call, s(:lit, 6), :/, s(:lit, 3)),
 s(:call, s(:lit, 1.0), :+, s(:lit, 3)),
 s(:call, s(:lit, 3.0), :+, s(:lit, 1.0)),
 s(:call, s(:lit, 3.0), :*, s(:lit, 6)),
 s(:call, s(:lit, 1.0), :/, s(:lit, 2)),
 s(:call, s(:lit, 1.0), :/, s(:lit, 0)),
 s(:call, s(:lit, 1.0), :%, s(:lit, 0.5)),
 s(:call, s(:lit, 5), :%, s(:lit, 3)),
 s(:call, s(:lit, 16), :%, s(:lit, 9)),
 s(:call, s(:lit, 12.349), :%, s(:lit, 1)),
 s(:call, s(:lit, 2), :<=>, s(:lit, 3)),
 s(:call, s(:lit, 1), :===, s(:lit, 0.0)),
 s(:call, s(:false), :!),
 s(:if,
  s(:call, s(:call, s(:lit, 1), :+, s(:lit, 1)), :==, s(:lit, 0)),
  s(:call, nil, :do_something),
  s(:if,
   s(:call, s(:call, s(:lit, 1), :+, s(:lit, 1)), :==, s(:lit, 2)),
   s(:call, nil, :do_something_else),
   s(:call, nil, :do_nothing))))
```

</details>

<details>
<summary>output</summary>

```ruby
s(:block,
 s(:if, s(:true), nil, s(:lasgn, :x, s(:lit, 1))),
 s(:lit, 1),
 s(:lit, 3),
 s(:lit, 1),
 s(:lit, 16),
 s(:lit, 4),
 s(:lit, 3),
 s(:lit, -1),
 s(:true),
 s(:true),
 s(:defined, s(:call, s(:lit, 1), :+, s(:lit, 1))),
 s(:lit, 3),
 s(:lit, 2),
 s(:lit, 12),
 s(:lit, 2),
 s(:lit, 4.0),
 s(:lit, 4.0),
 s(:lit, 18.0),
 s(:lit, 0.5),
 s(:call, s(:lit, 1.0), :/, s(:lit, 0)),
 s(:lit, 0.0),
 s(:lit, 2),
 s(:lit, 7),
 s(:lit, 0.3490000000000002),
 s(:lit, -1),
 s(:false),
 s(:true),
 s(:call, nil, :do_something_else))
```

</details>

Some intermediaries seem to be weirdly rounded
This optimization might also be applied to String arithmetic

In the future the ability to lookup global constants or freshly stored variables would make this optimization pass even more powerful

Please check if the ruby code is up to the standard, these are pretty much my first 100 lines ruby