### PR TITLE
Compiler2: Allow class definition to have empty body

### DIFF
--- a/lib/natalie/compiler2/instructions/define_class_instruction.rb
+++ b/lib/natalie/compiler2/instructions/define_class_instruction.rb
@@ -33,8 +33,7 @@ module Natalie
         code << "auto #{klass} = #{superclass}->as_class()->subclass(env, #{@name.to_s.inspect})"
         code << "self->const_set(#{@name.to_s.inspect}_s, #{klass})"
         code << "#{klass}->eval_body(env, #{fn})"
-        transform.exec(code)
-        transform.push('NilObject::the()')
+        transform.exec_and_push(:result_of_define_class, code)
       end
 
       def execute(vm)

--- a/src/natalie.cpp
+++ b/src/natalie.cpp
@@ -333,11 +333,16 @@ ArrayObject *to_ary(Env *env, Value obj, bool raise_for_non_array) {
 
 static Value splat_value(Env *env, Value value, size_t index, size_t offset_from_end, bool has_kwargs) {
     ArrayObject *splat = new ArrayObject {};
-    if (has_kwargs && value->is_array() && value->as_array()->last()->is_hash())
+    if (!value->is_array())
+        return splat;
+    auto array = value->as_array();
+    if (has_kwargs && array->last()->is_hash())
         offset_from_end += 1; // compensate for kwargs hash that was passed as the last argument
-    if (value->is_array() && index < value->as_array()->size() - offset_from_end) {
-        for (size_t s = index; s < value->as_array()->size() - offset_from_end; s++) {
-            splat->push((*value->as_array())[s]);
+    if (array->size() < offset_from_end)
+        return splat;
+    if (index < array->size() - offset_from_end) {
+        for (size_t s = index; s < array->size() - offset_from_end; s++) {
+            splat->push((*array)[s]);
         }
     }
     return splat;


### PR DESCRIPTION
Error:

```sh-session
> bin/natalie -c2 -e "class Foo; end"
error: non-void function does not return a value [-Werror,-Wreturn-type]
}
^
```

Expected:

```rb
p (class Foo; end) # => nil
p (class Bar; :bar; end) # => :bar
```