### PR TITLE
Update bignum_value helper

### DIFF
--- a/spec/core/float/coerce_spec.rb
+++ b/spec/core/float/coerce_spec.rb
@@ -9,10 +9,10 @@ describe "Float#coerce" do
     1.0.coerce(3.14).should == [3.14, 1.0]
 
     #a, b = -0.0.coerce(bignum_value)
-    #a.should be_close(9223372036854775808.0, TOLERANCE)
+    #a.should be_close(18446744073709551616.0, TOLERANCE)
     #b.should be_close(-0.0, TOLERANCE)
     #a, b = 1.0.coerce(bignum_value)
-    #a.should be_close(9223372036854775808.0, TOLERANCE)
+    #a.should be_close(18446744073709551616.0, TOLERANCE)
     #b.should be_close(1.0, TOLERANCE)
   end
 end

--- a/spec/core/float/divmod_spec.rb
+++ b/spec/core/float/divmod_spec.rb
@@ -10,7 +10,7 @@ describe "Float#divmod" do
     values[1].should be_close(2.8284, TOLERANCE)
     values = -1.0.divmod(bignum_value)
     values[0].should eql(-1)
-    values[1].should be_close(9223372036854775808.000, TOLERANCE)
+    values[1].should be_close(18446744073709551616.0, TOLERANCE)
     values = -1.0.divmod(1)
     values[0].should eql(-1)
     values[1].should eql(0.0)

--- a/spec/core/float/minus_spec.rb
+++ b/spec/core/float/minus_spec.rb
@@ -6,7 +6,7 @@ describe "Float#-" do
 
   it "returns self minus other" do
     (9_237_212.5280 - 5_280).should be_close(9231932.528, TOLERANCE)
-    (2_560_496.1691 - bignum_value).should be_close(-9223372036852215808.000, TOLERANCE)
+    (2_560_496.1691 - bignum_value).should be_close(-18446744073706991616.0, TOLERANCE)
     (5.5 - 5.5).should be_close(0.0,TOLERANCE)
   end
 end

--- a/spec/core/float/multiply_spec.rb
+++ b/spec/core/float/multiply_spec.rb
@@ -7,7 +7,7 @@ describe "Float#*" do
   it "returns self multiplied by other" do
     (4923.98221 * 2).should be_close(9847.96442, TOLERANCE)
     (6712.5 * 0.25).should be_close(1678.125, TOLERANCE)
-    (256.4096 * bignum_value).should be_close(2364961134621118431232.000, TOLERANCE)
+    (256.4096 * bignum_value).should be_close(4729922269242236862464.0, TOLERANCE)
   end
 
   it "raises a TypeError when given a non-Numeric" do

--- a/spec/core/float/plus_spec.rb
+++ b/spec/core/float/plus_spec.rb
@@ -6,7 +6,7 @@ describe "Float#+" do
 
   it "returns self plus other" do
     (491.213 + 2).should be_close(493.213, TOLERANCE)
-    (9.99 + bignum_value).should be_close(9223372036854775808.000, TOLERANCE)
+    (9.99 + bignum_value).should be_close(18446744073709551616.0, TOLERANCE)
     (1001.99 + 5.219).should be_close(1007.209, TOLERANCE)
   end
 end

--- a/spec/core/integer/bit_and_spec.rb
+++ b/spec/core/integer/bit_and_spec.rb
@@ -56,24 +56,24 @@ describe "Integer#&" do
       @bignum = bignum_value(5)
       (@bignum & 3).should == 1
       (@bignum & 52).should == 4
-      (@bignum & bignum_value(9921)).should == 9223372036854775809
+      (@bignum & bignum_value(9921)).should == 18446744073709551617
 
       ((2*bignum_value) & 1).should == 0
-      ((2*bignum_value) & (2*bignum_value)).should == 18446744073709551616
+      ((2*bignum_value) & (2*bignum_value)).should == 36893488147419103232
     end
 
     it "returns self bitwise AND other when one operand is negative" do
       ((2*bignum_value) & -1).should == (2*bignum_value)
       ((4*bignum_value) & -1).should == (4*bignum_value)
-      (@bignum & -0xffffffffffffff5).should == 9223372036854775809
+      (@bignum & -0xffffffffffffff5).should == 18446744073709551617
       (@bignum & -@bignum).should == 1
-      (@bignum & -0x8000000000000000).should == 9223372036854775808
+      (@bignum & -0x8000000000000000).should == 18446744073709551616
     end
 
     it "returns self bitwise AND other when both operands are negative" do
-      (-@bignum & -0x4000000000000005).should == -13835058055282163717
-      (-@bignum & -@bignum).should == -9223372036854775813
-      (-@bignum & -0x4000000000000000).should == -13835058055282163712
+      (-@bignum & -0x4000000000000005).should == -23058430092136939525
+      (-@bignum & -@bignum).should == -18446744073709551621
+      (-@bignum & -0x4000000000000000).should == -23058430092136939520
     end
 
     # NATFIXME: implement Integer#<<

--- a/spec/core/integer/bit_or_spec.rb
+++ b/spec/core/integer/bit_or_spec.rb
@@ -7,7 +7,7 @@ describe "Integer#|" do
       (5 | 4).should == 5
       (5 | 6).should == 7
       (248 | 4096).should == 4344
-      (0xffff | bignum_value + 0xf0f0).should == 0x8000_0000_0000_ffff
+      (0xffff | bignum_value + 0xf0f0).should == 0x1_0000_0000_0000_ffff
     end
 
     it "returns self bitwise OR a bignum" do
@@ -32,20 +32,20 @@ describe "Integer#|" do
     end
 
     it "returns self bitwise OR other" do
-      (@bignum | 2).should == 9223372036854775819
-      (@bignum | 9).should == 9223372036854775819
-      (@bignum | bignum_value).should == 9223372036854775819
+      (@bignum | 2).should == 18446744073709551627
+      (@bignum | 9).should == 18446744073709551627
+      (@bignum | bignum_value).should == 18446744073709551627
     end
 
     it "returns self bitwise OR other when one operand is negative" do
-      (@bignum | -0x40000000000000000).should == -64563604257983430645
+      (@bignum | -0x40000000000000000).should == -55340232221128654837
       (@bignum | -@bignum).should == -1
       (@bignum | -0x8000000000000000).should == -9223372036854775797
     end
 
     it "returns self bitwise OR other when both operands are negative" do
       (-@bignum | -0x4000000000000005).should == -1
-      (-@bignum | -@bignum).should == -9223372036854775819
+      (-@bignum | -@bignum).should == -18446744073709551627
       (-@bignum | -0x4000000000000000).should == -11
     end
 

--- a/spec/core/integer/bit_xor_spec.rb
+++ b/spec/core/integer/bit_xor_spec.rb
@@ -5,7 +5,7 @@ describe "Integer#^" do
     it "returns self bitwise EXCLUSIVE OR other" do
       (3 ^ 5).should == 6
       (-2 ^ -255).should == 255
-      (5 ^ bignum_value + 0xffff_ffff).should == 0x8000_0000_ffff_fffa
+      (5 ^ bignum_value + 0xffff_ffff).should == 0x1_0000_0000_ffff_fffa
     end
 
     it "returns self bitwise EXCLUSIVE OR a bignum" do
@@ -30,21 +30,21 @@ describe "Integer#^" do
     end
 
     it "returns self bitwise EXCLUSIVE OR other" do
-      (@bignum ^ 2).should == 9223372036854775824
+      (@bignum ^ 2).should == 18446744073709551632
       (@bignum ^ @bignum).should == 0
-      (@bignum ^ 14).should == 9223372036854775836
+      (@bignum ^ 14).should == 18446744073709551644
     end
 
     it "returns self bitwise EXCLUSIVE OR other when one operand is negative" do
-      (@bignum ^ -0x40000000000000000).should == -64563604257983430638
+      (@bignum ^ -0x40000000000000000).should == -55340232221128654830
       (@bignum ^ -@bignum).should == -4
-      (@bignum ^ -0x8000000000000000).should == -18446744073709551598
+      (@bignum ^ -0x8000000000000000).should == -27670116110564327406
     end
 
     it "returns self bitwise EXCLUSIVE OR other when both operands are negative" do
-      (-@bignum ^ -0x40000000000000000).should == 64563604257983430638
+      (-@bignum ^ -0x40000000000000000).should == 55340232221128654830
       (-@bignum ^ -@bignum).should == 0
-      (-@bignum ^ -0x4000000000000000).should == 13835058055282163694
+      (-@bignum ^ -0x4000000000000000).should == 23058430092136939502
     end
 
     it "returns self bitwise EXCLUSIVE OR other when all bits are 1 and other value is negative" do

--- a/spec/core/integer/complement_spec.rb
+++ b/spec/core/integer/complement_spec.rb
@@ -12,9 +12,9 @@ describe "Integer#~" do
 
   context "bignum" do
     it "returns self with each bit flipped" do
-      (~bignum_value(48)).should == -9223372036854775857
-      (~(-bignum_value(21))).should == 9223372036854775828
-      (~bignum_value(1)).should == -9223372036854775810
+      (~bignum_value(48)).should == -18446744073709551665
+      (~(-bignum_value(21))).should == 18446744073709551636
+      (~bignum_value(1)).should == -18446744073709551618
     end
   end
 end

--- a/spec/core/integer/div_spec.rb
+++ b/spec/core/integer/div_spec.rb
@@ -71,9 +71,9 @@ describe "Integer#div" do
     end
 
     it "returns self divided by other" do
-      @bignum.div(4).should == 2305843009213693974
+      @bignum.div(4).should == 4611686018427387926
       # NATFIXME: Implement Integer#/ for Rational
-      # @bignum.div(Rational(4, 1)).should == 2305843009213693974
+      # @bignum.div(Rational(4, 1)).should == 4611686018427387926
       @bignum.div(bignum_value(2)).should == 1
 
       (-(10**50)).div(-(10**40 + 1)).should == 9999999999
@@ -126,11 +126,11 @@ describe "Integer#div" do
     end
 
     it "returns a result of integer division of self by a float argument" do
-      @bignum.div(4294967295.5).should eql(2147483648)
+      @bignum.div(4294967295.5).should eql(4294967296)
       not_supported_on :opal do
-        @bignum.div(4294967295.0).should eql(2147483648)
+        @bignum.div(4294967295.0).should eql(4294967297)
         @bignum.div(bignum_value(88).to_f).should eql(1)
-        @bignum.div(-bignum_value(88).to_f).should eql(-1)
+        @bignum.div((-bignum_value(88)).to_f).should eql(-1)
       end
     end
 

--- a/spec/core/integer/divide_spec.rb
+++ b/spec/core/integer/divide_spec.rb
@@ -48,7 +48,7 @@ describe "Integer#/" do
     end
 
     it "returns self divided by other" do
-      (@bignum / 4).should == 2305843009213693974
+      (@bignum / 4).should == 4611686018427387926
 
       (@bignum / bignum_value(2)).should == 1
 
@@ -61,16 +61,16 @@ describe "Integer#/" do
 
     it "returns self divided by Float" do
       not_supported_on :opal do
-        (bignum_value(88) / 4294967295.0).should be_close(2147483648.5, TOLERANCE)
+        (bignum_value(88) / 4294967295.0).should be_close(4294967297.0, TOLERANCE)
       end
-      (bignum_value(88) / 4294967295.5).should be_close(2147483648.25, TOLERANCE)
+      (bignum_value(88) / 4294967295.5).should be_close(4294967296.5, TOLERANCE)
     end
 
     it "returns result the same class as the argument" do
-      (@bignum / 4).should == 2305843009213693974
-      (@bignum / 4.0).should be_close(2305843009213693974, TOLERANCE)
+      (@bignum / 4).should == 4611686018427387926
+      (@bignum / 4.0).should be_close(4611686018427387926, TOLERANCE)
       # NATFIXME: Support Rational
-      # (@bignum / Rational(4, 1)).should == Rational(2305843009213693974, 1)
+      # (@bignum / Rational(4, 1)).should == Rational(4611686018427387926, 1)
     end
 
     it "does NOT raise ZeroDivisionError if other is zero and is a Float" do

--- a/spec/core/integer/divmod_spec.rb
+++ b/spec/core/integer/divmod_spec.rb
@@ -46,16 +46,16 @@ describe "Integer#divmod" do
     # assert(0 < b ? (0 <= r && r < b) : (b < r && r <= 0))
     # So, r is always between 0 and b.
     it "returns an Array containing quotient and modulus obtained from dividing self by the given argument" do
-      @bignum.divmod(4).should == [2305843009213693965, 3]
-      @bignum.divmod(13).should == [709490156681136604, 11]
+      @bignum.divmod(4).should == [4611686018427387917, 3]
+      @bignum.divmod(13).should == [1418980313362273205, 6]
 
-      @bignum.divmod(4.5).should == [2049638230412172288, 3.5]
+      @bignum.divmod(4.5).should == [4099276460824344576, 2.5]
 
       not_supported_on :opal do
-        @bignum.divmod(4.0).should == [2305843009213693952, 0.0]
-        @bignum.divmod(13.0).should == [709490156681136640, 8.0]
+        @bignum.divmod(4.0).should == [4611686018427387904, 0.0]
+        @bignum.divmod(13.0).should == [1418980313362273280, 3.0]
 
-        @bignum.divmod(2.0).should == [4611686018427387904, 0.0]
+        @bignum.divmod(2.0).should == [9223372036854775808, 0.0]
       end
 
       @bignum.divmod(bignum_value).should == [1, 55]

--- a/spec/core/integer/left_shift_spec.rb
+++ b/spec/core/integer/left_shift_spec.rb
@@ -96,7 +96,7 @@ describe "Integer#<< (with n << m)" do
 
   context "bignum" do
     before :each do
-      @bignum = bignum_value * 16
+      @bignum = bignum_value * 8 # 2 ** 67
     end
 
     it "returns n shifted left m bits when n > 0, m > 0" do

--- a/spec/core/integer/minus_spec.rb
+++ b/spec/core/integer/minus_spec.rb
@@ -10,7 +10,7 @@ describe "Integer#-" do
       (9237212 - 5_280).should == 9231932
 
       (781 - 0.5).should == 780.5
-      (2_560_496 - bignum_value).should == -9223372036852215312
+      (2_560_496 - bignum_value).should == -18446744073706991120
     end
 
     it "raises a TypeError when given a non-Integer" do
@@ -29,8 +29,8 @@ describe "Integer#-" do
     end
 
     it "returns self minus the given Integer" do
-      (@bignum - 9).should == 9223372036854776113
-      (@bignum - 12.57).should be_close(9223372036854776109.43, TOLERANCE)
+      (@bignum - 9).should == 18446744073709551921
+      (@bignum - 12.57).should be_close(18446744073709551917.43, TOLERANCE)
       (@bignum - bignum_value(42)).should == 272
     end
 

--- a/spec/core/integer/multiply_spec.rb
+++ b/spec/core/integer/multiply_spec.rb
@@ -10,7 +10,7 @@ describe "Integer#*" do
       (1342177 * 800).should == 1073741600
       (65536 * 65536).should == 4294967296
 
-      (256 * bignum_value).should == 2361183241434822606848
+      (256 * bignum_value).should == 4722366482869645213696
       (6712 * 0.25).should == 1678.0
     end
 
@@ -32,8 +32,8 @@ describe "Integer#*" do
     it "returns self multiplied by the given Integer" do
       (@bignum * (1/bignum_value(0xffff).to_f)).should be_close(1.0, TOLERANCE)
       (@bignum * (1/bignum_value(0xffff).to_f)).should be_close(1.0, TOLERANCE)
-      (@bignum * 10).should == 92233720368547765800
-      (@bignum * (@bignum - 40)).should == 85070591730234629737795195287525433200
+      (@bignum * 10).should == 184467440737095523880
+      (@bignum * (@bignum - 40)).should == 340282366920938491207277694290934407024
     end
 
     it "raises a TypeError when given a non-Integer" do

--- a/spec/core/integer/plus_spec.rb
+++ b/spec/core/integer/plus_spec.rb
@@ -9,7 +9,7 @@ describe "Integer#+" do
       (491 + 2).should == 493
       (90210 + 10).should == 90220
 
-      (9 + bignum_value).should == 9223372036854775817
+      (9 + bignum_value).should == 18446744073709551625
       (1001 + 5.219).should == 1006.219
     end
 
@@ -29,9 +29,9 @@ describe "Integer#+" do
     end
 
     it "returns self plus the given Integer" do
-      (@bignum + 4).should == 9223372036854775888
-      (@bignum + 4.2).should be_close(9223372036854775888.2, TOLERANCE)
-      (@bignum + bignum_value(3)).should == 18446744073709551695
+      (@bignum + 4).should == 18446744073709551696
+      (@bignum + 4.2).should be_close(18446744073709551696.2, TOLERANCE)
+      (@bignum + bignum_value(3)).should == 36893488147419103311
     end
 
     it "raises a TypeError when given a non-Integer" do

--- a/spec/core/integer/right_shift_spec.rb
+++ b/spec/core/integer/right_shift_spec.rb
@@ -96,7 +96,7 @@ describe "Integer#>> (with n >> m)" do
 
   context "bignum" do
     before :each do
-      @bignum = bignum_value * 16
+      @bignum = bignum_value * 8 # 2 ** 67
     end
 
     it "returns n shifted right m bits when n > 0, m > 0" do

--- a/spec/core/integer/shared/abs.rb
+++ b/spec/core/integer/shared/abs.rb
@@ -11,8 +11,8 @@ describe :integer_abs, shared: true do
 
   context "bignum" do
     it "returns the absolute bignum value" do
-      bignum_value(39).send(@method).should == 9223372036854775847
-      (-bignum_value(18)).send(@method).should == 9223372036854775826
+      bignum_value(39).send(@method).should == 18446744073709551655
+      (-bignum_value(18)).send(@method).should == 18446744073709551634
     end
   end
 end

--- a/spec/core/integer/shared/exponent.rb
+++ b/spec/core/integer/shared/exponent.rb
@@ -31,11 +31,13 @@ describe :integer_exponent, shared: true do
       (-2).send(@method, 30).should eql(1073741824)
       (-2).send(@method, 31).should eql(-2147483648)
       (-2).send(@method, 32).should eql(4294967296)
+      (-2).send(@method, 33).should eql(-8589934592)
 
       (-2).send(@method, 61).should eql(-2305843009213693952)
       (-2).send(@method, 62).should eql(4611686018427387904)
       (-2).send(@method, 63).should eql(-9223372036854775808)
       (-2).send(@method, 64).should eql(18446744073709551616)
+      (-2).send(@method, 65).should eql(-36893488147419103232)
     end
 
     it "can raise 1 to a bignum safely" do
@@ -100,8 +102,8 @@ describe :integer_exponent, shared: true do
     end
 
     it "returns self raised to other power" do
-      (@bignum.send(@method, 4)).should == 7237005577332262361485077344629993318496048279512298547155833600056910050625
-      (@bignum.send(@method, 1.2)).should be_close(57262152889751597425762.57804, TOLERANCE)
+      (@bignum.send(@method, 4)).should == 115792089237316196603666111261383895964500887398800252671052694326794607293761
+      (@bignum.send(@method, 1.3)).should be_close(11109528802438156839288832.0, TOLERANCE)
     end
 
     it "raises a TypeError when given a non-Integer" do
@@ -121,8 +123,9 @@ describe :integer_exponent, shared: true do
 
     # NATFIXME: Implement Complex and Rational
     xit "returns a complex number when negative and raised to a fractional power" do
-      ((-@bignum).send(@method, (1.0/3)))      .should be_close(Complex(1048576,1816186.907597341), TOLERANCE)
-      ((-@bignum).send(@method, Rational(1,3))).should be_close(Complex(1048576,1816186.907597341), TOLERANCE)
+      (-bignum_value).send(@method, (1.0/2)).should be_close(Complex(0.0, 4294967296.0), TOLERANCE)
+      (-@bignum).send(@method, (1.0/3))      .should be_close(Complex(1321122.9748145656, 2288252.1154253655), TOLERANCE)
+      (-@bignum).send(@method, Rational(1,3)).should be_close(Complex(1321122.9748145656, 2288252.1154253655), TOLERANCE)
     end
   end
 end

--- a/spec/core/integer/shared/modulo.rb
+++ b/spec/core/integer/shared/modulo.rb
@@ -48,11 +48,11 @@ describe :integer_modulo, shared: true do
     end
 
     it "returns the modulus obtained from dividing self by the given argument" do
-      @bignum.send(@method, 5).should == 3
-      @bignum.send(@method, -5).should == -2
-      @bignum.send(@method, -100).should == -92
-      @bignum.send(@method, 2.22).should be_close(0.780180180180252, TOLERANCE)
-      @bignum.send(@method, bignum_value(10)).should == 9223372036854775808
+      @bignum.send(@method, 5).should == 1
+      @bignum.send(@method, -5).should == -4
+      @bignum.send(@method, -100).should == -84
+      @bignum.send(@method, 2.22).should be_close(1.5603603603605034, TOLERANCE)
+      @bignum.send(@method, bignum_value(10)).should == 18446744073709551616
     end
 
     it "raises a ZeroDivisionError when the given argument is 0" do

--- a/spec/core/integer/to_f_spec.rb
+++ b/spec/core/integer/to_f_spec.rb
@@ -11,9 +11,9 @@ describe "Integer#to_f" do
 
   context "bignum" do
     it "returns self converted to a Float" do
-      bignum_value(0x4000_0aa0_0bb0_0000).to_f.should eql(13_835_069_737_789_292_544.00)
-      bignum_value(0x8000_0000_0000_0ccc).to_f.should eql(18_446_744_073_709_555_712.00)
-      (-bignum_value(99)).to_f.should eql(-9_223_372_036_854_775_808.00)
+      bignum_value(0x4000_0aa0_0bb0_0000).to_f.should eql(23_058_441_774_644_068_352.0)
+      bignum_value(0x8000_0000_0000_0ccc).to_f.should eql(27_670_116_110_564_330_700.0)
+      (-bignum_value(99)).to_f.should eql(-18_446_744_073_709_551_715.0)
     end
 
     it "converts number close to Float::MAX without exceeding MAX or producing NaN" do

--- a/spec/core/integer/to_s_spec.rb
+++ b/spec/core/integer/to_s_spec.rb
@@ -74,9 +74,9 @@ describe "Integer#to_s" do
 
     describe "when given no base" do
       it "returns self converted to a String using base 10" do
-        bignum_value(9).to_s.should == "9223372036854775817"
-        bignum_value.to_s.should == "9223372036854775808"
-        (-bignum_value(675)).to_s.should == "-9223372036854776483"
+        bignum_value(9).to_s.should == "18446744073709551625"
+        bignum_value.to_s.should == "18446744073709551616"
+        (-bignum_value(675)).to_s.should == "-18446744073709552291"
       end
     end
 

--- a/spec/core/integer/uminus_spec.rb
+++ b/spec/core/integer/uminus_spec.rb
@@ -20,11 +20,11 @@ describe "Integer#-@" do
 
   context "bignum" do
     it "returns self as a negative value" do
-      bignum_value.send(:-@).should == -9223372036854775808
-      (-bignum_value).send(:-@).should == 9223372036854775808
+      bignum_value.send(:-@).should == -18446744073709551616
+      (-bignum_value).send(:-@).should == 18446744073709551616
 
-      bignum_value(921).send(:-@).should == -9223372036854776729
-      (-bignum_value(921).send(:-@)).should == 9223372036854776729
+      bignum_value(921).send(:-@).should == -18446744073709552537
+      (-bignum_value(921).send(:-@)).should == 18446744073709552537
     end
   end
 end

--- a/test/natalie/integer_test.rb
+++ b/test/natalie/integer_test.rb
@@ -20,12 +20,12 @@ describe 'integer' do
 
     it 'handles bignums correctly' do
       bignum = bignum_value
-      (bignum % -50).should == -42
-      (bignum % -500).should == -192
-      (bignum % -999).should == -919
-      (bignum % -1009).should == -817
-      (-bignum % 999).should == 919
-      (-bignum % -999).should == -80
+      (bignum % -50).should == -34
+      (bignum % -500).should == -384
+      (bignum % -999).should == -839
+      (bignum % -1009).should == -625
+      (-bignum % 999).should == 839
+      (-bignum % -999).should == -160
       (-2 % bignum).should == bignum - 2
     end
 
@@ -34,8 +34,8 @@ describe 'integer' do
       (6 % -3.5).should == -1.0
       (6 % 7.5).should == 6.0
       (6 % 1.5).should == 0.0
-      (bignum_value % 4.5).should == 3.5
-      (bignum_value % -4.5).should == -1.0
+      (bignum_value % 4.5).should == 2.5
+      (bignum_value % -4.5).should == -2.0
     end
   end
 

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -148,7 +148,7 @@ def infinity_value
 end
 
 def bignum_value(plus = 0)
-  0x8000_0000_0000_0000 + plus
+  (2 ** 64) + plus
 end
 
 def fixnum_max


### PR DESCRIPTION
The ruby spec suite changed this helper recently

Related commits: [728915c2f2f8743b530dc941d2f4ed28409da8a0](https://github.com/ruby/spec/commit/728915c2f2f8743b530dc941d2f4ed28409da8a0) and [49adc2f1640c8f6f86d26a9e4ea78cc6829700fc](https://github.com/ruby/mspec/commit/49adc2f1640c8f6f86d26a9e4ea78cc6829700fc)