### PR TITLE
Compiler2: Port, Devide and Expand pass0[c]

### DIFF
--- a/bin/natalie
+++ b/bin/natalie
@@ -13,7 +13,7 @@ require_relative '../lib/natalie'
 
 orig_args = ARGV.dup
 
-options = { load_path: [], require: [], profile: false }
+options = { load_path: [], require: [], profile: false , optimization_level: 0}
 OptionParser.new do |opts|
   opts.banner = 'Usage: natalie [options] file.rb'
 
@@ -102,6 +102,19 @@ OptionParser.new do |opts|
   opts.on('--experimental-repl-v2', 'Enable the new REPL (not available with self-hosted Natalie)') do
     options[:experimental_repl_v2] = true
   end
+
+  opts.on('-f [optimization]', 'Enable/Disable a specific optimization (only with -c2)',
+    options: {
+      'nocanary_array_functions' => 'Disable unfolding of functions on literal arrays [AST], default=on',
+      'cf, nocf' => 'Enable/Disable constant folding [AST], default=off, enabled with O1'
+  }) do |option|
+      options[:optimizations] ||= []
+      options[:optimizations].append(option)
+  end
+  opts.on('-O1', 'Enable basic optimizations (only with -c2)') do
+    options[:optimization_level] = 1
+  end
+
 end.parse!
 
 build_type_path = File.expand_path('../.build', __dir__)

--- a/lib/natalie/compiler2.rb
+++ b/lib/natalie/compiler2.rb
@@ -1,4 +1,5 @@
 require 'tempfile'
+require_relative './compiler2/pass0'
 require_relative './compiler2/pass1'
 require_relative './compiler2/pass2'
 require_relative './compiler2/instruction_manager'
@@ -91,6 +92,7 @@ module Natalie
         compile_cxx_flags: cxx_flags,
         compile_ld_flags: [],
         source_path: @path,
+        options: @options,
       }
     end
 
@@ -164,6 +166,12 @@ module Natalie
       ast = expand_macros(@ast, @path)
 
       @context = build_context
+
+      ast = Pass0.new(context, ast).transform
+      if debug == 'p0'
+        pp ast
+        exit
+      end
 
       instructions = Pass1.new(ast).transform
       if debug == 'p1'

--- a/lib/natalie/compiler2/optimizations/AST_based/canary_array_functions.rb
+++ b/lib/natalie/compiler2/optimizations/AST_based/canary_array_functions.rb
@@ -1,0 +1,90 @@
+require_relative '../../../compiler/base_pass'
+
+module Natalie
+  class Compiler2
+    # A 'canary' pass that tries to simplify well-known ruby pattern which would
+    # normally cost allocating a data-structure
+    # https://ruby-compilers.com/examples/#example-program-canaryrb
+    class CanaryArrayFunctions < ::Natalie::Compiler::BasePass
+      def initialize(context)
+        super
+        self.default_method = nil
+        self.warn_on_default = true
+        self.require_empty = false
+        self.strict = false
+      end
+
+      def process_iter(exp)
+        call_type, call, args, *body = exp
+        return exp.new(:iter, process_call(call), args, *body.map { |e| process_atom(e) })
+      end
+
+      def process_call(exp)
+        exp = exp.new(*exp.map { |e| process_atom(e) })
+        _, receiver, method, *args = exp
+        return exp unless receiver && !receiver.empty?
+
+        t, *values = receiver
+        return exp unless t == :array
+
+        case method
+        when :min
+          return canary_array_min(exp, values, args)
+        when :max
+          return canary_array_max(exp, values, args)
+        end
+        return exp
+      end
+
+      def canary_array_min(exp, values, args = nil, block = nil)
+        if (block.nil? && !args.nil? && args.length != 0)
+          raise ArgumentError.new(
+                  "(#{exp.file}:#{exp.line}) Wrong number of arguments for Array#min (expected 0, given #{args&.length.to_s})",
+                )
+        end
+        if (block && (args.nil? || args.length != 3))
+          raise ArgumentError.new(
+                  "(#{exp.file}:#{exp.line}) Wrong number of arguments for Array#min (expected 2, given #{args.nil? ? 0 : (args.length - 1).to_s})",
+                )
+        end
+
+        return exp.new(:nil) if values.empty?
+        return values[0] if values.length == 1
+        first, second, *rest = values
+        return(
+          exp.new(
+            :if,
+            exp.new(:call, first, :<, second),
+            canary_array_min(exp, [first, *rest]),
+            canary_array_min(exp, [second, *rest]),
+          )
+        )
+      end
+
+      def canary_array_max(exp, values, args = nil, block = nil)
+        if (block.nil? && !args.nil? && args.length != 0)
+          raise ArgumentError.new(
+                  "(#{exp.file}:#{exp.line}) Wrong number of arguments for Array#max (expected 0 given #{args&.length.to_s})",
+                )
+        end
+        if (block && (args.nil? || args.length != 3))
+          raise ArgumentError.new(
+                  "(#{exp.file}:#{exp.line}) Wrong number of arguments for Array#max (expected 2 given #{args.nil? ? 0 : (args.length - 1).to_s})",
+                )
+        end
+
+        return exp.new(:nil) if values.empty?
+        return values[0] if values.length == 1
+        first, second, *rest = values
+        return(
+          exp.new(
+            :if,
+            exp.new(:call, first, :>, second),
+            canary_array_max(exp, [first, *rest]),
+            canary_array_max(exp, [second, *rest]),
+          )
+        )
+      end
+    end
+  end
+end

--- a/lib/natalie/compiler2/optimizations/AST_based/constant_folding.rb
+++ b/lib/natalie/compiler2/optimizations/AST_based/constant_folding.rb
@@ -1,0 +1,172 @@
+require_relative '../../../compiler/base_pass'
+
+module Natalie
+  class Compiler2
+    # A 'canary' pass that tries to simplify well-known ruby pattern which would
+    # normally cost allocating a data-structure
+    # https://ruby-compilers.com/examples/#example-program-canaryrb
+    class ConstantFolding < ::Natalie::Compiler::BasePass
+      def initialize(context)
+        super
+        self.default_method = nil
+        self.warn_on_default = true
+        self.require_empty = false
+        self.strict = false
+        @in_defined_statement = false
+      end
+
+      def process_defined(exp, block_with_args = nil)
+        # Note: This might fail on nested defined?s, but who's gonna do that
+        @in_defined_statement = true
+        exp = exp.new(*exp.map { |e| process_atom(e) })
+        @in_defined_statement = false
+        return exp
+      end
+
+      def type_is_always_truthy(arg)
+        # FIXME: Are there any other types that are always truthy?
+        return %i[true str lit array].include?(arg)
+      end
+      def type_is_always_falsey(arg)
+        return %i[false nil].include?(arg)
+      end
+
+      def process_if(exp, block_with_args = nil)
+        exp = exp.new(*exp.map { |e| process_atom(e) })
+        _, (boolean, *), true_case, false_case = exp
+
+        # This transforms variations of
+        # ```rb
+        # x = 1 if bool # s(:if, bool, s(:lasgn, :x, s(:lit, 1), nil))
+        # ```
+        # To use `x = x` in the non assigning path, which will be optimized in
+        # pass1, to just ensure the existence of the variable `x`.
+        # This allows us to fold that block even though we might declare a
+        # variable in it.
+        was_simple_conditional_assign = false
+        if true_case.nil? && false_case.sexp_type == :lasgn
+          true_case = s(:lasgn, false_case[1], s(:lvar, false_case[1]))
+          was_simple_conditional_assign = true
+        elsif false_case.nil? && true_case.sexp_type == :lasgn
+          false_case = s(:lasgn, true_case[1], s(:lvar, true_case[1]))
+          was_simple_conditional_assign = true
+        end
+
+        # FIXME: We can't always fold away unused code paths, due to variables
+        #        being declared in if-statements might be hoisted into the upper
+        #        environment.
+        #        To fix that we would need to move variable pre-declaration from
+        #        pass2 to pass0.
+        # FIXME: There seems to be something getting here where the flatten function
+        #        is not defined/nil, seen in test/natalie/class_test.rb
+        if type_is_always_truthy(boolean) && (!(false_case&.flatten&.include?(:lasgn)) || was_simple_conditional_assign)
+          return true_case
+        end
+        if type_is_always_falsey(boolean) && (!(true_case&.flatten&.include?(:lasgn)) || was_simple_conditional_assign)
+          return false_case
+        end
+
+        return exp
+      end
+
+      def process_or(exp, block_with_args = nil)
+        exp = exp.new(*exp.map { |e| process_atom(e) })
+        _, (t1, *arg1), (t2, *arg2) = exp
+        return exp.new(t2, *arg2) if type_is_always_falsey(t1)
+        return exp.new(t1, *arg1) if type_is_always_truthy(t1)
+
+        return exp
+      end
+
+      def process_and(exp, block_with_args = nil)
+        exp = exp.new(*exp.map { |e| process_atom(e) })
+        _, (t1, *arg1), (t2, *arg2) = exp
+        return s(t1, *arg1) if type_is_always_falsey(t1)
+        return exp if !type_is_always_truthy(t1) # t1 is not const-evaluable
+
+        # t2 will be returned even if it is falsey, so we don't have to check it
+        return exp.new(t2, *arg2)
+      end
+
+      def process_call(exp, block_with_args = nil)
+        exp = exp.new(*exp.map { |e| process_atom(e) })
+        _, receiver, method, *args = exp
+        return exp unless receiver && !receiver.empty?
+
+        t, *values = receiver
+        return exp unless t == :lit
+        if args.length == 1 && args[0].sexp_type == :lit && !@in_defined_statement
+          # we cannot collapse these in defined? statements, because it changes the type
+          # from method to expression
+          class_arg1 = values[0].class
+          class_arg2 = args[0][1].class
+          if [Integer, Float].include?(class_arg1) && [Integer, Float].include?(class_arg2)
+            # FIXME: Boolean or/and/xor/compare
+            case method
+            when :+, :-, :*, :<=>
+              return canary_const_op(exp, values)
+            when :/, :%
+              # FIXME: We could propagate NaNs and INFINITIES in the float-division case
+              return canary_const_op(exp, values) unless args[0][1] == 0
+              # FIXME: This one makes String#* timeout
+              # when :**
+              #   return canary_const_op(exp, values) unless values[0] < 0
+            when :&, :|, :^, :<<, :>>
+              return canary_const_op(exp, values) if [class_arg1, class_arg2].all? { |x| x == Integer }
+            when :==, :!=, :>, :>=, :<, :<=, :===
+              return canary_const_bool_op(exp, values)
+            end
+          end
+        elsif args.length == 0
+          return canary_const_not(exp, values) if method == :!
+        end
+        return exp
+      end
+
+      def canary_array_min(exp, values)
+        return exp.new(:nil) if values.empty?
+        return values[0] if values.length == 1
+        first, second, *rest = values
+        return(
+          exp.new(
+            :if,
+            exp.new(:call, first, :<, second),
+            canary_array_min(exp, [first, *rest]),
+            canary_array_min(exp, [second, *rest]),
+          )
+        )
+      end
+
+      def canary_array_max(exp, values)
+        return exp.new(:nil) if values.empty?
+        return values[0] if values.length == 1
+        first, second, *rest = values
+        return(
+          exp.new(
+            :if,
+            exp.new(:call, first, :>, second),
+            canary_array_max(exp, [first, *rest]),
+            canary_array_max(exp, [second, *rest]),
+          )
+        )
+      end
+
+      def canary_const_op(exp, values)
+        _, (_, arg1), op, (_, arg2) = exp
+        return exp.new(:lit, arg1.send(op, arg2))
+      end
+      def canary_const_bool_op(exp, values)
+        _, (_, arg1), op, (_, arg2) = exp
+        return exp.new(:true) if arg1.send(op, arg2)
+        return exp.new(:false)
+      end
+
+      def canary_const_not(exp, values)
+        _, (type, *), _not = exp
+        return exp.new(:false) if type_is_always_truthy(type)
+        return exp.new(:true) if type_is_always_falsey(type)
+        return exp
+      end
+    end
+  end
+end

--- a/lib/natalie/compiler2/optimizations/AST_based/constant_folding.rb
+++ b/lib/natalie/compiler2/optimizations/AST_based/constant_folding.rb
@@ -118,7 +118,12 @@ module Natalie
             end
           end
         elsif args.length == 0
-          return canary_const_not(exp, values) if method == :!
+          case method
+          when :!
+            return canary_const_not(exp)
+          when :is_truthy
+            return canary_const_truthy(exp)
+          end
         end
         return exp
       end
@@ -161,10 +166,17 @@ module Natalie
         return exp.new(:false)
       end
 
-      def canary_const_not(exp, values)
+      def canary_const_not(exp)
         _, (type, *), _not = exp
         return exp.new(:false) if type_is_always_truthy(type)
         return exp.new(:true) if type_is_always_falsey(type)
+        return exp
+      end
+
+      def canary_const_truthy(exp)
+        _, (type, *), is_truthy = exp
+        return exp.new(:true) if type_is_always_truthy(type)
+        return exp.new(:false) if type_is_always_falsey(type)
         return exp
       end
     end

--- a/lib/natalie/compiler2/optimizations/ast_based.rb
+++ b/lib/natalie/compiler2/optimizations/ast_based.rb
@@ -1,0 +1,25 @@
+require_relative './AST_based/canary_array_functions'
+require_relative './AST_based/constant_folding'
+
+# FIXME: Some of these  might be a bit more powerful if we implement them using
+#        the stack-based IR
+# FIXME: These are still dependent on the original compilers BasePass
+module Natalie
+  class Compiler2
+    AST_BASED_OPTIMIZATIONS = [
+      {
+        name: 'canary_array_functions',
+        class: CanaryArrayFunctions,
+        optimization_level: 0,
+        disable_flags: %w[nocanarry_array_functions],
+      },
+      {
+        name: 'constant_folding',
+        class: ConstantFolding,
+        optimization_level: 1,
+        enable_flags: %w[cf],
+        disable_flags: %w[nocf],
+      },
+    ]
+  end
+end

--- a/lib/natalie/compiler2/pass0.rb
+++ b/lib/natalie/compiler2/pass0.rb
@@ -1,0 +1,29 @@
+require_relative './base_pass'
+require_relative 'optimizations/ast_based'
+
+module Natalie
+  class Compiler2
+    # AST based optimization pass
+    class Pass0 < BasePass
+      def initialize(context, ast)
+        @context = context
+        @ast = ast
+      end
+
+      def transform()
+        raise 'unexpected AST input' unless @ast.sexp_type == :block
+        for optimization in AST_BASED_OPTIMIZATIONS
+          # FIXME: We maybe we should reenable the flag we have an enabling statement after a disabling one
+          if (
+               @context[:options][:optimization_level] >= optimization[:optimization_level] ||
+                 optimization[:enable_flags].any? { |flag| @context[:options][:optimizations]&.include?(flag) }
+             ) && !optimization[:disable_flags].any? { |flag| @context[:options][:optimizations]&.include?(flag) }
+            @ast = optimization[:class].new(@context).go(@ast)
+          end
+        end
+
+        return @ast
+      end
+    end
+  end
+end


### PR DESCRIPTION
A first stab at some of the optimizer things discussed in the discord, applied to the original compilers Pass0c
Plus a reworked, improved and fixed version of #430 for Compiler2

This PR uses a more Serenity-ish commit style starting with the second commit to differentiate the Compilers Pass0c and Compilerr2s Pass0, tell me if I need to adjust the wording/message-style in any way

This might accidentally increase the capabilities of the stack-based IR by allowing some Array functions with blocks on constant arrays, which we don't seem to support otherwise...

In the future we might want to re-implement these passes using the stack-based IR in the future, as it might allow us to see into some variable's values and to eliminate the dependence on `Natalie::Compiler::BasePass`

@TheGrizzlyDev
I have removed the `block_with_args`, I wasn't sure if it was needed
Can you check the re-check logic behind the canary-pass?