### PR TITLE
Disallow overwriting optimized methods

### DIFF
--- a/bin/natalie
+++ b/bin/natalie
@@ -78,14 +78,18 @@ OptionParser.new do |opts|
     options[:keep_cpp] = true
   end
 
+  opts.on('--allow-overwrites', 'Allows overwriting of all stdlib object methods. This may have a significant performance impact.') do
+    options[:allow_overwrites] = true
+  end
+
   opts.on('--nat-parser', "Enable use of Natalie's own Ruby parser (rather than the ruby_parser gem)") do
     options[:nat_parser] = true
   end
-  
+
   opts.on('--log-load-error', 'Log a message when natalie cannot load a required file') do
     options[:log_load_error] = true
   end
-  
+
   opts.on('--experimental-repl-v2', 'Enable the new REPL (not available with self-hosted Natalie)') do
     options[:experimental_repl_v2] = true
   end

--- a/include/natalie.hpp
+++ b/include/natalie.hpp
@@ -60,6 +60,7 @@ namespace Natalie {
 extern const char *ruby_platform;
 extern const char *ruby_release_date;
 extern const char *ruby_revision;
+extern bool allow_overwrites;
 
 extern "C" {
 #include "onigmo.h"

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -144,6 +144,15 @@ public:
     bool has_env() { return !!m_env; }
     Env *env() { return m_env; }
 
+    void add_non_overwritable_method(SymbolObject *method) {
+        m_non_overwritable_methods.set(method);
+    }
+
+    void add_non_overwritable_methods(const TM::Vector<SymbolObject *> &methods) {
+        for (auto method : methods)
+            add_non_overwritable_method(method);
+    }
+
     virtual void visit_children(Visitor &) override final;
 
     virtual void gc_inspect(char *buf, size_t len) const override {
@@ -164,6 +173,8 @@ protected:
     Vector<ModuleObject *> m_included_modules {};
     MethodVisibility m_method_visibility { MethodVisibility::Public };
     bool m_module_function { false };
+
+    TM::Hashmap<SymbolObject *> m_non_overwritable_methods {};
 };
 
 }

--- a/lib/natalie/compiler.rb
+++ b/lib/natalie/compiler.rb
@@ -96,16 +96,19 @@ module Natalie
         compile_cxx_flags: cxx_flags,
         compile_ld_flags: [],
         source_path: @path,
+        allow_overwrites: allow_overwrites?,
       }
     end
 
     def transform(ast)
       @context = build_context
 
-      ast = Pass0c.new(@context).go(ast)
-      if debug == 'p0c'
-        pp ast
-        exit
+      unless allow_overwrites?
+        ast = Pass0c.new(@context).go(ast)
+        if debug == 'p0c'
+          pp ast
+          exit
+        end
       end
 
       ast = Pass1.new(@context).go(ast)
@@ -152,6 +155,10 @@ module Natalie
 
     def debug
       options[:debug]
+    end
+
+    def allow_overwrites?
+      !!options[:allow_overwrites]
     end
 
     def build

--- a/lib/natalie/compiler/pass4.rb
+++ b/lib/natalie/compiler/pass4.rb
@@ -111,6 +111,10 @@ module Natalie
             .sub('/*' + 'NAT_OBJ_INIT' + '*/') { obj_init_lines.join("\n") }
             .sub('/*' + 'NAT_EVAL_INIT' + '*/') { init_matter }
             .sub('/*' + 'NAT_EVAL_BODY' + '*/') { @decl.join("\n") + "\n" + result }
+            .sub(
+              '/*' + 'NAT_ALLOW_OVERWRITES' + '*/',
+              "Natalie::allow_overwrites = #{@compiler_context[:allow_overwrites]};",
+            )
         reindent(out)
       end
 

--- a/spec/core/integer/plus_spec.rb
+++ b/spec/core/integer/plus_spec.rb
@@ -40,4 +40,20 @@ describe "Integer#+" do
       -> { @bignum + :symbol}.should raise_error(TypeError)
     end
   end
+
+  it "can be redefined" do
+    code = <<~RUBY
+      class Integer
+        alias_method :old_plus, :+
+        def +(other)
+          self - other
+        end
+      end
+      result = 1 + 2
+      Integer.alias_method :+, :old_plus
+      print result
+    RUBY
+    # NATALIE-SPECIFIC: Natalie does not allow overrides of Integer#+ without using --allow-overwrites
+    ruby_exe(code, args: '--allow-overwrites').should == "-1"
+  end
 end

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -104,7 +104,12 @@ void Env::raise_name_error(SymbolObject *name, const String *message) {
 
 void Env::warn(const String *message) {
     Value _stderr = global_get("$stderr"_s);
-    message = String::format("{}:{}: warning: {}", m_file, m_line, message);
+    message = String::format("warning: {}", message);
+
+    if (m_file && m_line) {
+        message = String::format("{}:{}: {}", m_file, m_line, message);
+    }
+
     _stderr.send(this, "puts"_s, { new StringObject { message } });
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,11 +4,14 @@ using namespace Natalie;
 
 /*NAT_DECLARATIONS*/
 
+bool Natalie::allow_overwrites = true;
+
 extern "C" Env *build_top_env() {
     auto env = Natalie::build_top_env();
     Value self = GlobalEnv::the()->main_obj();
     (void)self; // don't warn about unused var
     /*NAT_OBJ_INIT*/
+    /*NAT_ALLOW_OVERWRITES*/
     return env;
 }
 

--- a/src/module_object.cpp
+++ b/src/module_object.cpp
@@ -228,6 +228,9 @@ void ModuleObject::methods(Env *env, ArrayObject *array, bool include_super) {
 }
 
 void ModuleObject::define_method(Env *env, SymbolObject *name, Method *method, MethodVisibility visibility) {
+    if (!Natalie::allow_overwrites && m_non_overwritable_methods.get(name)) {
+        env->warn("Natalie will not allow overwriting {}#{}. If you depend on it, please compile with the `--allow-overwrites` flag.", inspect_str(), name->c_str());
+    }
     m_methods.put(name, method, env);
     set_method_visibility(env, name, visibility);
 }

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -69,11 +69,35 @@ Env *build_top_env() {
     ClassObject *Fiber = Object->subclass(env, "Fiber", Object::Type::Fiber);
     Object->const_set("Fiber"_s, Fiber);
 
+    TM::Vector<SymbolObject *> numeric_non_overwritable_methods = {
+        "+"_s,
+        "-"_s,
+        "*"_s,
+        "<=>"_s,
+        "/"_s,
+        "%"_s,
+        "&"_s,
+        "|"_s,
+        "^"_s,
+        "<<"_s,
+        ">>"_s,
+        "=="_s,
+        "!="_s,
+        ">"_s,
+        "<"_s,
+        ">="_s,
+        "<="_s,
+        "==="_s,
+        "!"_s,
+    };
+
     ClassObject *Numeric = Object->subclass(env, "Numeric");
     Object->const_set("Numeric"_s, Numeric);
     Numeric->include_once(env, Comparable);
+    Numeric->add_non_overwritable_methods(numeric_non_overwritable_methods);
 
     ClassObject *Integer = Numeric->subclass(env, "Integer", Object::Type::Integer);
+    Integer->add_non_overwritable_methods(numeric_non_overwritable_methods);
     global_env->set_Integer(Integer);
     Object->const_set("Integer"_s, Integer);
     Value old_integer_constants[2] = { "Fixnum"_s, "Bignum"_s };
@@ -86,6 +110,7 @@ Env *build_top_env() {
     global_env->set_Float(Float);
     Object->const_set("Float"_s, Float);
     Float->include_once(env, Comparable);
+    Float->add_non_overwritable_methods(numeric_non_overwritable_methods);
     FloatObject::build_constants(env, Float);
 
     Value Math = new ModuleObject { "Math" };
@@ -102,6 +127,7 @@ Env *build_top_env() {
     global_env->set_Array(Array);
     Object->const_set("Array"_s, Array);
     Array->include_once(env, Enumerable);
+    Array->add_non_overwritable_methods({ "max"_s, "min"_s });
 
     ClassObject *Binding = Object->subclass(env, "Binding", Object::Type::Binding);
     global_env->set_Binding(Binding);

--- a/test/natalie/define_method_test.rb
+++ b/test/natalie/define_method_test.rb
@@ -16,7 +16,7 @@ describe '#define_method' do
           #{numeric_class}.define_method(:#{method}, ->(*) {})
         RUBY
 
-        ruby_exe(cmd, args: '2>&1').should include(
+        ruby_exe(cmd, args: '2>&1').should include_all(
                                              "Natalie will not allow overwriting #{numeric_class}##{method}. If you depend on it, please compile with the `--allow-overwrites` flag.\n",
                                            )
       end
@@ -25,7 +25,7 @@ describe '#define_method' do
     cmd = <<~RUBY
     Array.define_method(:min, ->(*) {  })
   RUBY
-    ruby_exe(cmd, args: '2>&1').should include(
+    ruby_exe(cmd, args: '2>&1').should include_all(
                                          "Natalie will not allow overwriting Array#min. If you depend on it, please compile with the `--allow-overwrites` flag.\n",
                                        )
   end

--- a/test/natalie/define_method_test.rb
+++ b/test/natalie/define_method_test.rb
@@ -7,3 +7,42 @@ describe 'define_singleton_method' do
     obj.foo.should == 'foo method'
   end
 end
+
+describe '#define_method' do
+  it 'warns on overwriting non-overwritable function' do
+    [Integer, Float].each do |numeric_class|
+      %i[+ !].each do |method|
+        cmd = <<~RUBY
+          #{numeric_class}.define_method(:#{method}, ->(*) {})
+        RUBY
+
+        ruby_exe(cmd, args: '2>&1').should include(
+                                             "Natalie will not allow overwriting #{numeric_class}##{method}. If you depend on it, please compile with the `--allow-overwrites` flag.\n",
+                                           )
+      end
+    end
+
+    cmd = <<~RUBY
+    Array.define_method(:min, ->(*) {  })
+  RUBY
+    ruby_exe(cmd, args: '2>&1').should include(
+                                         "Natalie will not allow overwriting Array#min. If you depend on it, please compile with the `--allow-overwrites` flag.\n",
+                                       )
+  end
+
+  it 'allows overwriting non-overwritable function if compiler flag passed' do
+    [Integer, Float].each do |numeric_class|
+      %i[+ !].each do |method|
+        cmd = <<~RUBY
+          #{numeric_class}.define_method(:#{method}, ->(*) {})
+        RUBY
+        ruby_exe(cmd, args: '--allow-overwrites 2>&1').should == ''
+      end
+    end
+
+    cmd = <<~RUBY
+    Array.define_method(:min, ->(*) {  })
+  RUBY
+    ruby_exe(cmd, args: '--allow-overwrites 2>&1').should == ''
+  end
+end

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -178,7 +178,9 @@ def ruby_exe(code, args: nil)
     file.write(code)
     file.rewind
 
-    output = `bin/natalie #{file.path} #{args}`
+    binary = ENV['NAT_BINARY'] || 'bin/natalie'
+
+    output = `#{binary} #{file.path} #{args}`
 
     raise SpecFailedException, "Expected exit status 0 but actual is #{$?.exitstatus}" unless $?.success?
 

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -174,13 +174,16 @@ def min_long
 end
 
 def ruby_exe(code, args: nil)
-  file = Tempfile.new('ruby_exe.rb') { |f| f.write(code) }
+  Tempfile.create('ruby_exe.rb') do |file|
+    file.write(code)
+    file.rewind
 
-  output = `bin/natalie #{file.path} #{args}`
+    output = `bin/natalie #{file.path} #{args}`
 
-  raise SpecFailedException, "Expected exit status 0 but actual is #{$?.exitstatus}" unless $?.success?
+    raise SpecFailedException, "Expected exit status 0 but actual is #{$?.exitstatus}" unless $?.success?
 
-  output
+    output
+  end
 end
 
 def ruby_version_is(version)

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -173,6 +173,16 @@ def min_long
   -((2**(8 * 8 - 2)) * 2)
 end
 
+def ruby_exe(code, args: nil)
+  file = Tempfile.new('ruby_exe.rb') { |f| f.write(code) }
+
+  output = `bin/natalie #{file.path} #{args}`
+
+  raise SpecFailedException, "Expected exit status 0 but actual is #{$?.exitstatus}" unless $?.success?
+
+  output
+end
+
 def ruby_version_is(version)
   ruby_version = SpecVersion.new RUBY_VERSION
   case version


### PR DESCRIPTION
This PR prints a warning when trying to overwrite optimized methods like Integer#+ or Array#min. To allow those sorts of overwrites a new flag `--allow-overwrites` was introduced with disables the canary compiler step and the warning.

To test this I also implement the `ruby_exe` helper from mspec.

I'm not really happy with how I pass the new flag from the compiler to our code. If there are better options for this I'd be happy to change it 😄 