### PR TITLE
Partial `String#length` & `String#size` spec compliance

### DIFF
--- a/spec/core/string/length_spec.rb
+++ b/spec/core/string/length_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/length'
+
+describe "String#length" do
+  it_behaves_like :string_length, :length
+end

--- a/spec/core/string/shared/length.rb
+++ b/spec/core/string/shared/length.rb
@@ -1,0 +1,55 @@
+# encoding: utf-8
+
+describe :string_length, shared: true do
+  it "returns the length of self" do
+    "".send(@method).should == 0
+    "\x00".send(@method).should == 1
+    "one".send(@method).should == 3
+    "two".send(@method).should == 3
+    "three".send(@method).should == 5
+    "four".send(@method).should == 4
+  end
+
+  xit "returns the length of a string in different encodings" do
+    utf8_str = 'こにちわ' * 100
+    utf8_str.size.should == 400
+    utf8_str.encode(Encoding::UTF_32BE).size.should == 400
+    utf8_str.encode(Encoding::SHIFT_JIS).size.should == 400
+  end
+
+  it "returns the length of the new self after encoding is changed" do
+    str = 'こにちわ'
+    str.send(@method)
+
+    str.force_encoding('BINARY').send(@method).should == 12
+  end
+
+  xit "returns the correct length after force_encoding(BINARY)" do
+    utf8 = "あ"
+    ascii = "a"
+    concat = utf8 + ascii
+
+    concat.encoding.should == Encoding::UTF_8
+    concat.bytesize.should == 4
+
+    concat.size.should == 2
+    concat.force_encoding(Encoding::ASCII_8BIT)
+    concat.size.should == 4
+  end
+
+  it "adds 1 for every invalid byte in UTF-8" do
+    "\xF4\x90\x80\x80".size.should == 4
+    "a\xF4\x90\x80\x80b".size.should == 6
+    "é\xF4\x90\x80\x80è".size.should == 6
+  end
+
+  xit "adds 1 (and not 2) for a incomplete surrogate in UTF-16" do
+    "\x00\xd8".force_encoding("UTF-16LE").size.should == 1
+    "\xd8\x00".force_encoding("UTF-16BE").size.should == 1
+  end
+
+  xit "adds 1 for a broken sequence in UTF-32" do
+    "\x04\x03\x02\x01".force_encoding("UTF-32LE").size.should == 1
+    "\x01\x02\x03\x04".force_encoding("UTF-32BE").size.should == 1
+  end
+end

--- a/spec/core/string/size_spec.rb
+++ b/spec/core/string/size_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/length'
+
+describe "String#size" do
+  it_behaves_like :string_length, :size
+end

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -32,10 +32,10 @@ char *StringObject::next_char(Env *env, char *buffer, size_t *index) {
         buffer[0] = str[i];
         if (((unsigned char)buffer[0] >> 3) == 30) { // 11110xxx, 4 bytes
             if (i + 3 >= len) raise_encoding_invalid_byte_sequence_error(env, i);
-            buffer[1] = str[++i];
-            buffer[2] = str[++i];
-            buffer[3] = str[++i];
-            buffer[4] = 0;
+            for (size_t j = 1; j < 5; j++)
+            {
+                buffer[j] = str[j];
+            }
         } else if (((unsigned char)buffer[0] >> 4) == 14) { // 1110xxxx, 3 bytes
             if (i + 2 >= len) raise_encoding_invalid_byte_sequence_error(env, i);
             buffer[1] = str[++i];


### PR DESCRIPTION
Adds spec files for `String#length` and `String#size`, and tweaks `StringObject::next_char`.

`StringObject::next_char` was being called by `StringObject::size`, after adding the size and length specs, I noticed the UTF-8 spec was failing. Using lldb, I noticed the while loop in `::size` was exiting early prior to completely processing the string due to index being incremented when processing UTF-8 strings.

The shared `length.rb` specs make calls to, `String#encode`, with encodings the project currently does not support. As well as, `String#bytesize`, which currently is unmapped in `binding_gen.rb`. I avoided implementing the various encodings being called in the shared spec, I feel like I'm way to naive to tackle that at the moment. However, I hope to look into implementing a spec compliant `#bytesize` next. Therefore,  I `x'd` out those specs to avoid errors, but it's been a while since I've contributed and do not remember if that's best practice. Please let me know what y'all prefer here.

