### PR TITLE
Make Kernel#instance_method_get spec compliant

### DIFF
--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -149,6 +149,7 @@ public:
     SexpObject *as_sexp_object_for_method_binding();
 
     SymbolObject *to_symbol(Env *, Conversion);
+    SymbolObject *to_instance_variable_name(Env *);
 
     const String *identifier_str(Env *, Conversion);
 

--- a/include/natalie/symbol_object.hpp
+++ b/include/natalie/symbol_object.hpp
@@ -50,7 +50,7 @@ public:
     }
 
     bool is_ivar_name() {
-        return strlen(m_name) > 0 && m_name[0] == '@';
+        return strlen(m_name) > 1 && m_name[0] == '@' && isalpha(m_name[1]);
     }
 
     bool is_cvar_name() {

--- a/spec/core/kernel/instance_variable_get_spec.rb
+++ b/spec/core/kernel/instance_variable_get_spec.rb
@@ -1,0 +1,105 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Kernel#instance_variable_get" do
+  before :each do
+    @obj = Object.new
+    @obj.instance_variable_set("@test", :test)
+  end
+
+  it "tries to convert the passed argument to a String using #to_str" do
+    obj = mock("to_str")
+    obj.should_receive(:to_str).and_return("@test")
+    @obj.instance_variable_get(obj)
+  end
+
+  it "returns the value of the passed instance variable that is referred to by the conversion result" do
+    obj = mock("to_str")
+    obj.stub!(:to_str).and_return("@test")
+    @obj.instance_variable_get(obj).should == :test
+  end
+
+  it "returns nil when the referred instance variable does not exist" do
+    @obj.instance_variable_get(:@does_not_exist).should be_nil
+  end
+
+  it "raises a TypeError when the passed argument does not respond to #to_str" do
+    -> { @obj.instance_variable_get(Object.new) }.should raise_error(TypeError)
+  end
+
+  it "raises a TypeError when the passed argument can't be converted to a String" do
+    obj = mock("to_str")
+    obj.stub!(:to_str).and_return(123)
+    -> { @obj.instance_variable_get(obj) }.should raise_error(TypeError)
+  end
+
+  it "raises a NameError when the conversion result does not start with an '@'" do
+    obj = mock("to_str")
+    obj.stub!(:to_str).and_return("test")
+    -> { @obj.instance_variable_get(obj) }.should raise_error(NameError)
+  end
+
+  it "raises a NameError when passed just '@'" do
+    obj = mock("to_str")
+    obj.stub!(:to_str).and_return('@')
+    -> { @obj.instance_variable_get(obj) }.should raise_error(NameError)
+  end
+end
+
+describe "Kernel#instance_variable_get when passed Symbol" do
+  before :each do
+    @obj = Object.new
+    @obj.instance_variable_set("@test", :test)
+  end
+
+  it "returns the value of the instance variable that is referred to by the passed Symbol" do
+    @obj.instance_variable_get(:@test).should == :test
+  end
+
+  it "raises a NameError when passed :@ as an instance variable name" do
+    -> { @obj.instance_variable_get(:"@") }.should raise_error(NameError)
+  end
+
+  it "raises a NameError when the passed Symbol does not start with an '@'" do
+    -> { @obj.instance_variable_get(:test) }.should raise_error(NameError)
+  end
+
+  it "raises a NameError when the passed Symbol is an invalid instance variable name" do
+    -> { @obj.instance_variable_get(:"@0") }.should raise_error(NameError)
+  end
+end
+
+describe "Kernel#instance_variable_get when passed String" do
+  before :each do
+    @obj = Object.new
+    @obj.instance_variable_set("@test", :test)
+  end
+
+  it "returns the value of the instance variable that is referred to by the passed String" do
+    @obj.instance_variable_get("@test").should == :test
+  end
+
+  it "raises a NameError when the passed String does not start with an '@'" do
+    -> { @obj.instance_variable_get("test") }.should raise_error(NameError)
+  end
+
+  it "raises a NameError when the passed String is an invalid instance variable name" do
+    -> { @obj.instance_variable_get("@0") }.should raise_error(NameError)
+  end
+
+  it "raises a NameError when passed '@' as an instance variable name" do
+    -> { @obj.instance_variable_get("@") }.should raise_error(NameError)
+  end
+end
+
+describe "Kernel#instance_variable_get when passed Integer" do
+  before :each do
+    @obj = Object.new
+    @obj.instance_variable_set("@test", :test)
+  end
+
+  it "raises a TypeError" do
+    -> { @obj.instance_variable_get(10) }.should raise_error(TypeError)
+    -> { @obj.instance_variable_get(-10) }.should raise_error(TypeError)
+  end
+end

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -255,7 +255,7 @@ Value KernelModule::instance_variable_get(Env *env, Value name_val) {
     if (is_integer() || is_float()) {
         return NilObject::the();
     }
-    auto name = name_val->to_symbol(env, Object::Conversion::Strict);
+    auto name = name_val->to_instance_variable_name(env);
     return ivar_get(env, name);
 }
 

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -247,7 +247,7 @@ Value KernelModule::instance_variable_defined(Env *env, Value name_val) {
     if (is_nil() || is_boolean() || is_integer() || is_float() || is_symbol()) {
         return FalseObject::the();
     }
-    auto name = name_val->to_symbol(env, Object::Conversion::Strict);
+    auto name = name_val->to_instance_variable_name(env);
     return ivar_defined(env, name);
 }
 
@@ -261,7 +261,7 @@ Value KernelModule::instance_variable_get(Env *env, Value name_val) {
 
 Value KernelModule::instance_variable_set(Env *env, Value name_val, Value value) {
     this->assert_not_frozen(env);
-    auto name = name_val->to_symbol(env, Object::Conversion::Strict);
+    auto name = name_val->to_instance_variable_name(env);
     ivar_set(env, name, value);
     return value;
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -296,6 +296,34 @@ SymbolObject *Object::to_symbol(Env *env, Conversion conversion) {
     }
 }
 
+SymbolObject *Object::to_instance_variable_name(Env *env) {
+    StringObject *name = nullptr;
+
+    if (is_symbol()) {
+        name = as_symbol()->to_s(env);
+    } else if (is_string()) {
+        name = as_string();
+    } else if (respond_to(env, "to_str"_s)) {
+        auto value = send(env, "to_str"_s);
+
+        if (value->is_string()) {
+            name = value->as_string();
+        }
+    }
+
+    if (!name) {
+        env->raise("TypeError", "{} is not a symbol nor a string", inspect_str(env));
+    }
+
+    SymbolObject *symbol = name->to_symbol(env);
+
+    if (!symbol->is_ivar_name()) {
+        env->raise("NameError", "`{}' is not allowed as an instance variable name", name->c_str());
+    }
+
+    return symbol;
+}
+
 void Object::set_singleton_class(ClassObject *klass) {
     klass->set_is_singleton(true);
     m_singleton_class = klass;


### PR DESCRIPTION
Some follow up changes to #358

In order to make `Kernel#instance_method_get` spec compliant I've added a new `Object::to_instance_variable_name` method to encapsulate the necessary type checking and conversion, and I've changed `SymbolObject::is_ivar_name` so that names like `@`, `@@`, and `@0` aren't considered valid ivar names when passed as strings.

I've also changed `instance_variable_defined` and `instance_variable_set` to use the new `to_instance_variable_name` method for consistency.

