### PR TITLE
Clean up Object::find_method

### DIFF
--- a/include/natalie/class_object.hpp
+++ b/include/natalie/class_object.hpp
@@ -20,6 +20,12 @@ public:
     ClassObject(ClassObject *klass)
         : ModuleObject { Object::Type::Class, klass } { }
 
+    ClassObject(ClassObject &other)
+        : ModuleObject { other }
+        , m_object_type { other.m_object_type }
+        , m_is_singleton { other.m_is_singleton }
+        , m_is_initialized { other.m_is_initialized } { }
+
     ClassObject *superclass(Env *env) override {
         if (!m_is_initialized)
             env->raise("TypeError", "uninitialized class");

--- a/include/natalie/kernel_module.hpp
+++ b/include/natalie/kernel_module.hpp
@@ -61,7 +61,6 @@ public:
     static Value this_method(Env *env);
     static bool block_given(Env *env, Block *block) { return !!block; }
 
-    Value clone(Env *env);
     Value define_singleton_method(Env *env, Value name, Block *block);
     Value hash(Env *env);
     Value inspect(Env *env);

--- a/include/natalie/module_object.hpp
+++ b/include/natalie/module_object.hpp
@@ -29,9 +29,10 @@ public:
     ModuleObject(ModuleObject &other)
         : Object { other.type(), other.klass() }
         , m_constants { other.m_constants }
-        , m_class_name { other.m_class_name }
         , m_superclass { other.m_superclass }
-        , m_methods { other.m_methods } {
+        , m_methods { other.m_methods }
+        , m_method_info { other.m_method_info }
+        , m_class_vars { other.m_class_vars } {
         for (ModuleObject *module : const_cast<ModuleObject &>(other).m_included_modules) {
             m_included_modules.push(module);
         }

--- a/include/natalie/object.hpp
+++ b/include/natalie/object.hpp
@@ -221,6 +221,7 @@ public:
     Method *find_method(Env *, SymbolObject *, MethodVisibility);
 
     Value dup(Env *);
+    Value clone(Env *env);
 
     bool is_a(Env *, Value) const;
     bool respond_to(Env *, Value, bool = true);

--- a/src/kernel_module.cpp
+++ b/src/kernel_module.cpp
@@ -73,25 +73,6 @@ Value KernelModule::binding(Env *env) {
     return new BindingObject { env };
 }
 
-Value KernelModule::clone(Env *env) {
-    auto duplicate = this->dup(env);
-    auto s_class = singleton_class();
-    if (s_class) {
-        auto singleton_methods = new ArrayObject {};
-        s_class->methods(env, singleton_methods);
-
-        for (auto &method_name : *singleton_methods) {
-            auto m = s_class->find_method(env, method_name->as_symbol());
-            duplicate->singleton_class()->define_method(
-                m->env(),
-                SymbolObject::intern(m->name()),
-                m->fn(),
-                m->arity());
-        }
-    }
-    return duplicate;
-}
-
 Value KernelModule::cur_dir(Env *env) {
     if (env->file() == nullptr) {
         env->raise("RuntimeError", "could not get current directory");

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -600,10 +600,14 @@ Value Object::dup(Env *env) {
     switch (m_type) {
     case Object::Type::Array:
         return new ArrayObject { *as_array() };
+    case Object::Type::Class:
+        return new ClassObject { *as_class() };
     case Object::Type::Exception:
         return new ExceptionObject { *as_exception() };
     case Object::Type::Hash:
         return new HashObject { env, *as_hash() };
+    case Object::Type::Module:
+        return new ModuleObject { *as_module() };
     case Object::Type::String:
         return new StringObject { *as_string() };
     case Object::Type::Range:
@@ -622,6 +626,15 @@ Value Object::dup(Env *env) {
         fprintf(stderr, "I don't know how to dup this kind of object yet %s (type = %d).\n", m_klass->inspect_str()->c_str(), static_cast<int>(m_type));
         abort();
     }
+}
+
+Value Object::clone(Env *env) {
+    auto duplicate = this->dup(env);
+    auto s_class = singleton_class();
+    if (s_class) {
+        duplicate->set_singleton_class(s_class->clone(env)->as_class());
+    }
+    return duplicate;
 }
 
 bool Object::is_a(Env *env, Value val) const {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -7,7 +7,7 @@ namespace Natalie {
 Object::Object(const Object &other)
     : m_klass { other.m_klass }
     , m_type { other.m_type }
-    , m_singleton_class { other.m_singleton_class ? new ClassObject { other.m_singleton_class } : nullptr }
+    , m_singleton_class { nullptr }
     , m_owner { other.m_owner }
     , m_ivars { other.m_ivars } { }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -589,8 +589,6 @@ Method *Object::find_method(Env *env, SymbolObject *method_name, MethodVisibilit
         } else {
             env->raise("NoMethodError", "private method `{}' called for {}", method_name->c_str(), inspect_str(env));
         }
-    } else if (method_name == "inspect"_s) {
-        env->raise("NoMethodError", "undefined method `inspect' for #<{}:{}>", m_klass->inspect_str(), int_to_hex_string(object_id(), false));
     } else if (is_module()) {
         env->raise("NoMethodError", "undefined method `{}' for {}:{}", method_name->c_str(), as_module()->inspect_str(), m_klass->inspect_str());
     } else {
@@ -772,6 +770,8 @@ bool Object::neq(Env *env, Value other) {
 }
 
 const String *Object::inspect_str(Env *env) {
+    if (!respond_to(env, "inspect"_s))
+        return String::format("#<{}:{}>", m_klass->inspect_str(), int_to_hex_string(object_id(), false));
     auto inspected = send(env, "inspect"_s);
     if (!inspected->is_string())
         return new String(""); // TODO: what to do here?


### PR DESCRIPTION
An object's singleton class is a subclass of the object's regular class, so only one of the two is needed to find methods.

This change also revealed that `Object::dup` was incorrectly copying the singleton class (which hadn't been implemented yet).