### PR TITLE
Fix YamlFormatter

### DIFF
--- a/test/support/formatters/yaml_formatter.rb
+++ b/test/support/formatters/yaml_formatter.rb
@@ -15,7 +15,7 @@ class YamlFormatter
         context, test, error = failure
         outcome = error.is_a?(SpecFailedException) ? 'FAILED' : 'ERROR'
         str = "#{test} #{outcome}\n"
-        str << error.message << "\n" << error.backtrace
+        str << error.message << "\n" << error.backtrace.to_s
         print '- ', str.inspect, "\n"
       end
     end


### PR DESCRIPTION
Instead of expecting an Array (the error backtrace) to be converted to a
String we have to call #to_s on it :^)