### PR TITLE
Make Enumerable#tally spec compliant

### DIFF
--- a/spec/core/enumerable/tally_spec.rb
+++ b/spec/core/enumerable/tally_spec.rb
@@ -33,3 +33,50 @@ ruby_version_is "2.7" do
     end
   end
 end
+
+ruby_version_is "3.1" do
+  describe "Enumerable#tally with a hash" do
+    before :each do
+      ScratchPad.record []
+    end
+
+    it "returns a hash with counts according to the value" do
+      enum = EnumerableSpecs::Numerous.new('foo', 'bar', 'foo', 'baz')
+      enum.tally({ 'foo' => 1 }).should == { 'foo' => 3, 'bar' => 1, 'baz' => 1}
+    end
+
+    it "returns the given hash" do
+      enum = EnumerableSpecs::Numerous.new('foo', 'bar', 'foo', 'baz')
+      hash = { 'foo' => 1 }
+      enum.tally(hash).should equal(hash)
+    end
+
+    it "raises a FrozenError and does not update the given hash when the hash is frozen" do
+      enum = EnumerableSpecs::Numerous.new('foo', 'bar', 'foo', 'baz')
+      hash = { 'foo' => 1 }.freeze
+      -> { enum.tally(hash) }.should raise_error(FrozenError)
+      hash.should == { 'foo' => 1 }
+    end
+
+    it "does not call given block" do
+      enum = EnumerableSpecs::Numerous.new('foo', 'bar', 'foo', 'baz')
+      enum.tally({ 'foo' => 1 }) { |v| ScratchPad << v }
+      ScratchPad.recorded.should == []
+    end
+
+    it "ignores the default value" do
+      enum = EnumerableSpecs::Numerous.new('foo', 'bar', 'foo', 'baz')
+      enum.tally(Hash.new(100)).should == { 'foo' => 2, 'bar' => 1, 'baz' => 1}
+    end
+
+    it "ignores the default proc" do
+      enum = EnumerableSpecs::Numerous.new('foo', 'bar', 'foo', 'baz')
+      enum.tally(Hash.new {100}).should == { 'foo' => 2, 'bar' => 1, 'baz' => 1}
+    end
+
+    it "needs the values counting each elements to be an integer" do
+      enum = EnumerableSpecs::Numerous.new('foo')
+      -> { enum.tally({ 'foo' => 'bar' }) }.should raise_error(TypeError)
+    end
+  end
+end

--- a/src/enumerable.rb
+++ b/src/enumerable.rb
@@ -892,13 +892,29 @@ module Enumerable
     broken_value
   end
 
-  def tally
-    hash = {}
+  def tally(hash = nil)
+    if hash
+      hash = hash.to_hash
+      if hash.frozen?
+        raise FrozenError, "can't modify frozen #{hash.class.name}: #{hash.inspect}"
+      end
+    else
+      hash = {}
+    end
+
     gather = ->(item) { item.size <= 1 ? item.first : item }
 
     each do |*item|
-      hash[gather.(item)] ||= 0
-      hash[gather.(item)] += 1
+      key = gather.(item)
+      if hash.key?(key)
+        value = hash[key]
+        unless value.is_a?(Integer)
+          raise TypeError, "wrong argument type #{value.class.name} (expected Integer)"
+        end
+        hash[key] = value + 1
+      else
+        hash[key] = 1
+      end
     end
 
     hash


### PR DESCRIPTION
Ruby 3.1 adds an optional hash argument: https://bugs.ruby-lang.org/issues/17744