### PR TITLE
Fix integer shift operations

### DIFF
--- a/spec/core/integer/left_shift_spec.rb
+++ b/spec/core/integer/left_shift_spec.rb
@@ -127,10 +127,6 @@ describe "Integer#<< (with n << m)" do
       (@bignum << -68).should == 0
     end
 
-    it "returns 0 when m < 0 and m is a Bignum" do
-      (@bignum << -bignum_value).should == 0
-    end
-
     it "returns a Fixnum == fixnum_max when (fixnum_max * 2) << -1 and n > 0" do
       result = (fixnum_max * 2) << -1
       result.should be_an_instance_of(Integer)
@@ -163,6 +159,53 @@ describe "Integer#<< (with n << m)" do
 
     it "raises a TypeError when passed a String" do
       -> { @bignum << "4" }.should raise_error(TypeError)
+    end
+  end
+
+  context "when m is a bignum or larger than int" do
+    it "returns -1 when m < 0 and n < 0" do
+      (-1 << -bignum_value).should == -1
+      (-1 << -(2**40)).should == -1
+
+      (-bignum_value << -bignum_value).should == -1
+      (-bignum_value << -(2**40)).should == -1
+    end
+
+    it "returns 0 when m < 0 and n >= 0" do
+      (0 << -bignum_value).should == 0
+      (1 << -bignum_value).should == 0
+      (bignum_value << -bignum_value).should == 0
+
+      (0 << -(2**40)).should == 0
+      (1 << -(2**40)).should == 0
+      (bignum_value << -(2**40)).should == 0
+    end
+
+    ruby_bug "#18517", ""..."3.2" do
+      it "returns 0 when m > 0 long and n == 0" do
+        (0 << (2**40)).should == 0
+      end
+    end
+
+    it "returns 0 when m > 0 bignum and n == 0" do
+      (0 << bignum_value).should == 0
+    end
+
+    ruby_bug "#18518", ""..."3.3" do
+      it "raises NoMemoryError when m > 0 and n != 0" do
+        coerce_long = mock("long")
+        coerce_long.stub!(:to_int).and_return(2**40)
+        coerce_bignum = mock("bignum")
+        coerce_bignum.stub!(:to_int).and_return(bignum_value)
+        exps = [2**40, bignum_value, coerce_long, coerce_bignum]
+
+        exps.each { |exp|
+          -> { (1 << exp) }.should raise_error(NoMemoryError)
+          -> { (-1 << exp) }.should raise_error(NoMemoryError)
+          -> { (bignum_value << exp) }.should raise_error(NoMemoryError)
+          -> { (-bignum_value << exp) }.should raise_error(NoMemoryError)
+        }
+      end
     end
   end
 end

--- a/spec/core/integer/right_shift_spec.rb
+++ b/spec/core/integer/right_shift_spec.rb
@@ -52,10 +52,6 @@ describe "Integer#>> (with n >> m)" do
       (-7 >> 64).should == -1
     end
 
-    it "returns 0 when m is a bignum" do
-      (3 >> bignum_value).should == 0
-    end
-
     it "returns a Bignum == fixnum_max * 2 when fixnum_max >> -1 and n > 0" do
       result = fixnum_max >> -1
       result.should be_an_instance_of(Integer)
@@ -153,10 +149,6 @@ describe "Integer#>> (with n >> m)" do
       (@bignum >> 68).should == 0
     end
 
-    it "returns 0 when m is a Bignum" do
-      (@bignum >> bignum_value).should == 0
-    end
-
     it "returns a Fixnum == fixnum_max when (fixnum_max * 2) >> 1 and n > 0" do
       result = (fixnum_max * 2) >> 1
       result.should be_an_instance_of(Integer)
@@ -189,6 +181,53 @@ describe "Integer#>> (with n >> m)" do
 
     it "raises a TypeError when passed a String" do
       -> { @bignum >> "4" }.should raise_error(TypeError)
+    end
+  end
+
+  context "when m is a bignum or larger than int" do
+    it "returns -1 when m > 0 and n < 0" do
+      (-1 >> bignum_value).should == -1
+      (-1 >> (2**40)).should == -1
+
+      (-bignum_value >> bignum_value).should == -1
+      (-bignum_value >> (2**40)).should == -1
+    end
+
+    it "returns 0 when m > 0 and n >= 0" do
+      (0 >> bignum_value).should == 0
+      (1 >> bignum_value).should == 0
+      (bignum_value >> bignum_value).should == 0
+
+      (0 >> (2**40)).should == 0
+      (1 >> (2**40)).should == 0
+      (bignum_value >> (2**40)).should == 0
+    end
+
+    ruby_bug "#18517", ""..."3.2" do
+      it "returns 0 when m < 0 long and n == 0" do
+        (0 >> -(2**40)).should == 0
+      end
+    end
+
+    it "returns 0 when m < 0 bignum and n == 0" do
+      (0 >> -bignum_value).should == 0
+    end
+
+    ruby_bug "#18518", ""..."3.3" do
+      it "raises NoMemoryError when m < 0 and n != 0" do
+        coerce_long = mock("long")
+        coerce_long.stub!(:to_int).and_return(-(2**40))
+        coerce_bignum = mock("bignum")
+        coerce_bignum.stub!(:to_int).and_return(-bignum_value)
+        exps = [-(2**40), -bignum_value, coerce_long, coerce_bignum]
+
+        exps.each { |exp|
+          -> { (1 >> exp) }.should raise_error(NoMemoryError)
+          -> { (-1 >> exp) }.should raise_error(NoMemoryError)
+          -> { (bignum_value >> exp) }.should raise_error(NoMemoryError)
+          -> { (-bignum_value >> exp) }.should raise_error(NoMemoryError)
+        }
+      end
     end
   end
 end

--- a/src/big_int.cpp
+++ b/src/big_int.cpp
@@ -1993,8 +1993,12 @@ BigInt BigInt::operator>>(const size_t &num) const {
     TM::String binary = to_binary();
     TM::String complete_string;
 
-    if (num > binary.size())
-        return BigInt(0);
+    if (num > binary.size()) {
+        if (is_negative())
+            return BigInt(-1);
+        else
+            return BigInt(0);
+    }
 
     for (size_t i = 0; i < binary.size() - num; ++i) {
         complete_string.append_char(binary[i]);

--- a/src/integer_object.cpp
+++ b/src/integer_object.cpp
@@ -568,8 +568,12 @@ Value IntegerObject::left_shift(Env *env, Value arg) {
         nat_int = arg.get_fast_integer();
     } else {
         auto integer = arg->to_int(env);
-        if (integer->is_bignum())
-            return Value::integer(0);
+        if (integer->is_bignum()) {
+            if (is_negative())
+                return Value::integer(-1);
+            else
+                return Value::integer(0);
+        }
 
         nat_int = integer->to_nat_int_t();
     }
@@ -600,8 +604,12 @@ Value IntegerObject::right_shift(Env *env, Value arg) {
         nat_int = arg.get_fast_integer();
     } else {
         auto integer = arg->to_int(env);
-        if (integer->is_bignum())
-            return Value::integer(0);
+        if (integer->is_bignum()) {
+            if (is_negative())
+                return Value::integer(-1);
+            else
+                return Value::integer(0);
+        }
 
         nat_int = integer->to_nat_int_t();
     }
@@ -610,21 +618,15 @@ Value IntegerObject::right_shift(Env *env, Value arg) {
         return left_shift(env, Value::integer(-nat_int));
     }
 
-    BigInt max = ::pow(BigInt(2), nat_int);
-    if (is_bignum()) {
-        auto bigint = to_bigint();
-        if (bigint > 0 && bigint < max)
-            return Value::integer(0);
-        else if (bigint < 0 && bigint > max)
-            return Value::integer(-1);
-    } else if (m_integer > 0 && max > m_integer) {
-        return Value::integer(0);
-    } else if (m_integer < 0 && max > -m_integer) {
-        return Value::integer(-1);
-    }
-
     if (is_bignum())
         return BignumObject::create_if_needed(to_bigint() >> nat_int);
+
+    if (nat_int > (nat_int_t)sizeof(nat_int_t)) {
+        if (is_negative())
+            return Value::integer(-1);
+        else
+            return Value::integer(0);
+    }
 
     return Value::integer(to_nat_int_t() >> nat_int);
 }

--- a/test/support/spec.rb
+++ b/test/support/spec.rb
@@ -202,6 +202,9 @@ def ruby_version_is(version)
   end
 end
 
+# We do not want replicate ruby bugs
+def ruby_bug(*); end
+
 def slow_test
   yield if ENV['ENABLE_SLOW_TESTS']
 end


### PR DESCRIPTION
This also adds the `ruby_bug` method to the spec library. I figured we just want to skip over specs for ruby bugs. What do you think? @seven1m 