### PR TITLE
Implement `observer` module

### DIFF
--- a/lib/observer.rb
+++ b/lib/observer.rb
@@ -4,23 +4,31 @@ module Observable
   end
 
   def add_observer(observer, callback = :update)
-    @observer_peers = {} unless defined? @observer_peers
+    @observers = {} unless defined? @observers
 
     unless observer.respond_to? callback
       raise NoMethodError, "observer does not respond to `#{callback}`"
     end
 
-    @observer_peers[observer] = callback
+    @observers[observer] = callback
+  end
+
+  def delete_observer(observer)
+    @observers.delete observer if defined? @observers
+  end
+
+  def delete_observers
+    @observers.clear if defined? @observers
   end
 
   def count_observers
-    return @observer_peers.size if defined? @observer_peers else 0
+    return @observers.size if defined? @observers else 0
   end
 
   def notify_observers(*arg)
     if defined? @observer_state and @observer_state
-      if defined? @observer_peers
-        @observer_peers.each do |observer, callback|
+      if defined? @observers
+        @observers.each do |observer, callback|
           observer.__send__(callback, *arg)
         end
       end

--- a/lib/observer.rb
+++ b/lib/observer.rb
@@ -13,6 +13,10 @@ module Observable
     @observer_peers[observer] = callback
   end
 
+  def count_observers
+    return @observer_peers.size if defined? @observer_peers else 0
+  end
+
   def notify_observers(*arg)
     if defined? @observer_state and @observer_state
       if defined? @observer_peers

--- a/lib/observer.rb
+++ b/lib/observer.rb
@@ -1,0 +1,27 @@
+module Observable
+  def changed(state = true)
+    @observer_state = state
+  end
+
+  def add_observer(observer, callback = :update)
+    @observer_peers = {} unless defined? @observer_peers
+
+    unless observer.respond_to? callback
+      raise NoMethodError, "observer does not respond to `#{callback}`"
+    end
+
+    @observer_peers[observer] = callback
+  end
+
+  def notify_observers(*arg)
+    if defined? @observer_state and @observer_state
+      if defined? @observer_peers
+        @observer_peers.each do |observer, callback|
+          observer.__send__(callback, *arg)
+        end
+      end
+      
+      @observer_state = false
+    end
+  end
+end

--- a/spec/library/observer/add_observer_spec.rb
+++ b/spec/library/observer/add_observer_spec.rb
@@ -1,0 +1,23 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Observer#add_observer" do
+
+  before :each do
+    @observable = ObservableSpecs.new
+    @observer = ObserverCallbackSpecs.new
+  end
+
+  it "adds the observer" do
+    @observer.value.should == nil
+    @observable.changed
+    @observable.notify_observers("test")
+    @observer.value.should == nil
+
+    @observable.add_observer(@observer)
+    @observable.changed
+    @observable.notify_observers("test2")
+    @observer.value.should == "test2"
+  end
+
+end

--- a/spec/library/observer/count_observers_spec.rb
+++ b/spec/library/observer/count_observers_spec.rb
@@ -1,0 +1,23 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Observer#count_observers" do
+  before :each do
+    @observable = ObservableSpecs.new
+    @observer   = ObserverCallbackSpecs.new
+    @observer2  = ObserverCallbackSpecs.new
+  end
+
+  it "returns the number of observers" do
+    @observable.count_observers.should == 0
+    @observable.add_observer(@observer)
+    @observable.count_observers.should == 1
+    @observable.add_observer(@observer2)
+    @observable.count_observers.should == 2
+  end
+
+  it "returns the number of unique observers" do
+    2.times { @observable.add_observer(@observer) }
+    @observable.count_observers.should == 1
+  end
+end

--- a/spec/library/observer/delete_observer_spec.rb
+++ b/spec/library/observer/delete_observer_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Observer#delete_observer" do
+  before :each do
+    @observable = ObservableSpecs.new
+    @observer = ObserverCallbackSpecs.new
+  end
+
+  it "deletes the observer" do
+    @observable.add_observer(@observer)
+    @observable.delete_observer(@observer)
+
+    @observable.changed
+    @observable.notify_observers("test")
+    @observer.value.should == nil
+  end
+
+end

--- a/spec/library/observer/delete_observers_spec.rb
+++ b/spec/library/observer/delete_observers_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Observer#delete_observers" do
+  before :each do
+    @observable = ObservableSpecs.new
+    @observer = ObserverCallbackSpecs.new
+  end
+
+  it "deletes the observers" do
+    @observable.add_observer(@observer)
+    @observable.delete_observers
+
+    @observable.changed
+    @observable.notify_observers("test")
+    @observer.value.should == nil
+  end
+
+end

--- a/spec/library/observer/fixtures/classes.rb
+++ b/spec/library/observer/fixtures/classes.rb
@@ -1,0 +1,17 @@
+require 'observer'
+
+class ObserverCallbackSpecs
+  attr_reader :value
+
+  def initialize
+    @value = nil
+  end
+
+  def update(value)
+    @value = value
+  end
+end
+
+class ObservableSpecs
+  include Observable
+end

--- a/spec/library/observer/notify_observers_spec.rb
+++ b/spec/library/observer/notify_observers_spec.rb
@@ -1,0 +1,31 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Observer#notify_observers" do
+
+  before :each do
+    @observable = ObservableSpecs.new
+    @observer = ObserverCallbackSpecs.new
+    @observable.add_observer(@observer)
+  end
+
+  it "must call changed before notifying observers" do
+    @observer.value.should == nil
+    @observable.notify_observers("test")
+    @observer.value.should == nil
+  end
+
+  it "verifies observer responds to update" do
+    -> {
+      @observable.add_observer(@observable)
+    }.should raise_error(NoMethodError)
+  end
+
+  it "receives the callback" do
+    @observer.value.should == nil
+    @observable.changed
+    @observable.notify_observers("test")
+    @observer.value.should == "test"
+  end
+
+end


### PR DESCRIPTION
This pull request introduces the `observer` module into Natalie and makes it spec-compliant too.

I'm not really sure what our takes are on implementing gems as first-party libraries - I know we already have some basic impl of the `strscan` gem too, so figured this would be okay.