### PR TITLE
Make Fixnum and Bignum deprecated constants

### DIFF
--- a/include/natalie/constant.hpp
+++ b/include/natalie/constant.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include "natalie/forward.hpp"
+#include "natalie/value.hpp"
+
+namespace Natalie {
+class Constant : public Cell {
+public:
+    Constant(SymbolObject *name, Value value)
+        : m_name(name)
+        , m_value(value) {};
+
+    SymbolObject *name() const { return m_name; }
+    Value value() const { return m_value; }
+    bool is_private() const { return m_private; }
+    void set_private(bool is_private) { this->m_private = is_private; }
+    bool is_deprecated() const { return m_deprecated; }
+    void set_deprecated(bool is_deprecated) { this->m_deprecated = is_deprecated; }
+
+    void visit_children(Visitor &visitor) {
+        visitor.visit(m_value);
+    }
+
+private:
+    SymbolObject *m_name;
+    Value m_value;
+    bool m_private = false;
+    bool m_deprecated = false;
+};
+}

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -3,6 +3,7 @@
 #include <assert.h>
 #include <string.h>
 
+#include "natalie/constant.hpp"
 #include "natalie/env.hpp"
 #include "natalie/forward.hpp"
 #include "natalie/global_env.hpp"
@@ -142,9 +143,7 @@ public:
 
 protected:
     Env *m_env { nullptr };
-    TM::Hashmap<SymbolObject *, Value> m_constants {};
-    TM::Hashmap<SymbolObject *> m_private_constants {};
-    TM::Hashmap<SymbolObject *> m_deprecated_constants {};
+    TM::Hashmap<SymbolObject *, Constant *> m_constants {};
     Optional<const String *> m_class_name {};
     ClassObject *m_superclass { nullptr };
     TM::Hashmap<SymbolObject *, Method *> m_methods {};

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -115,6 +115,7 @@ public:
     virtual Value protected_method(Env *, size_t, Value *) override;
     Value public_method(Env *, size_t, Value *);
 
+    Value deprecate_constant(Env *, size_t, Value *);
     Value private_constant(Env *, size_t, Value *);
     Value public_constant(Env *, size_t, Value *);
 
@@ -143,6 +144,7 @@ protected:
     Env *m_env { nullptr };
     TM::Hashmap<SymbolObject *, Value> m_constants {};
     TM::Hashmap<SymbolObject *> m_private_constants {};
+    TM::Hashmap<SymbolObject *> m_deprecated_constants {};
     Optional<const String *> m_class_name {};
     ClassObject *m_superclass { nullptr };
     TM::Hashmap<SymbolObject *, Method *> m_methods {};

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -659,6 +659,7 @@ gen.binding('Module', 'class_eval', 'ModuleObject', 'module_eval', argc: 0, pass
 gen.binding('Module', 'const_defined?', 'ModuleObject', 'const_defined', argc: 1, pass_env: true, pass_block: false, return_type: :bool)
 gen.binding('Module', 'const_set', 'ModuleObject', 'const_set', argc: 2, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Module', 'define_method', 'ModuleObject', 'define_method', argc: 1, pass_env: true, pass_block: true, return_type: :Object)
+gen.binding('Module', 'deprecate_constant', 'ModuleObject', 'deprecate_constant', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Module', 'extend', 'ModuleObject', 'extend', argc: 1.., pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Module', 'include', 'ModuleObject', 'include', argc: 1.., pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('Module', 'include?', 'ModuleObject', 'does_include_module', argc: 1, pass_env: true, pass_block: false, return_type: :bool)

--- a/spec/core/integer/constants_spec.rb
+++ b/spec/core/integer/constants_spec.rb
@@ -1,0 +1,25 @@
+require_relative '../../spec_helper'
+
+describe "Fixnum" do
+  it "is unified into Integer" do
+    suppress_warning do
+      Fixnum.should equal(Integer)
+    end
+  end
+
+  it "is deprecated" do
+    -> { Fixnum }.should complain(/constant ::Fixnum is deprecated/)
+  end
+end
+
+describe "Bignum" do
+  it "is unified into Integer" do
+    suppress_warning do
+      Bignum.should equal(Integer)
+    end
+  end
+
+  it "is deprecated" do
+    -> { Bignum }.should complain(/constant ::Bignum is deprecated/)
+  end
+end

--- a/spec/core/module/deprecate_constant_spec.rb
+++ b/spec/core/module/deprecate_constant_spec.rb
@@ -1,0 +1,70 @@
+require_relative '../../spec_helper'
+
+describe "Module#deprecate_constant" do
+  before :each do
+    @module = Module.new
+    @value = :value
+    # NATFIXME: Constant definition with this syntax does not work yet
+    # @module::PUBLIC1 = @value
+    # @module::PUBLIC2 = @value
+    # @module::PRIVATE = @value
+    @module.const_set(:PUBLIC1, @value)
+    @module.const_set(:PUBLIC2, @value)
+    @module.const_set(:PRIVATE, @value)
+
+    @module.private_constant :PRIVATE
+    @module.deprecate_constant :PRIVATE
+  end
+
+  describe "when accessing the deprecated module" do
+    it "passes the accessing" do
+      @module.deprecate_constant :PUBLIC1
+
+      value = nil
+      -> {
+        value = @module::PUBLIC1
+      }.should complain(/warning: constant .+::PUBLIC1 is deprecated/)
+      value.should equal(@value)
+
+      -> { @module::PRIVATE }.should raise_error(NameError)
+    end
+
+    it "warns with a message" do
+      @module.deprecate_constant :PUBLIC1
+
+      -> { @module::PUBLIC1 }.should complain(/warning: constant .+::PUBLIC1 is deprecated/)
+      # NATFIXME: Implement Module#const_get
+      # -> { @module.const_get :PRIVATE }.should complain(/warning: constant .+::PRIVATE is deprecated/)
+    end
+
+    ruby_version_is '2.7' do
+      # NATFIXME: Support Warning
+      xit "does not warn if Warning[:deprecated] is false" do
+        @module.deprecate_constant :PUBLIC1
+
+        deprecated = Warning[:deprecated]
+        begin
+          Warning[:deprecated] = false
+          -> { @module::PUBLIC1 }.should_not complain
+        ensure
+          Warning[:deprecated] = deprecated
+        end
+      end
+    end
+  end
+
+  it "accepts multiple symbols and strings as constant names" do
+    @module.deprecate_constant "PUBLIC1", :PUBLIC2
+
+    -> { @module::PUBLIC1 }.should complain(/warning: constant .+::PUBLIC1 is deprecated/)
+    -> { @module::PUBLIC2 }.should complain(/warning: constant .+::PUBLIC2 is deprecated/)
+  end
+
+  it "returns self" do
+    @module.deprecate_constant(:PUBLIC1).should equal(@module)
+  end
+
+  it "raises a NameError when given an undefined name" do
+    -> { @module.deprecate_constant :UNDEFINED }.should raise_error(NameError)
+  end
+end

--- a/src/bignum_object.cpp
+++ b/src/bignum_object.cpp
@@ -110,7 +110,7 @@ Value BignumObject::pow(Env *env, Value arg) {
 
         arg->assert_type(env, Object::Type::Integer, "Integer");
         if (arg->as_integer()->is_bignum()) {
-            env->warn("warning: in a**b, b may be too big");
+            env->warn("in a**b, b may be too big");
             return FloatObject { m_bigint->to_double() }.pow(env, arg);
         }
 
@@ -129,7 +129,7 @@ Value BignumObject::pow(Env *env, Value arg) {
     size_t length = m_bigint->to_string().length();
     constexpr const size_t BIGINT_LIMIT = 8 * 1024 * 1024;
     if (length > BIGINT_LIMIT || length * nat_int > BIGINT_LIMIT) {
-        env->warn("warning: in a**b, b may be too big");
+        env->warn("in a**b, b may be too big");
         return FloatObject { m_bigint->to_double() }.pow(env, arg);
     }
 

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -97,6 +97,7 @@ void Env::raise_errno() {
 
 void Env::warn(const String *message) {
     Value _stderr = global_get("$stderr"_s);
+    message = String::format("{}:{}: warning: {}", m_file, m_line, message);
     _stderr.send(this, "puts"_s, { new StringObject { message } });
 }
 

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -105,7 +105,7 @@ Value ModuleObject::const_find(Env *env, SymbolObject *name, ConstLookupSearchMo
         if (search_mode == ConstLookupSearchMode::Strict && search_parent->m_private_constants.get(name))
             env->raise("NameError", "private constant {}::{} referenced", search_parent->inspect_str(), name->c_str());
         if (search_parent->m_deprecated_constants.get(name)) {
-            env->warn("warning: constant {}::{} is deprecated", search_parent->inspect_str(), name->c_str());
+            env->warn("constant {}::{} is deprecated", search_parent->inspect_str(), name->c_str());
         }
         return val;
     }

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -75,8 +75,11 @@ Env *build_top_env() {
     ClassObject *Integer = Numeric->subclass(env, "Integer", Object::Type::Integer);
     global_env->set_Integer(Integer);
     Object->const_set("Integer"_s, Integer);
-    Object->const_set("Fixnum"_s, Integer);
-    Object->const_set("Bignum"_s, Integer);
+    Value old_integer_constants[2] = { "Fixnum"_s, "Bignum"_s };
+    for (auto name : old_integer_constants) {
+        Object->const_set(name->as_symbol(), Integer);
+    }
+    Object->deprecate_constant(env, 2, old_integer_constants);
 
     ClassObject *Float = Numeric->subclass(env, "Float", Object::Type::Float);
     global_env->set_Float(Float);

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -207,7 +207,10 @@ def not_supported_on(_)
 end
 
 def suppress_warning
+  old_stderr = $stderr
+  $stderr = IOStub.new
   yield
+  $stderr = old_stderr
 end
 
 def before(type = :each, &block)


### PR DESCRIPTION
This PR also adds support for deprecated constants by implementing `Module#deprecated_constant` and improves our `warn` method on the Env class to match ruby's behavior with warnings.