### PR TITLE
Socket: pack and unpack sockaddrs

### DIFF
--- a/include/natalie/string.hpp
+++ b/include/natalie/string.hpp
@@ -211,6 +211,13 @@ public:
         append(buf);
     }
 
+    void append(int i) {
+        int length = snprintf(NULL, 0, "%i", i);
+        char buf[length + 1];
+        snprintf(buf, length + 1, "%i", i);
+        append(buf);
+    }
+
     void append(const char *str) {
         if (!str) return;
         size_t new_length = strlen(str);

--- a/lib/socket.rb
+++ b/lib/socket.rb
@@ -93,6 +93,9 @@ class Socket < BasicSocket
     END
 
     __define_method__ :unpack_sockaddr_in, [:sockaddr], <<-END
+      if (sockaddr->is_a(env, self->const_find(env, "Addrinfo"_s, Object::ConstLookupSearchMode::NotStrict)))
+          sockaddr = sockaddr->send(env, "sockaddr"_s);
+
       sockaddr->assert_type(env, Object::Type::String, "String");
 
       if (sockaddr->as_string()->length() == sizeof(struct sockaddr_in6)) {
@@ -126,8 +129,17 @@ class Socket < BasicSocket
 end
 
 class Addrinfo
+  def initialize(sockaddr, family = nil, socktype = nil, protocol = nil)
+    @sockaddr = sockaddr
+    @family = family
+    @socktype = socktype
+    @protocol = protocol
+  end
+
+  attr_reader :sockaddr
+
   def self.tcp(ip, port)
-    Addrinfo.new # TODO
+    Addrinfo.new(Socket.pack_sockaddr_in(port, ip))
   end
 
   def self.udp(ip, port)

--- a/lib/socket.rb
+++ b/lib/socket.rb
@@ -172,6 +172,10 @@ class Addrinfo
     Addrinfo.new # TODO
   end
 
+  def self.unix(path)
+    Addrinfo.new(Socket.pack_sockaddr_un(path))
+  end
+
   def afamily
     # TODO
   end

--- a/lib/socket.rb
+++ b/lib/socket.rb
@@ -142,6 +142,9 @@ class Socket < BasicSocket
     END
 
     __define_method__ :unpack_sockaddr_un, [:sockaddr], <<-END
+      if (sockaddr->is_a(env, self->const_find(env, "Addrinfo"_s, Object::ConstLookupSearchMode::NotStrict)))
+          sockaddr = sockaddr->send(env, "sockaddr"_s);
+
       sockaddr->assert_type(env, Object::Type::String, "String");
 
       if (sockaddr->as_string()->length() != sizeof(struct sockaddr_un))
@@ -162,7 +165,7 @@ class Addrinfo
     @protocol = protocol
   end
 
-  attr_reader :sockaddr
+  attr_reader :sockaddr, :family
 
   def self.tcp(ip, port)
     Addrinfo.new(Socket.pack_sockaddr_in(port, ip))

--- a/lib/socket.rb
+++ b/lib/socket.rb
@@ -47,7 +47,7 @@ class Socket < BasicSocket
   end
 
   class << self
-    __define_method__ :sockaddr_in, [:port, :host], <<-END
+    __define_method__ :pack_sockaddr_in, [:port, :host], <<-END
       if (host->is_nil())
           host = new StringObject { "127.0.0.1" };
       if (host->is_string() && host->as_string()->is_empty())
@@ -120,10 +120,8 @@ class Socket < BasicSocket
           env->raise("ArgumentError", "not an AF_INET/AF_INET6 sockaddr");
       }
     END
-  end
 
-  def self.pack_sockaddr_in(port, host)
-    # TODO
+    alias sockaddr_in pack_sockaddr_in
   end
 end
 

--- a/spec/library/socket/shared/pack_sockaddr.rb
+++ b/spec/library/socket/shared/pack_sockaddr.rb
@@ -71,7 +71,7 @@ describe :socket_pack_sockaddr_un, shared: true do
 
     it "handles correctly paths with multibyte chars" do
       sockaddr_un = Socket.send(@method, '/home/вася/sock')
-      path = Socket.unpack_sockaddr_un(sockaddr_un).encode('UTF-8', 'UTF-8')
+      path = Socket.unpack_sockaddr_un(sockaddr_un).encode('UTF-8') # NATFIXME: this was `.encode('UTF-8', 'UTF-8')` but we don't support that yet
       path.should == '/home/вася/sock'
     end
   end

--- a/spec/library/socket/socket/pack_sockaddr_in_spec.rb
+++ b/spec/library/socket/socket/pack_sockaddr_in_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../spec_helper'
+require_relative '../fixtures/classes'
+require_relative '../shared/pack_sockaddr'
+
+describe "Socket#pack_sockaddr_in" do
+  it_behaves_like :socket_pack_sockaddr_in, :pack_sockaddr_in
+end

--- a/spec/library/socket/socket/pack_sockaddr_un_spec.rb
+++ b/spec/library/socket/socket/pack_sockaddr_un_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../spec_helper'
+require_relative '../fixtures/classes'
+require_relative '../shared/pack_sockaddr'
+
+describe "Socket#pack_sockaddr_un" do
+  it_behaves_like :socket_pack_sockaddr_un, :pack_sockaddr_un
+end

--- a/spec/library/socket/socket/sockaddr_un_spec.rb
+++ b/spec/library/socket/socket/sockaddr_un_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../spec_helper'
+require_relative '../fixtures/classes'
+require_relative '../shared/pack_sockaddr'
+
+describe "Socket#sockaddr_un" do
+  it_behaves_like :socket_pack_sockaddr_un, :sockaddr_un
+end

--- a/spec/library/socket/socket/unpack_sockaddr_in_spec.rb
+++ b/spec/library/socket/socket/unpack_sockaddr_in_spec.rb
@@ -32,16 +32,15 @@ describe "Socket.unpack_sockaddr_in" do
     end
   end
 
-  # NATFIXME: unix sockets
-  #with_feature :unix_socket do
-  #  it "raises an ArgumentError when the sin_family is not AF_INET" do
-  #    sockaddr = Socket.sockaddr_un '/tmp/x'
-  #    -> { Socket.unpack_sockaddr_in sockaddr }.should raise_error(ArgumentError)
-  #  end
+  with_feature :unix_socket do
+    it "raises an ArgumentError when the sin_family is not AF_INET" do
+      sockaddr = Socket.sockaddr_un '/tmp/x'
+      -> { Socket.unpack_sockaddr_in sockaddr }.should raise_error(ArgumentError)
+    end
 
-  #  it "raises an ArgumentError when passed addrinfo is not AF_INET/AF_INET6" do
-  #    addrinfo = Addrinfo.unix('/tmp/sock')
-  #    -> { Socket.unpack_sockaddr_in(addrinfo) }.should raise_error(ArgumentError)
-  #  end
-  #end
+    it "raises an ArgumentError when passed addrinfo is not AF_INET/AF_INET6" do
+      addrinfo = Addrinfo.unix('/tmp/sock')
+      -> { Socket.unpack_sockaddr_in(addrinfo) }.should raise_error(ArgumentError)
+    end
+  end
 end

--- a/spec/library/socket/socket/unpack_sockaddr_in_spec.rb
+++ b/spec/library/socket/socket/unpack_sockaddr_in_spec.rb
@@ -1,0 +1,47 @@
+require_relative '../spec_helper'
+require_relative '../fixtures/classes'
+
+describe "Socket.unpack_sockaddr_in" do
+  it "decodes the host name and port number of a packed sockaddr_in" do
+    sockaddr = Socket.sockaddr_in 3333, '127.0.0.1'
+    Socket.unpack_sockaddr_in(sockaddr).should == [3333, '127.0.0.1']
+  end
+
+  it "gets the hostname and port number from a passed Addrinfo" do
+    addrinfo = Addrinfo.tcp('127.0.0.1', 3333)
+    Socket.unpack_sockaddr_in(addrinfo).should == [3333, '127.0.0.1']
+  end
+
+  describe 'using an IPv4 address' do
+    it 'returns an Array containing the port and IP address' do
+      port = 80
+      ip   = '127.0.0.1'
+      addr = Socket.pack_sockaddr_in(port, ip)
+
+      Socket.unpack_sockaddr_in(addr).should == [port, ip]
+    end
+  end
+
+  describe 'using an IPv6 address' do
+    it 'returns an Array containing the port and IP address' do
+      port = 80
+      ip   = '::1'
+      addr = Socket.pack_sockaddr_in(port, ip)
+
+      Socket.unpack_sockaddr_in(addr).should == [port, ip]
+    end
+  end
+
+  # NATFIXME: unix sockets
+  #with_feature :unix_socket do
+  #  it "raises an ArgumentError when the sin_family is not AF_INET" do
+  #    sockaddr = Socket.sockaddr_un '/tmp/x'
+  #    -> { Socket.unpack_sockaddr_in sockaddr }.should raise_error(ArgumentError)
+  #  end
+
+  #  it "raises an ArgumentError when passed addrinfo is not AF_INET/AF_INET6" do
+  #    addrinfo = Addrinfo.unix('/tmp/sock')
+  #    -> { Socket.unpack_sockaddr_in(addrinfo) }.should raise_error(ArgumentError)
+  #  end
+  #end
+end

--- a/spec/library/socket/socket/unpack_sockaddr_un_spec.rb
+++ b/spec/library/socket/socket/unpack_sockaddr_un_spec.rb
@@ -1,0 +1,26 @@
+require_relative '../spec_helper'
+require_relative '../fixtures/classes'
+
+with_feature :unix_socket do
+  describe 'Socket.unpack_sockaddr_un' do
+    it 'decodes sockaddr to unix path' do
+      sockaddr = Socket.sockaddr_un('/tmp/sock')
+      Socket.unpack_sockaddr_un(sockaddr).should == '/tmp/sock'
+    end
+
+    it 'returns unix path from a passed Addrinfo' do
+      addrinfo = Addrinfo.unix('/tmp/sock')
+      Socket.unpack_sockaddr_un(addrinfo).should == '/tmp/sock'
+    end
+
+    it 'raises an ArgumentError when the sa_family is not AF_UNIX' do
+      sockaddr = Socket.sockaddr_in(0, '127.0.0.1')
+      -> { Socket.unpack_sockaddr_un(sockaddr) }.should raise_error(ArgumentError)
+    end
+
+    it 'raises an ArgumentError when passed addrinfo is not AF_UNIX' do
+      addrinfo = Addrinfo.tcp('127.0.0.1', 0)
+      -> { Socket.unpack_sockaddr_un(addrinfo) }.should raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/library/socket/spec_helper.rb
+++ b/spec/library/socket/spec_helper.rb
@@ -1,9 +1,9 @@
 require_relative '../../spec_helper'
 require 'socket'
 
-# NATFIXME: not sure what this does yet
+# NATFIXME: enable as needed
 #MSpec.enable_feature :sock_packet if Socket.const_defined?(:SOCK_PACKET)
-#MSpec.enable_feature :unix_socket unless PlatformGuard.windows?
+MSpec.enable_feature :unix_socket unless PlatformGuard.windows?
 #MSpec.enable_feature :udp_cork if Socket.const_defined?(:UDP_CORK)
 #MSpec.enable_feature :tcp_cork if Socket.const_defined?(:TCP_CORK)
 #MSpec.enable_feature :pktinfo if Socket.const_defined?(:IP_PKTINFO)

--- a/test/support/mspec.rb
+++ b/test/support/mspec.rb
@@ -1,0 +1,10 @@
+class MSpec
+  def self.features
+    @features || {}
+  end
+
+  def self.enable_feature(name)
+    @features ||= {}
+    @features[name] = true
+  end
+end

--- a/test/support/platform_guard.rb
+++ b/test/support/platform_guard.rb
@@ -1,0 +1,5 @@
+class PlatformGuard
+  def self.windows?
+    false
+  end
+end

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -1,5 +1,6 @@
 require_relative 'formatters/default_formatter'
 require_relative 'formatters/yaml_formatter'
+require_relative 'mspec'
 require_relative 'platform_guard'
 require_relative 'version'
 require 'tempfile'
@@ -136,6 +137,12 @@ end
 def specify(&block)
   return xit(nil, &block) if $context.last.skip
   @specs << [$context.dup, nil, block]
+end
+
+def with_feature(name)
+  if MSpec.features[name]
+    yield
+  end
 end
 
 def nan_value

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -1,5 +1,6 @@
 require_relative 'formatters/default_formatter'
 require_relative 'formatters/yaml_formatter'
+require_relative 'platform_guard'
 require_relative 'version'
 require 'tempfile'
 


### PR DESCRIPTION
My goal is to get the [Socket](https://ruby-doc.org/stdlib-2.5.3/libdoc/socket/rdoc/Socket.html) library sufficient enough that I can build a web server. Packing and unpacking sockaddrs seemed like a good place to start...