### PR TITLE
Make `Kernel#send` spec-compliant

### DIFF
--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -90,7 +90,8 @@ public:
     void set_method_visibility(Env *, SymbolObject *, MethodVisibility);
     MethodVisibility get_method_visibility(Env *, SymbolObject *);
     MethodInfo *find_method_info(Env *, SymbolObject *);
-    Method *find_method(Env *, SymbolObject *, ModuleObject ** = nullptr, Method * = nullptr) const;
+    Method *find_method(Env *, SymbolObject *, ModuleObject ** = nullptr, Method ** = nullptr) const;
+    Method *find_method(Env *, SymbolObject *, Method *) const;
     void assert_method_defined(Env *, SymbolObject *, Method *);
 
     Value instance_method(Env *, Value);

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -212,7 +212,7 @@ public:
         return send(env, name, args.size(), const_cast<Value *>(data(args)), block);
     }
 
-    Method *find_method(Env *, SymbolObject *, MethodVisibility, ModuleObject ** = nullptr, Method * = nullptr);
+    Method *find_method(Env *, SymbolObject *, MethodVisibility);
 
     Value dup(Env *);
 

--- a/spec/core/kernel/send_spec.rb
+++ b/spec/core/kernel/send_spec.rb
@@ -1,0 +1,68 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative '../../shared/basicobject/send'
+
+describe "Kernel#send" do
+  it "invokes the named public method" do
+    class KernelSpecs::Foo
+      def bar
+        'done'
+      end
+    end
+    KernelSpecs::Foo.new.send(:bar).should == 'done'
+  end
+
+  it "invokes the named alias of a public method" do
+    class KernelSpecs::Foo
+      def bar
+        'done'
+      end
+      alias :aka :bar
+    end
+    KernelSpecs::Foo.new.send(:aka).should == 'done'
+  end
+
+  it "invokes the named protected method" do
+    class KernelSpecs::Foo
+      protected
+      def bar
+        'done'
+      end
+    end
+    KernelSpecs::Foo.new.send(:bar).should == 'done'
+  end
+
+  it "invokes the named private method" do
+    class KernelSpecs::Foo
+      private
+      def bar
+        'done2'
+      end
+    end
+    KernelSpecs::Foo.new.send(:bar).should == 'done2'
+  end
+
+  it "invokes the named alias of a private method" do
+    class KernelSpecs::Foo
+      private
+      def bar
+        'done2'
+      end
+      alias :aka :bar
+    end
+    KernelSpecs::Foo.new.send(:aka).should == 'done2'
+  end
+
+  it "invokes the named alias of a protected method" do
+    class KernelSpecs::Foo
+      protected
+      def bar
+        'done2'
+      end
+      alias :aka :bar
+    end
+    KernelSpecs::Foo.new.send(:aka).should == 'done2'
+  end
+
+  it_behaves_like :basicobject_send, :send
+end

--- a/spec/shared/basicobject/send.rb
+++ b/spec/shared/basicobject/send.rb
@@ -1,0 +1,128 @@
+module SendSpecs
+end
+
+describe :basicobject_send, shared: true do
+  it "invokes the named method" do
+    class SendSpecs::Foo
+      def bar
+        'done'
+      end
+    end
+    SendSpecs::Foo.new.send(@method, :bar).should == 'done'
+  end
+
+  it "accepts a String method name" do
+    class SendSpecs::Foo
+      def bar
+        'done'
+      end
+    end
+    SendSpecs::Foo.new.send(@method, 'bar').should == 'done'
+  end
+
+  it "invokes a class method if called on a class" do
+    class SendSpecs::Foo
+      def self.bar
+        'done'
+      end
+    end
+    SendSpecs::Foo.send(@method, :bar).should == 'done'
+  end
+
+  it "raises a TypeError if the method name is not a string or symbol" do
+    -> { SendSpecs.send(@method, nil) }.should raise_error(TypeError, /not a symbol nor a string/)
+    -> { SendSpecs.send(@method, 42) }.should raise_error(TypeError, /not a symbol nor a string/)
+    -> { SendSpecs.send(@method, 3.14) }.should raise_error(TypeError, /not a symbol nor a string/)
+    -> { SendSpecs.send(@method, true) }.should raise_error(TypeError, /not a symbol nor a string/)
+  end
+
+  it "raises a NameError if the corresponding method can't be found" do
+    class SendSpecs::Foo
+      def bar
+        'done'
+      end
+    end
+    -> { SendSpecs::Foo.new.send(@method, :syegsywhwua) }.should raise_error(NameError)
+  end
+
+  it "raises a NameError if the corresponding singleton method can't be found" do
+    class SendSpecs::Foo
+      def self.bar
+        'done'
+      end
+    end
+    -> { SendSpecs::Foo.send(@method, :baz) }.should raise_error(NameError)
+  end
+
+  it "raises an ArgumentError if no arguments are given" do
+    class SendSpecs::Foo; end
+    -> { SendSpecs::Foo.new.send @method }.should raise_error(ArgumentError)
+  end
+
+  it "raises an ArgumentError if called with more arguments than available parameters" do
+    class SendSpecs::Foo
+      def bar; end
+    end
+
+    -> { SendSpecs::Foo.new.send(@method, :bar, :arg) }.should raise_error(ArgumentError)
+  end
+
+  it "raises an ArgumentError if called with fewer arguments than required parameters" do
+    class SendSpecs::Foo
+      def foo(arg); end
+    end
+
+    -> { SendSpecs::Foo.new.send(@method, :foo) }.should raise_error(ArgumentError)
+  end
+
+  it "succeeds if passed an arbitrary number of arguments as a splat parameter" do
+    class SendSpecs::Foo
+      def baz(*args) args end
+    end
+
+    begin
+      SendSpecs::Foo.new.send(@method, :baz).should == []
+      SendSpecs::Foo.new.send(@method, :baz, :quux).should == [:quux]
+      SendSpecs::Foo.new.send(@method, :baz, :quux, :foo).should == [:quux, :foo]
+    rescue
+      fail
+    end
+  end
+
+  it "succeeds when passing 1 or more arguments as a required and a splat parameter" do
+    class SendSpecs::Foo
+      def baz(first, *rest) [first, *rest] end
+    end
+
+    SendSpecs::Foo.new.send(@method, :baz, :quux).should == [:quux]
+    SendSpecs::Foo.new.send(@method, :baz, :quux, :foo).should == [:quux, :foo]
+  end
+
+  it "succeeds when passing 0 arguments to a method with one parameter with a default" do
+    class SendSpecs::Foo
+      def foo(first = true) first end
+    end
+
+    begin
+      SendSpecs::Foo.new.send(@method, :foo).should == true
+      SendSpecs::Foo.new.send(@method, :foo, :arg).should == :arg
+    rescue
+      fail
+    end
+  end
+
+  it "has a negative arity" do
+    method(@method).arity.should < 0
+  end
+
+  it "invokes module methods with super correctly" do
+    m1 = Module.new { def foo(ary); ary << :m1; end; }
+    m2 = Module.new { def foo(ary = []); super(ary); ary << :m2; end; }
+    c2 = Class.new do
+      include m1
+      include m2
+    end
+
+    c2.new.send(@method, :foo, *[[]]).should == %i[m1 m2]
+  end
+end

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -692,7 +692,7 @@ const String *int_to_hex_string(nat_int_t num, bool capitalize) {
 
 Value super(Env *env, Value self, size_t argc, Value *args, Block *block) {
     auto current_method = env->current_method();
-    auto super_method = self->klass()->find_method(env, SymbolObject::intern(current_method->name()), nullptr, current_method);
+    auto super_method = self->klass()->find_method(env, SymbolObject::intern(current_method->name()), current_method);
     if (!super_method)
         env->raise("NoMethodError", "super: no superclass method `{}' for {}", current_method->name(), self->inspect_str(env));
     assert(super_method != current_method);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -527,10 +527,10 @@ Value Object::send(Env *env, size_t argc, Value *args, Block *block) {
     return send(env->caller(), name, argc - 1, args + 1, block);
 }
 
-Method *Object::find_method(Env *env, SymbolObject *method_name, MethodVisibility visibility_at_least, ModuleObject **matching_class_or_module, Method *after_method) {
+Method *Object::find_method(Env *env, SymbolObject *method_name, MethodVisibility visibility_at_least) {
     auto singleton = singleton_class();
     if (singleton) {
-        Method *method = singleton_class()->find_method(env, method_name, matching_class_or_module, after_method);
+        Method *method = singleton_class()->find_method(env, method_name);
         if (method) {
             if (!method->is_undefined()) {
                 MethodVisibility visibility = singleton_class()->get_method_visibility(env, method_name);
@@ -547,7 +547,7 @@ Method *Object::find_method(Env *env, SymbolObject *method_name, MethodVisibilit
         }
     }
     ModuleObject *klass = this->klass();
-    Method *method = klass->find_method(env, method_name, matching_class_or_module);
+    Method *method = klass->find_method(env, method_name);
     if (method && !method->is_undefined()) {
         MethodVisibility visibility = klass->get_method_visibility(env, method_name);
         if (visibility >= visibility_at_least) {
@@ -560,7 +560,7 @@ Method *Object::find_method(Env *env, SymbolObject *method_name, MethodVisibilit
     } else if (method_name == "inspect"_s) {
         env->raise("NoMethodError", "undefined method `inspect' for #<{}:{}>", klass->inspect_str(), int_to_hex_string(object_id(), false));
     } else if (is_module()) {
-        env->raise("NoMethodError", "undefined method `{}' for {}:{}", method_name->c_str(), klass->as_module()->inspect_str(), klass->inspect_str());
+        env->raise("NoMethodError", "undefined method `{}' for {}:{}", method_name->c_str(), as_module()->inspect_str(), klass->inspect_str());
     } else {
         env->raise("NoMethodError", "undefined method `{}' for {}", method_name->c_str(), inspect_str(env));
     }

--- a/test/natalie/class_test.rb
+++ b/test/natalie/class_test.rb
@@ -68,6 +68,8 @@ describe 'class' do
   end
 end
 
+module M0; end
+
 module M1
   def m1
     'm1'
@@ -79,6 +81,8 @@ module M2
     'm2'
   end
 end
+
+module M3; end
 
 # reopen module
 module M1
@@ -92,7 +96,9 @@ class ExtendTest
 end
 
 class IncludeTest
+  prepend M0
   include M1, M2
+  include M3
 end
 
 class IncludeTestOverride
@@ -126,7 +132,7 @@ describe 'class' do
 
   describe 'include' do
     it 'includes methods from a module' do
-      IncludeTest.ancestors.should == [IncludeTest, M1, M2, Object, Kernel, BasicObject]
+      IncludeTest.ancestors.should == [M0, IncludeTest, M3, M1, M2, Object, Kernel, BasicObject]
       IncludeTest.new.m1.should == 'm1'
       IncludeTest.new.m1b.should == 'm1b'
       IncludeTestOverride.new.m1.should == 'my m1'


### PR DESCRIPTION
From [Calling Methods ¶ Method Lookup](https://ruby-doc.org/core-3.0.0/doc/syntax/calling_methods_rdoc.html#label-Method+Lookup):

> Here is the order of method lookup for the receiver's class or module `R`:
> 
> - The prepended modules of `R` in reverse order
> - For a matching method in `R`
> - The included modules of `R` in reverse order
> 
> If `R` is a class with a superclass, this is repeated with `R`'s superclass until a method is found.

On Natalie's `master` branch, included modules are actually looked up in _forward_ order. This can be fixed by adding them to `m_included_modules` at the index that is right after the class into which they are included (instead of adding them at the end of the list).

Additionally, the `after_method` parameter of `find_method` only keeps its change to `nullptr` in the current method scope (or recursive `find_method` calls), but not across method scopes that are at the same level in the class hierarchy. This can be fixed by using a double pointer:

`Method *find_method(..., Method *after_method)` | `Method *find_method(..., Method **after_method)`
--- | ---
![graphviz (0)](https://user-images.githubusercontent.com/70830482/148338610-d8dc0dc6-9dfe-481c-b626-227957376a5e.png) | ![graphviz (1)](https://user-images.githubusercontent.com/70830482/148338608-037ddaae-8b82-48b1-98e9-2afa686a0a75.png)

 