### PR TITLE
Make Range#inspect spec compliant

### DIFF
--- a/spec/core/range/inspect_spec.rb
+++ b/spec/core/range/inspect_spec.rb
@@ -1,0 +1,45 @@
+require_relative '../../spec_helper'
+
+describe "Range#inspect" do
+  it "provides a printable form, using #inspect to convert the start and end objects" do
+    ('A'..'Z').inspect.should == '"A".."Z"'
+    ('A'...'Z').inspect.should == '"A"..."Z"'
+
+    (0..21).inspect.should == "0..21"
+    (-8..0).inspect.should ==  "-8..0"
+    (-411..959).inspect.should == "-411..959"
+    (0xfff..0xfffff).inspect.should == "4095..1048575"
+    (0.5..2.4).inspect.should == "0.5..2.4"
+  end
+
+  it "works for endless ranges" do
+    eval("(1..)").inspect.should ==  "1.."
+    eval("(0.1...)").inspect.should ==  "0.1..."
+  end
+
+  ruby_version_is '2.7' do
+    it "works for beginless ranges" do
+      eval("(..1)").inspect.should ==  "..1"
+      eval("(...0.1)").inspect.should ==  "...0.1"
+    end
+
+    it "works for nil ... nil ranges" do
+      eval("(..nil)").inspect.should ==  "nil..nil"
+      eval("(nil...)").inspect.should ==  "nil...nil"
+    end
+  end
+
+  ruby_version_is ''...'2.7' do
+    it "returns a tainted string if either end is tainted" do
+      (("a".taint)..."c").inspect.tainted?.should be_true
+      ("a"...("c".taint)).inspect.tainted?.should be_true
+      ("a"..."c").taint.inspect.tainted?.should be_true
+    end
+
+    it "returns a untrusted string if either end is untrusted" do
+      (("a".untrust)..."c").inspect.untrusted?.should be_true
+      ("a"...("c".untrust)).inspect.untrusted?.should be_true
+      ("a"..."c").untrust.inspect.untrusted?.should be_true
+    end
+  end
+end

--- a/src/range_object.cpp
+++ b/src/range_object.cpp
@@ -92,19 +92,19 @@ Value RangeObject::first(Env *env, Value n) {
 }
 
 Value RangeObject::inspect(Env *env) {
-    if (m_exclude_end) {
-        if (m_end->is_nil()) {
-            return StringObject::format(env, "{}...", m_begin->inspect_str(env));
-        } else {
-            return StringObject::format(env, "{}...{}", m_begin->inspect_str(env), m_end->inspect_str(env));
-        }
-    } else {
-        if (m_end->is_nil()) {
-            return StringObject::format(env, "{}..", m_begin->inspect_str(env));
-        } else {
-            return StringObject::format(env, "{}..{}", m_begin->inspect_str(env), m_end->inspect_str(env));
-        }
+    StringObject *string = new StringObject {};
+    if (!m_begin->is_nil() || m_end->is_nil()) {
+        string->append(env, m_begin->inspect_str(env));
     }
+    if (m_exclude_end) {
+        string->append(env, "...");
+    } else {
+        string->append(env, "..");
+    }
+    if (!m_end->is_nil() || m_begin->is_nil()) {
+        string->append(env, m_end->inspect_str(env));
+    }
+    return string;
 }
 
 bool RangeObject::eq(Env *env, Value other_value) {


### PR DESCRIPTION
Currently it doesn't handle a nil begin value:

    $ bin/natalie
    nat> (..3).inspect
    "nil..3"

    $ irb
    irb(main):001:0> (..3).inspect
    => "..3"

I've re-implemented `RangeObject::inspect` to use append instead of `StringObject::format` in order to avoid nesting the ifs and eliminate the duplication between them.