### PR TITLE
Make Integer#** spec compliant

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -193,7 +193,7 @@ file 'build/onigmo/lib/libonigmo.a' do
 end
 
 file 'build/generated/numbers.rb' do |t|
-  f1 = Tempfile.new('numbers.c')
+  f1 = Tempfile.new(['numbers', '.cpp'])
   f2 = Tempfile.create('numbers')
   f2.close
   begin
@@ -204,7 +204,7 @@ file 'build/generated/numbers.rb' do |t|
     f1.puts "  printf(\"NAT_MIN_FIXNUM = %lli\\n\", NAT_MIN_FIXNUM);"
     f1.puts "}"
     f1.close
-    sh "#{cc} -Iinclude -x c -o #{f2.path} #{f1.path}"
+    sh "#{cxx} #{cxx_flags.join(' ')} -std=#{STANDARD} -o #{f2.path} #{f1.path}"
     sh "#{f2.path} > #{t.name}"
   ensure
     File.unlink(f1.path)

--- a/include/natalie/big_int.hpp
+++ b/include/natalie/big_int.hpp
@@ -157,3 +157,5 @@ public:
     // Random number generating functions:
     friend BigInt big_random(size_t);
 };
+
+BigInt pow(const BigInt &base, long long exp);

--- a/include/natalie/bignum_object.hpp
+++ b/include/natalie/bignum_object.hpp
@@ -19,6 +19,10 @@ public:
         : IntegerObject { -1 }
         , m_bigint(new BigInt(num)) { }
 
+    BignumObject(const long long &num)
+        : IntegerObject { -1 }
+        , m_bigint(new BigInt(num)) { }
+
     ~BignumObject() {
         if (m_bigint) delete m_bigint;
     }
@@ -46,6 +50,7 @@ public:
     Value sub(Env *, Value) override;
     Value mul(Env *, Value) override;
     Value div(Env *, Value) override;
+    Value pow(Env *, Value) override;
     Value negate(Env *) override;
     Value times(Env *, Block *) override;
     Value to_f() const override;

--- a/include/natalie/constants.hpp
+++ b/include/natalie/constants.hpp
@@ -1,5 +1,8 @@
 // This is used at build time as well in order to generate numbers.rb
 #include <limits.h>
+#include <math.h>
 
 #define NAT_MAX_FIXNUM LLONG_MAX
 #define NAT_MIN_FIXNUM LLONG_MIN + 1
+
+const long long NAT_MAX_FIXNUM_SQRT = (long long)sqrt((double)NAT_MAX_FIXNUM);

--- a/include/natalie/constants.hpp
+++ b/include/natalie/constants.hpp
@@ -1,8 +1,26 @@
 // This is used at build time as well in order to generate numbers.rb
+#pragma once
+#include "natalie/types.hpp"
 #include <limits.h>
-#include <math.h>
 
 #define NAT_MAX_FIXNUM LLONG_MAX
 #define NAT_MIN_FIXNUM LLONG_MIN + 1
 
-const long long NAT_MAX_FIXNUM_SQRT = (long long)sqrt((double)NAT_MAX_FIXNUM);
+namespace Natalie {
+
+constexpr nat_int_t lowest_squarable_fixnum() {
+    nat_int_t mask = (nat_int_t)1 << (sizeof(nat_int_t) * 8 - 2);
+    nat_int_t max_sqrt = 0;
+    while (mask > 0) {
+        nat_int_t current_sum = max_sqrt + mask;
+        mask >>= 1;
+        if ((NAT_MAX_FIXNUM / current_sum) < current_sum) continue; // overflow
+        max_sqrt = current_sum;
+    }
+
+    return max_sqrt;
+}
+
+constexpr nat_int_t NAT_MAX_FIXNUM_SQRT = lowest_squarable_fixnum();
+
+}

--- a/include/natalie/integer_object.hpp
+++ b/include/natalie/integer_object.hpp
@@ -54,7 +54,7 @@ public:
     virtual Value mul(Env *, Value);
     virtual Value div(Env *, Value);
     Value mod(Env *, Value) const;
-    Value pow(Env *, Value) const;
+    virtual Value pow(Env *, Value);
     Value cmp(Env *, Value);
     virtual Value times(Env *, Block *);
     Value bitwise_and(Env *, Value) const;

--- a/include/natalie/integer_object.hpp
+++ b/include/natalie/integer_object.hpp
@@ -5,6 +5,7 @@
 #include <inttypes.h>
 
 #include "natalie/class_object.hpp"
+#include "natalie/constants.hpp"
 #include "natalie/forward.hpp"
 #include "natalie/global_env.hpp"
 #include "natalie/macros.hpp"

--- a/spec/core/array/bsearch_index_spec.rb
+++ b/spec/core/array/bsearch_index_spec.rb
@@ -72,8 +72,7 @@ describe "Array#bsearch_index" do
         [1, 2].should include(@array.bsearch_index { |x| (1 - x / 4) * (2**100) })
       end
 
-      # NATFIXME: Make Integer#** spec compliant to work with bignums
-      xit "returns nil when block never returns 0" do
+      it "returns nil when block never returns 0" do
         @array.bsearch_index { |x| 1 * (2**100) }.should be_nil
         @array.bsearch_index { |x| (-1) * (2**100) }.should be_nil
       end

--- a/spec/core/float/round_spec.rb
+++ b/spec/core/float/round_spec.rb
@@ -68,15 +68,13 @@ describe "Float#round" do
     0.42.round(2.0**30).should == 0.42
   end
 
-  # NATFIXME: Implement Bignum support for Integer#**
-  xit "returns big values rounded to nearest" do
+  it "returns big values rounded to nearest" do
     +2.5e20.round(-20).should   eql( +3 * 10 ** 20  )
     -2.5e20.round(-20).should   eql( -3 * 10 ** 20  )
   end
 
   # redmine #5272
-  # TODO: e-notation
-  xit "returns rounded values for big values" do
+  it "returns rounded values for big values" do
     +2.4e20.round(-20).should   eql( +2 * 10 ** 20  )
     -2.4e20.round(-20).should   eql( -2 * 10 ** 20  )
     +2.5e200.round(-200).should eql( +3 * 10 ** 200 )

--- a/spec/core/integer/divide_spec.rb
+++ b/spec/core/integer/divide_spec.rb
@@ -47,8 +47,7 @@ describe "Integer#/" do
       @bignum = bignum_value(88)
     end
 
-    # NATFIXME: Make Integer#** spec compliant by supporting bignums
-    xit "returns self divided by other" do
+    it "returns self divided by other" do
       (@bignum / 4).should == 2305843009213693974
 
       (@bignum / bignum_value(2)).should == 1
@@ -56,8 +55,9 @@ describe "Integer#/" do
       (-(10**50) / -(10**40 + 1)).should == 9999999999
       ((10**50) / (10**40 + 1)).should == 9999999999
 
-      ((-10**50) / (10**40 + 1)).should == -10000000000
-      ((10**50) / -(10**40 + 1)).should == -10000000000
+      # NATFIXME: BigInt (the lib we use) returns -9999999999 instead
+      # ((-10**50) / (10**40 + 1)).should == -10000000000
+      # ((10**50) / -(10**40 + 1)).should == -10000000000
     end
 
     it "returns self divided by Float" do

--- a/spec/core/integer/exponent_spec.rb
+++ b/spec/core/integer/exponent_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/exponent'
+
+describe "Integer#**" do
+  it_behaves_like :integer_exponent, :**
+end

--- a/spec/core/integer/odd_spec.rb
+++ b/spec/core/integer/odd_spec.rb
@@ -18,8 +18,7 @@ describe "Integer#odd?" do
     end
   end
 
-  # NATFIXME: need to work on IntegerObject::pow() so it handles Bignum
-  xcontext "bignum" do
+  context "bignum" do
     it "returns true if self is odd and positive" do
       (987_279**19).odd?.should be_true
     end

--- a/spec/core/integer/shared/exponent.rb
+++ b/spec/core/integer/shared/exponent.rb
@@ -1,0 +1,128 @@
+describe :integer_exponent, shared: true do
+  context "fixnum" do
+    it "returns self raised to the given power" do
+      2.send(@method, 0).should eql 1
+      2.send(@method, 1).should eql 2
+      2.send(@method, 2).should eql 4
+
+      9.send(@method, 0.5).should eql 3.0
+      # NATFIXME: Implement Rational
+      # 9.send(@method, Rational(1, 2)).should eql 3.0
+      # 5.send(@method, -1).to_f.to_s.should == '0.2'
+
+      2.send(@method, 40).should eql 1099511627776
+    end
+
+    it "overflows the answer to a bignum transparently" do
+      2.send(@method, 29).should eql 536870912
+      2.send(@method, 30).should eql 1073741824
+      2.send(@method, 31).should eql 2147483648
+      2.send(@method, 32).should eql 4294967296
+
+      2.send(@method, 61).should eql 2305843009213693952
+      2.send(@method, 62).should eql 4611686018427387904
+      2.send(@method, 63).should eql 9223372036854775808
+      2.send(@method, 64).should eql 18446744073709551616
+      8.send(@method, 23).should eql 590295810358705651712
+    end
+
+    it "raises negative numbers to the given power" do
+      (-2).send(@method, 29).should eql(-536870912)
+      (-2).send(@method, 30).should eql(1073741824)
+      (-2).send(@method, 31).should eql(-2147483648)
+      (-2).send(@method, 32).should eql(4294967296)
+
+      (-2).send(@method, 61).should eql(-2305843009213693952)
+      (-2).send(@method, 62).should eql(4611686018427387904)
+      (-2).send(@method, 63).should eql(-9223372036854775808)
+      (-2).send(@method, 64).should eql(18446744073709551616)
+    end
+
+    it "can raise 1 to a bignum safely" do
+      1.send(@method, 4611686018427387904).should eql 1
+    end
+
+    it "can raise -1 to a bignum safely" do
+      (-1).send(@method, 4611686018427387904).should eql(1)
+      (-1).send(@method, 4611686018427387905).should eql(-1)
+    end
+
+    it "returns Float::INFINITY when the number is too big" do
+      -> {
+        2.send(@method, 427387904).should == Float::INFINITY
+      }.should complain(/warning: in a\*\*b, b may be too big/)
+    end
+
+    it "raises a ZeroDivisionError for 0 ** -1" do
+      -> { 0.send(@method, -1) }.should raise_error(ZeroDivisionError)
+      # NATFIXME: Implement Rational
+      # -> { 0.send(@method, Rational(-1, 1)) }.should raise_error(ZeroDivisionError)
+    end
+
+    it "returns Float::INFINITY for 0 ** -1.0" do
+      0.send(@method, -1.0).should == Float::INFINITY
+    end
+
+    it "raises a TypeError when given a non-numeric power" do
+      -> { 13.send(@method, "10") }.should raise_error(TypeError)
+      -> { 13.send(@method, :symbol) }.should raise_error(TypeError)
+      -> { 13.send(@method, nil) }.should raise_error(TypeError)
+    end
+
+    it "coerces power and calls #**" do
+      num_2 = mock("2")
+      num_13 = mock("13")
+      num_2.should_receive(:coerce).with(13).and_return([num_13, num_2])
+      num_13.should_receive(:**).with(num_2).and_return(169)
+
+      13.send(@method, num_2).should == 169
+    end
+
+    it "returns Float when power is Float" do
+      2.send(@method, 2.0).should == 4.0
+    end
+
+    # NATFIXME: Implement Rational
+    xit "returns Rational when power is Rational" do
+      2.send(@method, Rational(2, 1)).should == Rational(4, 1)
+    end
+
+    # NATFIXME: Implement Complex and Rational
+    xit "returns a complex number when negative and raised to a fractional power" do
+      (-8).send(@method, 1.0/3)         .should be_close(Complex(1, 1.73205), TOLERANCE)
+      (-8).send(@method, Rational(1, 3)).should be_close(Complex(1, 1.73205), TOLERANCE)
+    end
+  end
+
+  context "bignum" do
+    before :each do
+      @bignum = bignum_value(47)
+    end
+
+    it "returns self raised to other power" do
+      (@bignum.send(@method, 4)).should == 7237005577332262361485077344629993318496048279512298547155833600056910050625
+      (@bignum.send(@method, 1.2)).should be_close(57262152889751597425762.57804, TOLERANCE)
+    end
+
+    it "raises a TypeError when given a non-Integer" do
+      -> { @bignum.send(@method, mock('10')) }.should raise_error(TypeError)
+      -> { @bignum.send(@method, "10") }.should raise_error(TypeError)
+      -> { @bignum.send(@method, :symbol) }.should raise_error(TypeError)
+    end
+
+    it "switch to a Float when the values is too big" do
+      flt = nil
+      -> {
+        flt = @bignum.send(@method, @bignum)
+      }.should complain(/warning: in a\*\*b, b may be too big/)
+      flt.should be_kind_of(Float)
+      flt.infinite?.should == 1
+    end
+
+    # NATFIXME: Implement Complex and Rational
+    xit "returns a complex number when negative and raised to a fractional power" do
+      ((-@bignum).send(@method, (1.0/3)))      .should be_close(Complex(1048576,1816186.907597341), TOLERANCE)
+      ((-@bignum).send(@method, Rational(1,3))).should be_close(Complex(1048576,1816186.907597341), TOLERANCE)
+    end
+  end
+end

--- a/spec/core/integer/to_f_spec.rb
+++ b/spec/core/integer/to_f_spec.rb
@@ -17,11 +17,7 @@ describe "Integer#to_f" do
     end
 
     it "converts number close to Float::MAX without exceeding MAX or producing NaN" do
-      # NATFIXME: Implement Integer#** to support overflows to bignums
-      # (10**308).to_f.should == 10.0 ** 308
-      x = 10
-      307.times { x *= 10 }
-      x.to_f.should == 10.0 ** 308
+      (10**308).to_f.should == 10.0 ** 308
     end
   end
 end

--- a/src/big_int.cpp
+++ b/src/big_int.cpp
@@ -1167,10 +1167,12 @@ BigInt BigInt::operator*(const BigInt &num) const {
         product = strtoll(this->value.c_str(), NULL, 10) * strtoll(num.value.c_str(), NULL, 10);
     else if (is_power_of_10(this->value)) { // if LHS is a power of 10 do optimised operation
         product.value = num.value;
-        product.value.append(this->value.substring(1));
+        if (this->value.length() > 1)
+            product.value.append(this->value.substring(1));
     } else if (is_power_of_10(num.value)) { // if RHS is a power of 10 do optimised operation
         product.value = this->value;
-        product.value.append(num.value.substring(1));
+        if (num.value.length() > 1)
+            product.value.append(num.value.substring(1));
     } else {
         // identify the numbers as `larger` and `smaller`
         Natalie::String larger, smaller;

--- a/src/big_int.cpp
+++ b/src/big_int.cpp
@@ -834,7 +834,7 @@ BigInt big_pow10(size_t exp) {
     Returns a BigInt equal to base^exp.
 */
 
-BigInt pow(const BigInt &base, int exp) {
+BigInt pow(const BigInt &base, long long exp) {
     if (exp < 0) {
         // Cannot divide by zero
         assert(base != 0);

--- a/src/bignum_object.cpp
+++ b/src/bignum_object.cpp
@@ -25,8 +25,7 @@ Value BignumObject::abs(Env *env) {
 
 Value BignumObject::add(Env *env, Value arg) {
     if (arg->is_float()) {
-        double current = strtod(m_bigint->to_string().c_str(), NULL);
-        auto result = current + arg->as_float()->to_double();
+        auto result = m_bigint->to_double() + arg->as_float()->to_double();
         return new FloatObject { result };
     }
 
@@ -42,8 +41,7 @@ Value BignumObject::add(Env *env, Value arg) {
 
 Value BignumObject::sub(Env *env, Value arg) {
     if (arg->is_float()) {
-        double current = strtod(m_bigint->to_string().c_str(), NULL);
-        auto result = current - arg->as_float()->to_double();
+        auto result = m_bigint->to_double() - arg->as_float()->to_double();
         return new FloatObject { result };
     }
 
@@ -59,8 +57,7 @@ Value BignumObject::sub(Env *env, Value arg) {
 
 Value BignumObject::mul(Env *env, Value arg) {
     if (arg->is_float()) {
-        double current = strtod(m_bigint->to_string().c_str(), NULL);
-        auto result = current * arg->as_float()->to_double();
+        auto result = m_bigint->to_double() * arg->as_float()->to_double();
         return new FloatObject { result };
     }
 
@@ -76,8 +73,7 @@ Value BignumObject::mul(Env *env, Value arg) {
 
 Value BignumObject::div(Env *env, Value arg) {
     if (arg->is_float()) {
-        double current = strtod(m_bigint->to_string().c_str(), NULL);
-        auto result = current / arg->as_float()->to_double();
+        auto result = m_bigint->to_double() / arg->as_float()->to_double();
         return new FloatObject { result };
     }
 

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -1,6 +1,5 @@
 #include "natalie.hpp"
 
-#include "natalie/constants.hpp"
 #include <math.h>
 
 namespace Natalie {

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -231,14 +231,84 @@ Value IntegerObject::mod(Env *env, Value arg) const {
     return Value::integer(result);
 }
 
-Value IntegerObject::pow(Env *env, Value arg) const {
-    if (arg.is_fast_integer())
-        return Value::integer(::pow(m_integer, arg.get_fast_integer()));
+Value fast_pow(Env *env, nat_int_t a, nat_int_t b) {
+    if (b == 0)
+        return Value::integer(1);
+    if (b == 1)
+        return Value::integer(a);
+    if (a == 0)
+        return Value::integer(0);
 
-    arg.unguard();
-    arg->assert_type(env, Object::Type::Integer, "Integer");
-    auto result = ::pow(m_integer, arg->as_integer()->to_nat_int_t());
-    return Value::integer(result);
+    auto handle_overflow = [env, &a, &b](nat_int_t last_result, bool should_be_negative) -> Value {
+        auto result = BignumObject(a).pow(env, Value::integer(b));
+
+        // Check if the bignum pow overflowed.
+        if (result->is_float() && result->as_float()->is_infinite(env)) {
+            return result;
+        }
+
+        result = result->as_integer()->mul(env, Value::integer(should_be_negative ? -last_result : last_result));
+        return result;
+    };
+
+    nat_int_t result = 1;
+
+    bool negative = a < 0;
+    if (negative) a = -a;
+    negative = negative && (b % 2);
+
+    while (b != 0) {
+        while (b % 2 == 0) {
+            if (a > NAT_MAX_FIXNUM_SQRT) {
+                return handle_overflow(result, negative);
+            }
+            b >>= 1;
+            a *= a;
+        }
+
+        if (will_multiplication_overflow(result, a)) {
+            return handle_overflow(result, negative);
+        }
+        result *= a;
+        --b;
+    }
+    return Value::integer(negative ? -result : result);
+}
+
+Value IntegerObject::pow(Env *env, Value arg) {
+    nat_int_t nat_int;
+    if (arg.is_fast_integer()) {
+        nat_int = arg.get_fast_integer();
+    } else {
+        arg.unguard();
+
+        if (arg->is_float())
+            return FloatObject { to_nat_int_t() }.pow(env, arg);
+
+        if (!arg->is_integer()) {
+            auto coerced = Natalie::coerce(env, arg, this);
+            arg = coerced.second;
+            if (!coerced.first->is_integer()) {
+                return coerced.first->send(env, "**"_s, { arg });
+            }
+        }
+
+        arg->assert_type(env, Object::Type::Integer, "Integer");
+
+        if (arg->as_integer()->is_bignum())
+            return BignumObject { to_nat_int_t() }.pow(env, arg);
+
+        nat_int = arg->as_integer()->to_nat_int_t();
+    }
+
+    if (m_integer == 0 && nat_int < 0)
+        env->raise("ZeroDivisionError", "divided by 0");
+
+    // NATFIXME: If a negative number is passed we want to return a Rational
+    if (nat_int < 0)
+        NAT_NOT_YET_IMPLEMENTED();
+
+    return fast_pow(env, m_integer, nat_int);
 }
 
 Value IntegerObject::cmp(Env *env, Value arg) {

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -223,11 +223,15 @@ Value StringObject::mul(Env *env, Value arg) const {
     if (arg->as_integer()->has_to_be_bignum())
         arg->as_integer()->assert_fixnum(env);
 
+    auto nat_int = arg->as_integer()->to_nat_int_t();
+    if (nat_int && (std::numeric_limits<size_t>::max() / nat_int) < length())
+        env->raise("ArgumentError", "argument too big");
+
     StringObject *new_string = new StringObject { "", m_encoding };
     if (this->is_empty())
         return new_string;
 
-    for (nat_int_t i = 0; i < arg->as_integer()->to_nat_int_t(); i++) {
+    for (nat_int_t i = 0; i < nat_int; i++) {
         new_string->append(env, this);
     }
     return new_string;


### PR DESCRIPTION
This was some fun 😅 

There are some points to take a closer look here:
* Ruby does not allow pow-ing that results in *really* large numbers. There seems to be some threshold related to the size the resulting bigint would need. I tried to replicate the behavior but the boundary is different between natalie and MRI for now.
* I'm not sure if the constant definition in natalie/constants.hpp is ok? I wanted to use constexpr but I can not because sqrt is not a constexpr... Please correct me if we should use something else.
* BigInt's division algorithm seems to be doing something different that what MRI does. I did not want to investigate further for this PR but we might want to look at this (basically `-100000000000000000000000000000000000000000000000000 / 10000000000000000000000000000000000000001` returns `-9999999999` but it should be `-10000000000`)

[#201]

