### PR TITLE
Allow folding of simple conditional assignments

### DIFF
--- a/lib/natalie/compiler/pass1.rb
+++ b/lib/natalie/compiler/pass1.rb
@@ -480,6 +480,7 @@ module Natalie
 
       def process_lasgn(exp)
         _, name, val = exp
+        return exp.new(:var_declare, :env, s(:s, name)) if val == s(:lvar, name)
         exp.new(:var_set, :env, s(:s, name), process(val))
       end
 


### PR DESCRIPTION
### Optimize self-assignment out

This is just a neat way of ensuring a variable exists, so we can replace
it with just a declare_var statement.

### Allow folding of simple conditional assignments

This works, by replacing the non assigning path with a `var = var`
statement to ensure that the variable it is allocated.

---- 

This now allows us to fold
```rb
x = 1 unless false
```
to
```rb
x = 1
```