### PR TITLE
Fix variable names in IncludeExpectation methods

### DIFF
--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -775,7 +775,7 @@ class IncludeExpectation
   def match(subject)
     @values.each do |value|
       unless subject.include?(value)
-        raise SpecFailedException, "#{subject.inspect} should include #{@value.inspect}"
+        raise SpecFailedException, "#{subject.inspect} should include #{value.inspect}"
       end
     end
   end
@@ -783,7 +783,7 @@ class IncludeExpectation
   def inverted_match(subject)
     @values.each do |value|
       if subject.include?(value)
-        raise SpecFailedException, "#{subject.inspect} should not include #{@value.inspect}"
+        raise SpecFailedException, "#{subject.inspect} should not include #{value.inspect}"
       end
     end
   end


### PR DESCRIPTION
These lines should be referencing the local variable `value` not the instance variable `@value`