### PR TITLE
Inline Value::integer call statements in pass4

### DIFF
--- a/lib/natalie/compiler/pass4.rb
+++ b/lib/natalie/compiler/pass4.rb
@@ -673,7 +673,13 @@ module Natalie
 
       def process_set(exp)
         (_, name, value) = exp
-        decl "#{name} = #{process_atom value};"
+        case value[0]
+        when :new
+          (_, klass, *args) = value
+          decl "#{name} = new #{klass} { #{args.map { |a| process_atom(a) }.join(', ') } };"
+        else
+          decl "#{name} = #{process_atom value};"
+        end
         name
       end
 
@@ -687,6 +693,11 @@ module Natalie
       def process_sexp(exp, name = nil, type = 'Value ')
         debug_info(exp)
         (fn, *args) = exp
+        
+        if fn == :"Value::integer"
+          return "Value::integer(#{args.map { |a| process_atom(a) }.join(', ') })"
+        end
+
         if VOID_FUNCTIONS.include?(fn)
           if METHODS.include?(fn)
             (obj, *args) = args


### PR DESCRIPTION
This stops us from always creating ValueInteger\d variables, just to
reassign and discard them in the next statement.

This also applies the same new-call inlining to variable assignment,
which we already had for variable declaration.

---

This makes 
```rb
a = 1
a = 2
a = [1, 2 , 3]
```

compile to
```c++
Value a2 = Value { NilObject::the() };
env->set_file(source_files[0]); env->set_line(1);
a2 = Value::integer(1);
env->set_file(source_files[0]); env->set_line(2);
a2 = Value::integer(2);
Value arr1 = new ArrayObject {  };
env->set_file(source_files[0]); env->set_line(3);
arr1->as_array()->push(Value::integer(1));
env->set_file(source_files[0]); env->set_line(3);
arr1->as_array()->push(Value::integer(2));
env->set_file(source_files[0]); env->set_line(3);
arr1->as_array()->push(Value::integer(3));
a2 = arr1;
```
insetead of 
```c++
Value a2 = Value { NilObject::the() };
env->set_file(source_files[0]); env->set_line(1);
Value Valueinteger3 = Value::integer(1);
a2 = Valueinteger3;
env->set_file(source_files[0]); env->set_line(2);
Value Valueinteger4 = Value::integer(2);
a2 = Valueinteger4;
Value arr1 = new ArrayObject {  };
env->set_file(source_files[0]); env->set_line(3);
Value Valueinteger5 = Value::integer(1);
arr1->as_array()->push(Valueinteger5);
env->set_file(source_files[0]); env->set_line(3);
Value Valueinteger6 = Value::integer(2);
arr1->as_array()->push(Valueinteger6);
env->set_file(source_files[0]); env->set_line(3);
Value Valueinteger7 = Value::integer(3);
arr1->as_array()->push(Valueinteger7);
a2 = arr1;
```` 