### PR TITLE
Parser: fix some issues with assignment expressions

### DIFF
--- a/include/natalie_parser/node.hpp
+++ b/include/natalie_parser/node.hpp
@@ -67,10 +67,12 @@ public:
         Shell,
         Splat,
         SplatAssignment,
+        SplatValue,
         StabbyProc,
         String,
         Super,
         Symbol,
+        ToArray,
         True,
         Until,
         While,
@@ -1329,6 +1331,24 @@ protected:
     Node *m_node { nullptr };
 };
 
+class SplatValueNode : public Node {
+public:
+    SplatValueNode(const Token &token, Node *value)
+        : Node { token }
+        , m_value { value } { }
+
+    ~SplatValueNode() {
+        delete m_value;
+    }
+
+    virtual Type type() override { return Type::SplatValue; }
+
+    Node *value() const { return m_value; }
+
+protected:
+    Node *m_value { nullptr };
+};
+
 class StabbyProcNode : public NodeWithArgs {
 public:
     using NodeWithArgs::NodeWithArgs;
@@ -1364,6 +1384,24 @@ public:
 
 protected:
     SharedPtr<String> m_name {};
+};
+
+class ToArrayNode : public Node {
+public:
+    ToArrayNode(const Token &token, Node *value)
+        : Node { token }
+        , m_value { value } { }
+
+    ~ToArrayNode() {
+        delete m_value;
+    }
+
+    virtual Type type() override { return Type::ToArray; }
+
+    Node *value() const { return m_value; }
+
+protected:
+    Node *m_value { nullptr };
 };
 
 class TrueNode : public Node {

--- a/include/natalie_parser/parser.hpp
+++ b/include/natalie_parser/parser.hpp
@@ -257,6 +257,7 @@ private:
     Node *parse_assignment_expression(Node *, LocalsHashmap &);
     Node *parse_call_expression_without_parens(Node *, LocalsHashmap &);
     Node *parse_call_expression_with_parens(Node *, LocalsHashmap &);
+    Node *parse_call_arg(LocalsHashmap &, bool, bool *);
     void parse_call_args(NodeWithArgs *, LocalsHashmap &, bool = false);
     Node *parse_constant_resolution_expression(Node *, LocalsHashmap &);
     Node *parse_infix_expression(Node *, LocalsHashmap &);

--- a/include/natalie_parser/parser.hpp
+++ b/include/natalie_parser/parser.hpp
@@ -255,6 +255,8 @@ private:
     Node *parse_yield(LocalsHashmap &);
 
     Node *parse_assignment_expression(Node *, LocalsHashmap &);
+    Node *parse_assignment_expression(Node *, LocalsHashmap &, bool);
+    Node *parse_assignment_expression_value(bool, LocalsHashmap &, bool);
     Node *parse_call_expression_without_parens(Node *, LocalsHashmap &);
     Node *parse_call_expression_with_parens(Node *, LocalsHashmap &);
     Node *parse_call_arg(LocalsHashmap &, bool, bool *);

--- a/src/parser_object.cpp
+++ b/src/parser_object.cpp
@@ -155,8 +155,7 @@ Value ParserObject::node_to_ruby(Env *env, Node *node) {
         case Node::Type::MultipleAssignment: {
             auto masgn = static_cast<MultipleAssignmentNode *>(assignment_node->identifier());
             auto sexp = multiple_assignment_to_ruby_with_array(env, masgn);
-            auto value = new SexpObject { env, node, { "to_ary"_s } };
-            value->push(node_to_ruby(env, assignment_node->value()));
+            auto value = node_to_ruby(env, assignment_node->value());
             sexp->push(value);
             return sexp;
         }
@@ -797,6 +796,10 @@ Value ParserObject::node_to_ruby(Env *env, Node *node) {
             sexp->push(node_to_ruby(env, splat_node->node()));
         return sexp;
     }
+    case Node::Type::SplatValue: {
+        auto splat_value_node = static_cast<SplatValueNode *>(node);
+        return new SexpObject { env, splat_value_node, { "svalue"_s, node_to_ruby(env, splat_value_node->value()) } };
+    }
     case Node::Type::StabbyProc: {
         auto stabby_proc_node = static_cast<StabbyProcNode *>(node);
         return new SexpObject { env, stabby_proc_node, { "lambda"_s } };
@@ -808,6 +811,10 @@ Value ParserObject::node_to_ruby(Env *env, Node *node) {
     case Node::Type::Symbol: {
         auto symbol_node = static_cast<SymbolNode *>(node);
         return new SexpObject { env, symbol_node, { "lit"_s, SymbolObject::intern(symbol_node->name().ref()) } };
+    }
+    case Node::Type::ToArray: {
+        auto to_array_node = static_cast<ToArrayNode *>(node);
+        return new SexpObject { env, to_array_node, { "to_ary"_s, node_to_ruby(env, to_array_node->value()) } };
     }
     case Node::Type::True: {
         auto true_node = static_cast<TrueNode *>(node);

--- a/test/natalie/parser_test.rb
+++ b/test/natalie/parser_test.rb
@@ -202,6 +202,11 @@ describe 'Parser' do
       Parser.parse('x = foo.bar').should == s(:block, s(:lasgn, :x, s(:call, s(:call, nil, :foo), :bar)))
       Parser.parse('x = y = 2').should == s(:block, s(:lasgn, :x, s(:lasgn, :y, s(:lit, 2))))
       Parser.parse('x = y = z = 2').should == s(:block, s(:lasgn, :x, s(:lasgn, :y, s(:lasgn, :z, s(:lit, 2)))))
+      Parser.parse('x = 1, 2').should == s(:block, s(:lasgn, :x, s(:svalue, s(:array, s(:lit, 1), s(:lit, 2)))))
+      Parser.parse('x, y = 1, 2').should == s(:block, s(:masgn, s(:array, s(:lasgn, :x), s(:lasgn, :y)), s(:array, s(:lit, 1), s(:lit, 2))))
+      Parser.parse('x, y = 1').should == s(:block, s(:masgn, s(:array, s(:lasgn, :x), s(:lasgn, :y)), s(:to_ary, s(:lit, 1))))
+      Parser.parse('x = *[1, 2]').should == s(:block, s(:lasgn, :x, s(:svalue, s(:splat, s(:array, s(:lit, 1), s(:lit, 2))))))
+      Parser.parse('x, y = *[1, 2]').should == s(:block, s(:masgn, s(:array, s(:lasgn, :x), s(:lasgn, :y)), s(:splat, s(:array, s(:lit, 1), s(:lit, 2)))))
     end
 
     it 'parses attr assignment' do

--- a/test/natalie/parser_test.rb
+++ b/test/natalie/parser_test.rb
@@ -323,6 +323,7 @@ describe 'Parser' do
       Parser.parse('b=1; foo(a, *b, c)').should == s(:block, s(:lasgn, :b, s(:lit, 1)), s(:call, nil, :foo, s(:call, nil, :a), s(:splat, s(:lvar, :b)), s(:call, nil, :c)))
       Parser.parse('foo.()').should == s(:block, s(:call, s(:call, nil, :foo), :call))
       Parser.parse('foo.(1, 2)').should == s(:block, s(:call, s(:call, nil, :foo), :call, s(:lit, 1), s(:lit, 2)))
+      Parser.parse('foo(a = b, c)').should == s(:block, s(:call, nil, :foo, s(:lasgn, :a, s(:call, nil, :b)), s(:call, nil, :c)))
       if (RUBY_ENGINE == 'natalie')
         -> { Parser.parse('foo(') }.should raise_error(
                                              SyntaxError,
@@ -352,6 +353,7 @@ describe 'Parser' do
       Parser.parse('self.end').should == s(:block, s(:call, s(:self), :end))
       Parser.parse('describe :enumeratorize, shared: true').should == s(:block, s(:call, nil, :describe, s(:lit, :enumeratorize), s(:hash, s(:lit, :shared), s(:true))))
       Parser.parse("describe :enumeratorize, shared: true do\nnil\nend").should == s(:block, s(:iter, s(:call, nil, :describe, s(:lit, :enumeratorize), s(:hash, s(:lit, :shared), s(:true))), 0, s(:nil)))
+      Parser.parse('foo a = b, c').should == s(:block, s(:call, nil, :foo, s(:lasgn, :a, s(:call, nil, :b)), s(:call, nil, :c)))
     end
 
     it 'parses operator method calls' do


### PR DESCRIPTION
Assignment expression as call argument:

```rb
foo(a = b, c)
```

Multiple assignment with comma-separated values:

```rb
x, y = 1, 2
```