### PR TITLE
Make `Module#private` spec-compliant

### DIFF
--- a/include/natalie/method.hpp
+++ b/include/natalie/method.hpp
@@ -4,27 +4,24 @@
 #include "natalie/env.hpp"
 #include "natalie/forward.hpp"
 #include "natalie/gc.hpp"
-#include "natalie/method_visibility.hpp"
 #include "natalie/module_object.hpp"
 
 namespace Natalie {
 
 class Method : public Cell {
 public:
-    Method(const char *name, ModuleObject *owner, MethodFnPtr fn, int arity, MethodVisibility visibility)
+    Method(const char *name, ModuleObject *owner, MethodFnPtr fn, int arity)
         : m_name { name }
         , m_owner { owner }
         , m_fn { fn }
         , m_arity { arity }
-        , m_undefined { !fn }
-        , m_visibility { visibility } { }
+        , m_undefined { !fn } { }
 
-    Method(const char *name, ModuleObject *owner, Block *block, MethodVisibility visibility)
+    Method(const char *name, ModuleObject *owner, Block *block)
         : m_name { name }
         , m_owner { owner }
         , m_arity { block->arity() }
-        , m_env { new Env(*block->env()) }
-        , m_visibility { visibility } {
+        , m_env { new Env(*block->env()) } {
         block->copy_fn_pointer_to_method(this);
         assert(m_env);
     }
@@ -65,9 +62,6 @@ public:
     const String *name() { return &m_name; }
     ModuleObject *owner() { return m_owner; }
 
-    MethodVisibility visibility() { return m_visibility; }
-    void set_visibility(MethodVisibility visibility) { m_visibility = visibility; }
-
     int arity() const { return m_arity; }
 
     virtual void visit_children(Visitor &visitor) override final {
@@ -86,6 +80,5 @@ private:
     int m_arity { 0 };
     Env *m_env { nullptr };
     bool m_undefined { false };
-    MethodVisibility m_visibility { MethodVisibility::Public };
 };
 }

--- a/include/natalie/method_info.hpp
+++ b/include/natalie/method_info.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "natalie/gc.hpp"
+#include "natalie/method_visibility.hpp"
+
+namespace Natalie {
+
+class MethodInfo : public Cell {
+public:
+    MethodInfo(const char *name, MethodVisibility visibility)
+        : m_name { name }
+        , m_visibility { visibility } {}
+
+    MethodVisibility visibility() { return m_visibility; }
+    void set_visibility(MethodVisibility visibility) { m_visibility = visibility; }
+
+    virtual void visit_children(Visitor &visitor) override final {}
+
+    virtual void gc_inspect(char *buf, size_t len) const override {
+        snprintf(buf, len, "<MethodInfo %p name='%s'>", this, m_name);
+    }
+
+private:
+    const char *m_name {};
+    MethodVisibility m_visibility { MethodVisibility::Public };
+};
+}

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -7,6 +7,7 @@
 #include "natalie/forward.hpp"
 #include "natalie/global_env.hpp"
 #include "natalie/macros.hpp"
+#include "natalie/method_info.hpp"
 #include "natalie/method_visibility.hpp"
 #include "natalie/object.hpp"
 #include "tm/optional.hpp"
@@ -87,9 +88,13 @@ public:
     virtual SymbolObject *undefine_method(Env *, SymbolObject *) override;
 
     void methods(Env *, ArrayObject *, bool = true);
+    void define_method(Env *, SymbolObject *, Method *, MethodVisibility);
+    void set_method_visibility(Env *, SymbolObject *, MethodVisibility);
+    MethodVisibility get_method_visibility(Env *, SymbolObject *);
+    MethodInfo *find_method_info(Env *, SymbolObject *);
     Method *find_method(Env *, SymbolObject *, ModuleObject ** = nullptr, Method * = nullptr) const;
 
-    Value instance_methods(Env *, Value, std::function<bool(Method *)>);
+    Value instance_methods(Env *, Value, std::function<bool(MethodVisibility)>);
     Value instance_methods(Env *, Value);
     Value private_instance_methods(Env *, Value);
     Value protected_instance_methods(Env *, Value);
@@ -146,6 +151,7 @@ protected:
     Optional<const String *> m_class_name {};
     ClassObject *m_superclass { nullptr };
     TM::Hashmap<SymbolObject *, Method *> m_methods {};
+    TM::Hashmap<SymbolObject *, MethodInfo *> m_method_info {};
     TM::Hashmap<SymbolObject *, Value> m_class_vars {};
     Vector<ModuleObject *> m_included_modules {};
     MethodVisibility m_method_visibility { MethodVisibility::Public };

--- a/spec/language/fixtures/private.rb
+++ b/spec/language/fixtures/private.rb
@@ -1,0 +1,59 @@
+module Private
+  class A
+    def foo
+      "foo"
+    end
+
+    private
+    def bar
+      "bar"
+    end
+  end
+
+  class B
+    def foo
+      "foo"
+    end
+
+    private
+
+    def self.public_defs_method; 0; end
+
+    class C
+      def baz
+        "baz"
+      end
+    end
+
+    class << self
+      def public_class_method1; 1; end
+      private
+      def private_class_method1; 1; end
+    end
+
+    def bar
+      "bar"
+    end
+  end
+
+  module D
+    private
+    def foo
+      "foo"
+    end
+  end
+
+   class E
+     include D
+   end
+
+   class G
+     def foo
+       "foo"
+     end
+   end
+
+   class H < A
+     private :foo
+   end
+end

--- a/spec/language/private_spec.rb
+++ b/spec/language/private_spec.rb
@@ -1,0 +1,69 @@
+require_relative '../spec_helper'
+require_relative 'fixtures/private'
+
+describe "The private keyword" do
+  # NATFIXME: Make Kernel#methods spec-compliant
+  xit "marks following methods as being private" do
+    a = Private::A.new
+    a.methods.should_not include(:bar)
+    -> { a.bar }.should raise_error(NoMethodError)
+
+    b = Private::B.new
+    b.methods.should_not include(:bar)
+    -> { b.bar }.should raise_error(NoMethodError)
+  end
+
+  # def expr.meth() methods are always public
+  it "has no effect on def expr.meth() methods" do
+    Private::B.public_defs_method.should == 0
+  end
+
+  it "is overridden when a new class is opened" do
+    c = Private::B::C.new
+    c.methods.should include(:baz)
+    c.baz
+    Private::B.public_class_method1.should == 1
+    -> { Private::B.private_class_method1 }.should raise_error(NoMethodError)
+  end
+
+  it "is no longer in effect when the class is closed" do
+    b = Private::B.new
+    b.methods.should include(:foo)
+    b.foo
+  end
+
+  it "changes visibility of previously called method" do
+    klass = Class.new do
+      def foo
+       "foo"
+      end
+    end
+    f = klass.new
+    f.foo
+    klass.class_eval do
+      private :foo
+    end
+    -> { f.foo }.should raise_error(NoMethodError)
+  end
+
+  # NATFIXME: Update compiler/pass1 to support namespaced module/class declarations
+  xit "changes visibility of previously called methods with same send/call site" do
+    g = ::Private::G.new
+    -> {
+      2.times do
+        g.foo
+        module ::Private
+          class G
+            private :foo
+          end
+        end
+      end
+    }.should raise_error(NoMethodError)
+  end
+
+  it "changes the visibility of the existing method in the subclass" do
+    ::Private::A.new.foo.should == 'foo'
+    -> { ::Private::H.new.foo }.should raise_error(NoMethodError)
+    ::Private::H.new.send(:foo).should == 'foo'
+  end
+end


### PR DESCRIPTION
For example:

```rb
class A
  def foo
    "bar"
  end
end

class B < A
  private :foo
end

A.new.foo # => "bar"
B.new.foo # => NoMethodError
B.remove_method :foo
B.new.foo # => "bar"
```