### PR TITLE
Parser: fix multiple assignment with namespaced/top-level constant

### DIFF
--- a/include/natalie/parser_object.hpp
+++ b/include/natalie/parser_object.hpp
@@ -27,7 +27,7 @@ private:
     Value class_or_module_name_to_ruby(Env *env, Node *name);
 
     SexpObject *build_args_sexp(Env *env, Node *parent, Vector<Node *> &args);
-    SexpObject *build_assignment_sexp(Env *env, Node *parent, IdentifierNode *identifier);
+    SexpObject *build_assignment_sexp(Env *env, Node *parent, Node *identifier);
     SexpObject *multiple_assignment_to_ruby_with_array(Env *env, MultipleAssignmentNode *node);
 };
 

--- a/include/natalie_parser/token.hpp
+++ b/include/natalie_parser/token.hpp
@@ -506,6 +506,7 @@ public:
         case Type::BareName:
         case Type::ClassVariable:
         case Type::Constant:
+        case Type::ConstantResolution:
         case Type::GlobalVariable:
         case Type::InstanceVariable:
             return true;

--- a/src/natalie_parser/node.cpp
+++ b/src/natalie_parser/node.cpp
@@ -52,6 +52,8 @@ void MultipleAssignmentNode::add_locals(TM::Hashmap<const char *> &locals) {
             identifier->add_to_locals(locals);
             break;
         }
+        case Node::Type::Colon2:
+        case Node::Type::Colon3:
         case Node::Type::Splat:
             break;
         case Node::Type::SplatAssignment: {

--- a/src/natalie_parser/parser.cpp
+++ b/src/natalie_parser/parser.cpp
@@ -30,10 +30,10 @@ enum class Parser::Precedence {
     SUM, // + -
     PRODUCT, // * / %
     PREFIX, // -1 +1
-    CONSTANTRESOLUTION, // ::
     UNARY_MINUS, // -
     EXPONENT, // **
     UNARY_PLUS, // ! ~ +
+    CONSTANTRESOLUTION, // ::
     DOT, // foo.bar foo&.bar
     CALL, // foo()
     REF, // foo[1] / foo[1] = 2

--- a/src/natalie_parser/parser.cpp
+++ b/src/natalie_parser/parser.cpp
@@ -33,6 +33,7 @@ enum class Parser::Precedence {
     UNARY_MINUS, // -
     EXPONENT, // **
     UNARY_PLUS, // ! ~ +
+    ASSIGNMENTIDENTIFIER,
     CONSTANTRESOLUTION, // ::
     DOT, // foo.bar foo&.bar
     CALL, // foo()
@@ -561,9 +562,10 @@ Node *Parser::parse_comma_separated_identifiers(LocalsHashmap &locals) {
         case Token::Type::BareName:
         case Token::Type::ClassVariable:
         case Token::Type::Constant:
+        case Token::Type::ConstantResolution:
         case Token::Type::GlobalVariable:
         case Token::Type::InstanceVariable:
-            list->add_node(parse_identifier(locals));
+            list->add_node(parse_expression(Precedence::ASSIGNMENTIDENTIFIER, locals));
             break;
         case Token::Type::LParen:
             advance();

--- a/test/natalie/parser_test.rb
+++ b/test/natalie/parser_test.rb
@@ -289,6 +289,7 @@ describe 'Parser' do
       Parser.parse('Foo::bar x, y').should == s(:block, s(:call, s(:const, :Foo), :bar, s(:call, nil, :x), s(:call, nil, :y)))
       Parser.parse('::FOO = 1').should == s(:block, s(:cdecl, s(:colon3, :FOO), s(:lit, 1)))
       Parser.parse('Foo::BAR = 1').should == s(:block, s(:cdecl, s(:colon2, s(:const, :Foo), :BAR), s(:lit, 1)))
+      Parser.parse('-Foo::BAR').should == s(:block, s(:call, s(:colon2, s(:const, :Foo), :BAR), :-@))
     end
 
     it 'parses global variables' do


### PR DESCRIPTION
For example:

```rb
A, B::C = 1, 2
A, ::B = 1, 2
```