### PR TITLE
Vector improvements - improve relocation of existing entries in insert and remove

### DIFF
--- a/include/tm/vector.hpp
+++ b/include/tm/vector.hpp
@@ -14,25 +14,26 @@ const int VECTOR_MIN_CAPACITY = 10;
 template <typename T>
 class Vector {
 public:
+    #define ARRAY_OF_SIZE(size) static_cast<T *>(::operator new(size * sizeof(T)))
     Vector()
         : m_capacity { VECTOR_MIN_CAPACITY }
-        , m_data { new T[VECTOR_MIN_CAPACITY] {} } { }
+        , m_data { ARRAY_OF_SIZE(VECTOR_MIN_CAPACITY) } { }
 
     Vector(size_t initial_capacity)
         : m_size { initial_capacity }
         , m_capacity { initial_capacity }
-        , m_data { new T[initial_capacity] {} } { }
+        , m_data { ARRAY_OF_SIZE(initial_capacity) } { }
 
     Vector(size_t initial_capacity, T filler)
         : m_size { initial_capacity }
         , m_capacity { initial_capacity }
-        , m_data { new T[initial_capacity] {} } {
+        , m_data { ARRAY_OF_SIZE(initial_capacity) } {
         fill(0, initial_capacity, filler);
     }
 
     Vector(std::initializer_list<T> list)
         : m_capacity { list.size() }
-        , m_data { new T[list.size()] } {
+        , m_data { ARRAY_OF_SIZE(list.size()) } {
         for (auto v : list) {
             push(v);
         }
@@ -41,7 +42,7 @@ public:
     Vector(const Vector &other)
         : m_size { other.m_size }
         , m_capacity { other.m_size }
-        , m_data { new T[m_size] {} } {
+        , m_data { ARRAY_OF_SIZE(other.m_size) } {
         memcpy(m_data, other.m_data, sizeof(T) * m_size);
     }
 

--- a/include/tm/vector.hpp
+++ b/include/tm/vector.hpp
@@ -225,10 +225,8 @@ private:
         , m_data(data) { }
 
     void grow(size_t capacity) {
-        auto old_data = m_data;
-        m_data = new T[capacity] {};
-        memcpy(m_data, old_data, sizeof(T) * TM_MIN(capacity, m_capacity));
-        delete[] old_data;
+        if (capacity > m_capacity)
+            m_data = static_cast<T *>(reallocarray(m_data, capacity, sizeof(T)));
         m_capacity = capacity;
     }
 

--- a/src/array_object.cpp
+++ b/src/array_object.cpp
@@ -862,6 +862,10 @@ Value ArrayObject::index(Env *env, Value object, Block *block) {
 Value ArrayObject::shift(Env *env, Value count) {
     assert_not_frozen(env);
     auto has_count = count != nullptr;
+
+    if (!has_count && is_empty())
+        return NilObject::the();
+
     size_t shift_count = 1;
     Value result = nullptr;
     if (has_count) {


### PR DESCRIPTION
This especially crafted script measures up to a 10% improvement in speed 
```ruby
a = []
100_000.times { a << 1 }
100_000.times { a.pop }
```

Having said that, we shouldn't expect the same speed-up anywhere else.