### PR TITLE
Some small GC improvements

### DIFF
--- a/src/gc.cpp
+++ b/src/gc.cpp
@@ -25,8 +25,6 @@ void MarkingVisitor::visit(Value val) {
 }
 
 TM::Hashmap<Cell *> Heap::gather_conservative_roots() {
-    Hashmap<Cell *> roots;
-
     void *dummy;
     void *end_of_stack = &dummy;
 
@@ -35,8 +33,12 @@ TM::Hashmap<Cell *> Heap::gather_conservative_roots() {
     assert(end_of_stack);
     assert(m_start_of_stack > end_of_stack);
 
+    Hashmap<Cell *> roots;
+
     for (char *ptr = reinterpret_cast<char *>(end_of_stack); ptr < m_start_of_stack; ptr += sizeof(intptr_t)) {
         Cell *potential_cell = *reinterpret_cast<Cell **>(ptr); // NOLINT
+        if (roots.get(potential_cell))
+            continue;
         if (is_a_heap_cell_in_use(potential_cell)) {
             roots.set(potential_cell);
         }
@@ -47,6 +49,8 @@ TM::Hashmap<Cell *> Heap::gather_conservative_roots() {
     setjmp(jump_buf);
     for (char *i = (char *)jump_buf; i < (char *)jump_buf + sizeof(jump_buf); ++i) {
         Cell *potential_cell = *reinterpret_cast<Cell **>(i);
+        if (roots.get(potential_cell))
+            continue;
         if (is_a_heap_cell_in_use(potential_cell)) {
             roots.set(potential_cell);
         }

--- a/src/gc.cpp
+++ b/src/gc.cpp
@@ -75,10 +75,6 @@ void Heap::collect() {
         NativeProfiler::the()->push(mark_profiler_event);
     });
 
-    for (auto allocator : m_allocators) {
-        allocator->unmark_all_cells_in_all_blocks();
-    }
-
     if (is_profiled) {
         mark_profiler_event->start_now();
     }
@@ -123,6 +119,8 @@ void Heap::sweep() {
                     if (!had_free) {
                         allocator->add_free_block(block);
                     }
+                } else {
+                    cell->unmark();
                 }
             }
         }


### PR DESCRIPTION
Gain: 1.05-1.10 faster across variously configured benchmarks of various scripts

Changes:
-  Automatically unmark cells during collection so that we completely remove the global unmarking from the marking phase
- Do not check again cells that have already been gathered from gather_conservative_roots()