### PR TITLE
Implement Numeric methods

### DIFF
--- a/spec/core/numeric/comparison_spec.rb
+++ b/spec/core/numeric/comparison_spec.rb
@@ -1,0 +1,48 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Numeric#<=>" do
+  before :each do
+    @obj = NumericSpecs::Subclass.new
+  end
+
+  it "returns 0 if self equals other" do
+    (@obj <=> @obj).should == 0
+  end
+
+  it "returns nil if self does not equal other" do
+    (@obj <=> NumericSpecs::Subclass.new).should == nil
+    (@obj <=> 10).should == nil
+    (@obj <=> -3.5).should == nil
+    (@obj <=> bignum_value).should == nil
+  end
+
+  describe "with subclasses of Numeric" do
+    before :each do
+      @a = NumericSpecs::Comparison.new
+      @b = NumericSpecs::Comparison.new
+
+      ScratchPad.clear
+    end
+
+    it "is called when instances are compared with #<" do
+      (@a < @b).should be_false
+      ScratchPad.recorded.should == :numeric_comparison
+    end
+
+    it "is called when instances are compared with #<=" do
+      (@a <= @b).should be_false
+      ScratchPad.recorded.should == :numeric_comparison
+    end
+
+    it "is called when instances are compared with #>" do
+      (@a > @b).should be_true
+      ScratchPad.recorded.should == :numeric_comparison
+    end
+
+    it "is called when instances are compared with #>=" do
+      (@a >= @b).should be_true
+      ScratchPad.recorded.should == :numeric_comparison
+    end
+  end
+end

--- a/spec/core/numeric/fdiv_spec.rb
+++ b/spec/core/numeric/fdiv_spec.rb
@@ -1,0 +1,32 @@
+require_relative '../../spec_helper'
+require_relative 'shared/quo'
+
+describe "Numeric#fdiv" do
+  it "coerces self with #to_f" do
+    numeric = mock_numeric('numeric')
+    numeric.should_receive(:to_f).and_return(3.0)
+    numeric.fdiv(0.5).should == 6.0
+  end
+
+  it "coerces other with #to_f" do
+    numeric = mock_numeric('numeric')
+    numeric.should_receive(:to_f).and_return(3.0)
+    6.fdiv(numeric).should == 2.0
+  end
+
+  it "performs floating-point division" do
+    3.fdiv(2).should == 1.5
+  end
+
+  it "returns a Float" do
+    bignum_value.fdiv(Float::MAX).should be_an_instance_of(Float)
+  end
+
+  it "returns Infinity if other is 0" do
+    8121.92821.fdiv(0).infinite?.should == 1
+  end
+
+  it "returns NaN if other is NaN" do
+    3334.fdiv(nan_value).nan?.should be_true
+  end
+end

--- a/spec/core/numeric/finite_spec.rb
+++ b/spec/core/numeric/finite_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../spec_helper'
+
+describe "Numeric#finite?" do
+  it "returns true by default" do
+    o = mock_numeric("finite")
+    o.finite?.should be_true
+  end
+end

--- a/spec/core/numeric/imag_spec.rb
+++ b/spec/core/numeric/imag_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../spec_helper'
+require_relative 'shared/imag'
+
+describe "Numeric#imag" do
+  it_behaves_like :numeric_imag, :imag
+end

--- a/spec/core/numeric/imaginary_spec.rb
+++ b/spec/core/numeric/imaginary_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../spec_helper'
+require_relative 'shared/imag'
+
+describe "Numeric#imaginary" do
+  it_behaves_like :numeric_imag, :imaginary
+end

--- a/spec/core/numeric/infinite_spec.rb
+++ b/spec/core/numeric/infinite_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../spec_helper'
+
+describe "Numeric#infinite?" do
+  it "returns nil by default" do
+    o = mock_numeric("infinite")
+    o.infinite?.should == nil
+  end
+end

--- a/spec/core/numeric/integer_spec.rb
+++ b/spec/core/numeric/integer_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Numeric#integer?" do
+  it "returns false" do
+    NumericSpecs::Subclass.new.should_not.integer?
+  end
+end

--- a/spec/core/numeric/nonzero_spec.rb
+++ b/spec/core/numeric/nonzero_spec.rb
@@ -1,0 +1,18 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Numeric#nonzero?" do
+  before :each do
+    @obj = NumericSpecs::Subclass.new
+  end
+
+  it "returns self if self#zero? is false" do
+    @obj.should_receive(:zero?).and_return(false)
+    @obj.nonzero?.should == @obj
+  end
+
+  it "returns nil if self#zero? is true" do
+    @obj.should_receive(:zero?).and_return(true)
+    @obj.nonzero?.should == nil
+  end
+end

--- a/spec/core/numeric/numeric_spec.rb
+++ b/spec/core/numeric/numeric_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../spec_helper'
+
+describe "Numeric" do
+  it "includes Comparable" do
+    Numeric.include?(Comparable).should == true
+  end
+end

--- a/spec/core/numeric/phase_spec.rb
+++ b/spec/core/numeric/phase_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../spec_helper'
+require_relative 'shared/arg'
+
+describe "Numeric#phase" do
+  it_behaves_like :numeric_arg, :phase
+end

--- a/spec/core/numeric/polar_spec.rb
+++ b/spec/core/numeric/polar_spec.rb
@@ -1,0 +1,51 @@
+require_relative '../../spec_helper'
+
+describe "Numeric#polar" do
+  before :each do
+    @pos_numbers = [
+      1,
+      3898172610**9,
+      987.18273,
+      Float::MAX,
+      # NATFIXME: Implement Rational
+      # Rational(13,7),
+      infinity_value,
+    ]
+    @neg_numbers = @pos_numbers.map {|n| -n}
+    @numbers = @pos_numbers + @neg_numbers
+    @numbers.push(0, 0.0)
+  end
+
+  it "returns a two-element Array" do
+    @numbers.each do |number|
+      number.polar.should be_an_instance_of(Array)
+      number.polar.size.should == 2
+    end
+  end
+
+  it "sets the first value to the absolute value of self" do
+    @numbers.each do |number|
+      number.polar.first.should == number.abs
+    end
+  end
+
+  it "sets the last value to 0 if self is positive" do
+    (@numbers - @neg_numbers).each do |number|
+      number.should >= 0
+      number.polar.last.should == 0
+    end
+  end
+
+  it "sets the last value to Pi if self is negative" do
+    @neg_numbers.each do |number|
+      number.should < 0
+      number.polar.last.should == Math::PI
+    end
+  end
+
+  it "returns [NaN, NaN] if self is NaN" do
+    nan_value.polar.size.should == 2
+    nan_value.polar.first.nan?.should be_true
+    nan_value.polar.last.nan?.should be_true
+  end
+end

--- a/spec/core/numeric/real_spec.rb
+++ b/spec/core/numeric/real_spec.rb
@@ -1,0 +1,38 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Numeric#real" do
+  before :each do
+    @numbers = [
+      20,             # Integer
+      398.72,         # Float
+      # NATFIXME: Implement Rational
+      # Rational(3, 4), # Rational
+      bignum_value,   # Bignum
+      infinity_value,
+      nan_value
+    ].map{ |n| [n, -n] }.flatten
+  end
+
+  it "returns self" do
+    @numbers.each do |number|
+      if number.to_f.nan?
+        number.real.nan?.should be_true
+      else
+        number.real.should == number
+      end
+    end
+  end
+
+  it "raises an ArgumentError if given any arguments" do
+    @numbers.each do |number|
+      -> { number.real(number) }.should raise_error(ArgumentError)
+    end
+  end
+end
+
+describe "Numeric#real?" do
+  it "returns true" do
+    NumericSpecs::Subclass.new.should.real?
+  end
+end

--- a/spec/core/numeric/rect_spec.rb
+++ b/spec/core/numeric/rect_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../spec_helper'
+require_relative 'shared/rect'
+
+describe "Numeric#rect" do
+  it_behaves_like :numeric_rect, :rect
+end

--- a/spec/core/numeric/rectangular_spec.rb
+++ b/spec/core/numeric/rectangular_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../spec_helper'
+require_relative 'shared/rect'
+
+describe "Numeric#rectangular" do
+  it_behaves_like :numeric_rect, :rectangular
+end

--- a/spec/core/numeric/remainder_spec.rb
+++ b/spec/core/numeric/remainder_spec.rb
@@ -1,0 +1,67 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Numeric#remainder" do
+  before :each do
+    @obj    = NumericSpecs::Subclass.new
+    @result = mock("Numeric#% result")
+    @other  = mock("Passed Object")
+  end
+
+  it "returns the result of calling self#% with other if self is 0" do
+    @obj.should_receive(:%).with(@other).and_return(@result)
+    @result.should_receive(:==).with(0).and_return(true)
+
+    @obj.remainder(@other).should equal(@result)
+  end
+
+  it "returns the result of calling self#% with other if self and other are greater than 0" do
+    @obj.should_receive(:%).with(@other).and_return(@result)
+    @result.should_receive(:==).with(0).and_return(false)
+
+    @obj.should_receive(:<).with(0).and_return(false)
+
+    @obj.should_receive(:>).with(0).and_return(true)
+    @other.should_receive(:<).with(0).and_return(false)
+
+    @obj.remainder(@other).should equal(@result)
+  end
+
+  it "returns the result of calling self#% with other if self and other are less than 0" do
+    @obj.should_receive(:%).with(@other).and_return(@result)
+    @result.should_receive(:==).with(0).and_return(false)
+
+    @obj.should_receive(:<).with(0).and_return(true)
+    @other.should_receive(:>).with(0).and_return(false)
+
+    @obj.should_receive(:>).with(0).and_return(false)
+
+    @obj.remainder(@other).should equal(@result)
+  end
+
+  it "returns the result of calling self#% with other - other if self is greater than 0 and other is less than 0" do
+    @obj.should_receive(:%).with(@other).and_return(@result)
+    @result.should_receive(:==).with(0).and_return(false)
+
+    @obj.should_receive(:<).with(0).and_return(false)
+
+    @obj.should_receive(:>).with(0).and_return(true)
+    @other.should_receive(:<).with(0).and_return(true)
+
+    @result.should_receive(:-).with(@other).and_return(:result)
+
+    @obj.remainder(@other).should == :result
+  end
+
+  it "returns the result of calling self#% with other - other if self is less than 0 and other is greater than 0" do
+    @obj.should_receive(:%).with(@other).and_return(@result)
+    @result.should_receive(:==).with(0).and_return(false)
+
+    @obj.should_receive(:<).with(0).and_return(true)
+    @other.should_receive(:>).with(0).and_return(true)
+
+    @result.should_receive(:-).with(@other).and_return(:result)
+
+    @obj.remainder(@other).should == :result
+  end
+end

--- a/spec/core/numeric/shared/imag.rb
+++ b/spec/core/numeric/shared/imag.rb
@@ -1,0 +1,27 @@
+require_relative '../../../spec_helper'
+
+describe :numeric_imag, shared: true do
+  before :each do
+    @numbers = [
+      20,             # Integer
+      398.72,         # Float
+      # NATFIXME: Implement Rational
+      # Rational(3, 4), # Rational
+      bignum_value, # Bignum
+      infinity_value,
+      nan_value
+    ].map{|n| [n,-n]}.flatten
+  end
+
+  it "returns 0" do
+    @numbers.each do |number|
+      number.send(@method).should == 0
+    end
+  end
+
+  it "raises an ArgumentError if given any arguments" do
+   @numbers.each do |number|
+     -> { number.send(@method, number) }.should raise_error(ArgumentError)
+   end
+  end
+end

--- a/spec/core/numeric/shared/quo.rb
+++ b/spec/core/numeric/shared/quo.rb
@@ -1,0 +1,7 @@
+describe :numeric_quo_18, shared: true do
+  it "returns the result of calling self#/ with other" do
+    obj = mock_numeric('numeric')
+    obj.should_receive(:/).with(19).and_return(:result)
+    obj.send(@method, 19).should == :result
+  end
+end

--- a/spec/core/numeric/shared/rect.rb
+++ b/spec/core/numeric/shared/rect.rb
@@ -1,0 +1,49 @@
+require_relative '../../../spec_helper'
+
+describe :numeric_rect, shared: true do
+  before :each do
+    @numbers = [
+      20,             # Integer
+      398.72,         # Float
+      # NATFIXME: Implement Rational
+      # Rational(3, 4), # Rational
+      99999999**99, # Bignum
+      infinity_value,
+      nan_value
+    ]
+  end
+
+  it "returns an Array" do
+    @numbers.each do |number|
+      number.send(@method).should be_an_instance_of(Array)
+    end
+  end
+
+  it "returns a two-element Array" do
+    @numbers.each do |number|
+      number.send(@method).size.should == 2
+    end
+  end
+
+  it "returns self as the first element" do
+   @numbers.each do |number|
+     if Float === number and number.nan?
+       number.send(@method).first.nan?.should be_true
+     else
+       number.send(@method).first.should == number
+     end
+   end
+  end
+
+  it "returns 0 as the last element" do
+   @numbers.each do |number|
+     number.send(@method).last.should == 0
+   end
+  end
+
+  it "raises an ArgumentError if given any arguments" do
+   @numbers.each do |number|
+     -> { number.send(@method, number) }.should raise_error(ArgumentError)
+   end
+  end
+end

--- a/spec/core/numeric/to_int_spec.rb
+++ b/spec/core/numeric/to_int_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Numeric#to_int" do
+  it "returns self#to_i" do
+    obj = NumericSpecs::Subclass.new
+    obj.should_receive(:to_i).and_return(:result)
+    obj.to_int.should == :result
+  end
+end

--- a/src/numeric.rb
+++ b/src/numeric.rb
@@ -144,4 +144,8 @@ class Numeric
   def integer?
     false
   end
+
+  def to_int
+    self.to_i
+  end
 end

--- a/src/numeric.rb
+++ b/src/numeric.rb
@@ -50,6 +50,12 @@ class Numeric
 
   alias angle arg
 
+  alias phase arg
+
+  def polar
+    [self.abs, self.arg]
+  end
+
   def conj
     self
   end

--- a/src/numeric.rb
+++ b/src/numeric.rb
@@ -1,4 +1,6 @@
-module Numeric
+class Numeric
+  include Comparable
+
   def coerce(other)
     self.class == other.class ? [other, self] : [Float(other), Float(self)]
   end

--- a/src/numeric.rb
+++ b/src/numeric.rb
@@ -102,4 +102,16 @@ class Numeric
   def fdiv(other)
     Float(self) / Float(other)
   end
+
+  def finite?
+    true
+  end
+
+  def infinite?
+    nil
+  end
+
+  def integer?
+    false
+  end
 end

--- a/src/numeric.rb
+++ b/src/numeric.rb
@@ -91,4 +91,15 @@ class Numeric
   def divmod(other)
     [self.div(other), self % other]
   end
+
+  def remainder(other)
+    remainder = self % other
+    return remainder if remainder == 0
+    return remainder - other if (self < 0 && other > 0) || (self > 0 && other < 0)
+    remainder
+  end
+
+  def fdiv(other)
+    Float(self) / Float(other)
+  end
 end

--- a/src/numeric.rb
+++ b/src/numeric.rb
@@ -52,6 +52,26 @@ class Numeric
 
   alias conjugate conj
 
+  def imag
+    0
+  end
+
+  alias imaginary imag
+
+  def real
+    self
+  end
+
+  def real?
+    true
+  end
+
+  def rect
+    [self.real, self.imag]
+  end
+
+  alias rectangular rect
+
   def ceil
     Float(self).ceil
   end

--- a/src/numeric.rb
+++ b/src/numeric.rb
@@ -30,6 +30,10 @@ class Numeric
     self == 0
   end
 
+  def nonzero?
+    self.zero? ? nil : self
+  end
+
   def abs
     self.negative? ? -self : self
   end

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -365,6 +365,9 @@ class Matcher
   def positive?
     method_missing(:positive?)
   end
+  def real?
+    method_missing(:real?)
+  end
   def start_with?(other)
     method_missing(:start_with?, other)
   end


### PR DESCRIPTION
Remaining Numeric methods:

- `#denominator`, `#numerator`, and `#quo` require Rational
- `#to_c` and `#i` require Complex
- `#step` requires `Enumerator::ArithmeticSequence`
- `#singleton_method_added`