### PR TITLE
Initialize arrays with an initializer list when applicable in pass 1

### DIFF
--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -1009,6 +1009,7 @@ void ArrayObject::push_splat(Env *env, Value val) {
         val = val.send(env, "to_a"_s);
     }
     if (val->is_array()) {
+        m_vector.set_capacity(m_vector.capacity() + val->as_array()->size());
         for (Value v : *val->as_array()) {
             push(*v);
         }


### PR DESCRIPTION
### Initialize arrays with an initializer list when applicable in pass 1

This removes a chain of push calls we would do otherwise.

### Ensure capacity on ArrayObject::push_splat

This can circumvent useless reallocation and copies in the underlying
vector.