### PR TITLE
Fix error messages that may reference anonymous classes

### DIFF
--- a/include/natalie/array_packer/packer.hpp
+++ b/include/natalie/array_packer/packer.hpp
@@ -53,7 +53,7 @@ namespace ArrayPacker {
                         str->assert_type(env, Object::Type::String, "String");
                         string = str->as_string()->to_low_level_string();
                     } else {
-                        env->raise("TypeError", "no implicit conversion of {} into String", item->klass()->class_name_or_blank());
+                        env->raise("TypeError", "no implicit conversion of {} into String", item->klass()->inspect_str());
                         NAT_UNREACHABLE();
                     }
 
@@ -76,7 +76,7 @@ namespace ArrayPacker {
                             num->assert_type(env, Object::Type::Integer, "Integer");
                             integer = num->as_integer();
                         } else {
-                            env->raise("TypeError", "no implicit conversion of {} into Integer", item->klass()->class_name_or_blank());
+                            env->raise("TypeError", "no implicit conversion of {} into Integer", item->klass()->inspect_str());
                             NAT_UNREACHABLE();
                         }
 

--- a/include/natalie/method_object.hpp
+++ b/include/natalie/method_object.hpp
@@ -31,7 +31,7 @@ public:
         if (the_owner->is_class() && the_owner->as_class()->is_singleton())
             return StringObject::format(env, "#<Method: {}.{}(*)>", m_object->inspect_str(env), m_method->name());
         else
-            return StringObject::format(env, "#<Method: {}#{}(*)>", owner()->class_name_or_blank(), m_method->name());
+            return StringObject::format(env, "#<Method: {}#{}(*)>", owner()->inspect_str(), m_method->name());
     }
 
     int arity() { return m_method ? m_method->arity() : 0; }

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -61,13 +61,6 @@ public:
         return m_class_name;
     }
 
-    const String *class_name_or_blank() {
-        if (m_class_name)
-            return m_class_name.value();
-        else
-            return new String("");
-    }
-
     void set_class_name(const String *name) {
         assert(name);
         m_class_name = name;
@@ -100,6 +93,7 @@ public:
 
     bool is_method_defined(Env *, Value) const;
 
+    const String *inspect_str();
     Value inspect(Env *);
     Value name(Env *);
     Value attr_reader(Env *, size_t, Value *);

--- a/src/class_object.cpp
+++ b/src/class_object.cpp
@@ -5,7 +5,7 @@ namespace Natalie {
 Value ClassObject::initialize(Env *env, Value superclass, Block *block) {
     if (superclass) {
         if (!superclass->is_class()) {
-            env->raise("TypeError", "superclass must be a Class ({} given)", superclass->klass()->class_name_or_blank());
+            env->raise("TypeError", "superclass must be a Class ({} given)", superclass->klass()->inspect_str());
         }
     } else {
         superclass = GlobalEnv::the()->Object();

--- a/src/exception_object.cpp
+++ b/src/exception_object.cpp
@@ -16,7 +16,7 @@ void ExceptionObject::build_backtrace(Env *env) {
 
 Value ExceptionObject::initialize(Env *env, Value message) {
     if (!message) {
-        auto name = m_klass->class_name_or_blank();
+        auto name = m_klass->inspect_str();
         set_message(new StringObject { *name });
     } else {
         if (!message->is_string()) {
@@ -28,7 +28,7 @@ Value ExceptionObject::initialize(Env *env, Value message) {
 }
 
 Value ExceptionObject::inspect(Env *env) {
-    return StringObject::format(env, "#<{}: {}>", m_klass->inspect_str(env), m_message);
+    return StringObject::format(env, "#<{}: {}>", m_klass->inspect_str(), m_message);
 }
 
 Value ExceptionObject::backtrace(Env *env) {

--- a/src/file_object.cpp
+++ b/src/file_object.cpp
@@ -35,7 +35,7 @@ Value FileObject::initialize(Env *env, Value filename, Value flags_obj, Block *b
             break;
         }
         default:
-            env->raise("TypeError", "no implicit conversion of {} into String", flags_obj->klass()->class_name_or_blank());
+            env->raise("TypeError", "no implicit conversion of {} into String", flags_obj->klass()->inspect_str());
         }
     }
     int mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;

--- a/src/float_object.cpp
+++ b/src/float_object.cpp
@@ -384,7 +384,7 @@ Value FloatObject::divmod(Env *env, Value arg) {
     }
     arg.unguard();
 
-    if (!arg->is_numeric()) env->raise("TypeError", "{} can't be coerced into Float", arg->klass()->class_name_or_blank());
+    if (!arg->is_numeric()) env->raise("TypeError", "{} can't be coerced into Float", arg->klass()->inspect_str());
     if (arg->is_float() && arg->as_float()->is_nan()) env->raise("FloatDomainError", "NaN");
     if (arg->is_float() && arg->as_float()->is_zero()) env->raise("ZeroDivisionError", "divided by 0");
     if (arg->is_integer() && arg->as_integer()->is_zero()) env->raise("ZeroDivisionError", "divided by 0");
@@ -486,7 +486,7 @@ bool FloatObject::optimized_method(SymbolObject *method_name) {
                                                                                                                     \
         if (!lhs->is_float()) return lhs.send(env, SymbolObject::intern(NAT_QUOTE(op)), { rhs });                   \
         if (!rhs->is_float()) {                                                                                     \
-            env->raise("ArgumentError", "comparison of Float with {} failed", rhs->klass()->class_name_or_blank()); \
+            env->raise("ArgumentError", "comparison of Float with {} failed", rhs->klass()->inspect_str());         \
         }                                                                                                           \
                                                                                                                     \
         if (lhs->as_float()->is_nan() || rhs->as_float()->is_nan()) {                                               \

--- a/src/hash_object.cpp
+++ b/src/hash_object.cpp
@@ -271,7 +271,7 @@ Value HashObject::inspect(Env *env) {
             else
                 obj = new StringObject("?");
             if (!obj->is_string())
-                obj = StringObject::format(env, "#<{}:{}>", obj->klass()->class_name_or_blank(), int_to_hex_string(obj->object_id(), false));
+                obj = StringObject::format(env, "#<{}:{}>", obj->klass()->inspect_str(), int_to_hex_string(obj->object_id(), false));
             return obj->as_string();
         };
 
@@ -368,7 +368,7 @@ Value HashObject::dig(Env *env, size_t argc, Value *args) {
         return val;
 
     if (!val->respond_to(env, dig))
-        env->raise("TypeError", "{} does not have #dig method", val->klass()->class_name_or_blank());
+        env->raise("TypeError", "{} does not have #dig method", val->klass()->inspect_str());
 
     return val.send(env, dig, argc - 1, args + 1);
 }
@@ -558,7 +558,7 @@ Value HashObject::to_h(Env *env, Block *block) {
         if (!result->is_array() && result->respond_to(env, "to_ary"_s))
             result = result.send(env, "to_ary"_s);
         if (!result->is_array())
-            env->raise("TypeError", "wrong element type {} (expected array)", result->klass()->class_name_or_blank());
+            env->raise("TypeError", "wrong element type {} (expected array)", result->klass()->inspect_str());
         auto result_array = result->as_array();
         if (result_array->size() != 2)
             env->raise("ArgumentError", "element has wrong array length (expected 2, was {})", result_array->size());

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -143,7 +143,7 @@ Value IoObject::seek(Env *env, Value amount_value, Value whence_value) const {
             break;
         }
         default:
-            env->raise("TypeError", "no implicit conversion of {} into Integer", whence_value->klass()->class_name_or_blank());
+            env->raise("TypeError", "no implicit conversion of {} into Integer", whence_value->klass()->inspect_str());
         }
     }
     int result = lseek(m_fileno, amount, whence);

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -157,7 +157,7 @@ Value KernelModule::Float(Env *env, Value value, Value kwargs) {
         }
     }
     if (exception)
-        env->raise("TypeError", "can't convert {} into Float", value->klass()->inspect_str(env));
+        env->raise("TypeError", "can't convert {} into Float", value->klass()->inspect_str());
     else
         return nullptr;
 }
@@ -202,7 +202,7 @@ Value KernelModule::Hash(Env *env, Value value) {
     }
 
     if (!value->respond_to(env, "to_hash"_s)) {
-        env->raise("TypeError", "can't convert {} into Hash", value->klass()->inspect_str(env));
+        env->raise("TypeError", "can't convert {} into Hash", value->klass()->inspect_str());
     }
 
     value = value.send(env, "to_hash"_s);
@@ -230,7 +230,7 @@ Value KernelModule::inspect(Env *env) {
     if (is_module() && as_module()->class_name()) {
         return new StringObject { *as_module()->class_name().value() };
     } else {
-        return StringObject::format(env, "#<{}:{}>", klass()->inspect_str(env), pointer_id());
+        return StringObject::format(env, "#<{}:{}>", klass()->inspect_str(), pointer_id());
     }
 }
 
@@ -286,7 +286,7 @@ Value KernelModule::method(Env *env, Value name) {
         Method *method = singleton_class()->find_method(env, name_symbol);
         if (method) {
             if (method->is_undefined()) {
-                env->raise("NoMethodError", "undefined method `{}' for {}:Class", name_symbol->inspect_str(env), m_klass->class_name_or_blank());
+                env->raise("NoMethodError", "undefined method `{}' for {}:Class", name_symbol->inspect_str(env), m_klass->inspect_str());
             }
             return new MethodObject { this, method };
         }
@@ -294,7 +294,7 @@ Value KernelModule::method(Env *env, Value name) {
     Method *method = m_klass->find_method(env, name_symbol);
     if (method)
         return new MethodObject { this, method };
-    env->raise("NoMethodError", "undefined method `{}' for {}:Class", name_symbol->inspect_str(env), m_klass->class_name_or_blank());
+    env->raise("NoMethodError", "undefined method `{}' for {}:Class", name_symbol->inspect_str(env), m_klass->inspect_str());
 }
 
 Value KernelModule::methods(Env *env) {
@@ -348,7 +348,7 @@ Value KernelModule::raise(Env *env, Value klass, Value message) {
         Value arg = klass;
         if (arg->is_class()) {
             klass = arg->as_class();
-            message = new StringObject { *arg->as_class()->class_name_or_blank() };
+            message = new StringObject { *arg->as_class()->inspect_str() };
         } else if (arg->is_string()) {
             klass = find_top_level_const(env, "RuntimeError"_s)->as_class();
             message = arg;
@@ -382,7 +382,7 @@ Value KernelModule::sleep(Env *env, Value length) {
         ts.tv_nsec = (secs - ts.tv_sec) * 1000000000;
         nanosleep(&ts, nullptr);
     } else {
-        env->raise("TypeError", "can't convert {} into time interval", length->klass()->inspect_str(env));
+        env->raise("TypeError", "can't convert {} into time interval", length->klass()->inspect_str());
     }
     return length;
 }

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -237,7 +237,7 @@ void print_exception_with_backtrace(Env *env, ExceptionObject *exception) {
         StringObject *line = (*backtrace)[0]->as_string();
         dprintf(fd, "%s: ", line->c_str());
     }
-    dprintf(fd, "%s (%s)\n", exception->message()->c_str(), exception->klass()->class_name_or_blank()->c_str());
+    dprintf(fd, "%s (%s)\n", exception->message()->c_str(), exception->klass()->inspect_str()->c_str());
 }
 
 void handle_top_level_exception(Env *env, ExceptionObject *exception, bool run_exit_handlers) {
@@ -271,8 +271,8 @@ ArrayObject *to_ary(Env *env, Value obj, bool raise_for_non_array) {
             ary = new ArrayObject { obj };
             return ary->as_array();
         } else {
-            auto *class_name = obj->klass()->class_name_or_blank();
-            env->raise("TypeError", "can't convert {} to Array ({}#to_ary gives {})", class_name, class_name, ary->klass()->class_name_or_blank());
+            auto *class_name = obj->klass()->inspect_str();
+            env->raise("TypeError", "can't convert {} to Array ({}#to_ary gives {})", class_name, class_name, ary->klass()->inspect_str());
         }
     } else {
         return new ArrayObject { obj };

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -414,7 +414,7 @@ Value StringObject::force_encoding(Env *env, Value encoding) {
         set_encoding(find_encoding_by_name(env, encoding->as_string()->to_low_level_string())->num());
         break;
     default:
-        env->raise("TypeError", "no implicit conversion of {} into String", encoding->klass()->class_name_or_blank());
+        env->raise("TypeError", "no implicit conversion of {} into String", encoding->klass()->inspect_str());
     }
     return this;
 }
@@ -497,7 +497,7 @@ Value StringObject::sub(Env *env, Value find, Value replacement, Block *block) {
         StringObject *expanded_replacement;
         return regexp_sub(env, find->as_regexp(), replacement->as_string(), &match, &expanded_replacement);
     } else {
-        env->raise("TypeError", "wrong argument type {} (expected Regexp)", find->klass()->class_name_or_blank());
+        env->raise("TypeError", "wrong argument type {} (expected Regexp)", find->klass()->inspect_str());
     }
 }
 
@@ -522,7 +522,7 @@ Value StringObject::gsub(Env *env, Value find, Value replacement_value, Block *b
         } while (match);
         return result;
     } else {
-        env->raise("TypeError", "wrong argument type {} (expected Regexp)", find->klass()->class_name_or_blank());
+        env->raise("TypeError", "wrong argument type {} (expected Regexp)", find->klass()->inspect_str());
     }
 }
 
@@ -649,7 +649,7 @@ Value StringObject::split(Env *env, Value splitter, Value max_count_value) {
         }
         return ary;
     } else {
-        env->raise("TypeError", "wrong argument type {} (expected Regexp))", splitter->klass()->class_name_or_blank());
+        env->raise("TypeError", "wrong argument type {} (expected Regexp))", splitter->klass()->inspect_str());
     }
 }
 


### PR DESCRIPTION
Error using `class_name_or_blank`:

```rb
anonymous_class = Class.new
'string'.force_encoding anonymous_class.new # => TypeError (no implicit conversion of  into String)
```

Error using `inspect_str`:

```rb
anonymous_class = Class.new
'string'.force_encoding anonymous_class.new # => TypeError (no implicit conversion of #<Class:0x7fcf44827020> into String)
```