### PR TITLE
Implement the `base64` module

### DIFF
--- a/include/natalie/array_packer/packer.hpp
+++ b/include/natalie/array_packer/packer.hpp
@@ -37,6 +37,7 @@ namespace ArrayPacker {
                 case 'Z':
                 case 'h':
                 case 'H':
+                case 'm':
                 case 'u': {
                     if (at_end())
                         env->raise("ArgumentError", "too few arguments");

--- a/include/natalie/array_packer/string_handler.hpp
+++ b/include/natalie/array_packer/string_handler.hpp
@@ -162,7 +162,7 @@ namespace ArrayPacker {
             return six_bit == 0 ? '`' : (six_bit + 32);
         }
 
-        std::array<char, 4> encode_triplet(char a, char b, char c) {
+        std::array<char, 4> base64_encode_triplet(char a, char b, char c) {
             static constexpr char encode_table[] = {
                 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K',
                 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V',
@@ -200,7 +200,7 @@ namespace ArrayPacker {
                 auto second = next();
                 auto third = next();
 
-                auto base64_chars = encode_triplet(first, second, third);
+                auto base64_chars = base64_encode_triplet(first, second, third);
 
                 push(base64_chars[0]);
                 push(base64_chars[1]);
@@ -210,14 +210,14 @@ namespace ArrayPacker {
 
             auto const remaining = size - (triples * 3);
             if (! at_end() && remaining == 2) {
-                auto base64_chars = encode_triplet(next(), next(), 0x00);
+                auto base64_chars = base64_encode_triplet(next(), next(), 0x00);
 
                 push(base64_chars[0]);
                 push(base64_chars[1]);
                 push(base64_chars[2]);
                 push('=');
             } else {
-                auto base64_chars = encode_triplet(next(), 0x00, 0x00);
+                auto base64_chars = base64_encode_triplet(next(), 0x00, 0x00);
 
                 push(base64_chars[0]);
                 push(base64_chars[1]);

--- a/include/natalie/array_packer/string_handler.hpp
+++ b/include/natalie/array_packer/string_handler.hpp
@@ -3,6 +3,7 @@
 #include "natalie/array_packer/tokenizer.hpp"
 #include "natalie/env.hpp"
 #include "tm/string.hpp"
+#include <array>
 
 namespace Natalie {
 
@@ -34,6 +35,9 @@ namespace ArrayPacker {
                 break;
             case 'H':
                 pack_with_loop(&StringHandler::pack_H);
+                break;
+            case 'm':
+                pack_m();
                 break;
             case 'u':
                 pack_u();
@@ -156,6 +160,72 @@ namespace ArrayPacker {
             constexpr unsigned char six_bit_mask = 0b00111111;
             unsigned char six_bit = ascii & six_bit_mask;
             return six_bit == 0 ? '`' : (six_bit + 32);
+        }
+
+        std::array<char, 4> encode_triplet(char a, char b, char c) {
+            static constexpr char encode_table[] = {
+                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K',
+                'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V',
+                'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g',
+                'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r',
+                's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2',
+                '3', '4', '5', '6', '7', '8', '9', '+', '/'
+            };
+
+            auto const bits = (a << 16) | (b << 8) | c;
+
+            auto const b64_first = encode_table[(bits >> 18) & 0b0011'1111];
+            auto const b64_second = encode_table[(bits >> 12) & 0b0011'1111];
+            auto const b64_third = encode_table[(bits >> 6) & 0b0011'1111];
+            auto const b64_fourth = encode_table[bits & 0b0011'1111];
+
+            return { b64_first, b64_second, b64_third, b64_fourth };
+        }
+
+        void pack_m() {
+            bool has_valid_count = !m_token.star && m_token.count >= 0;
+            size_t count = has_valid_count ? m_token.count : 60;
+
+            auto size = (int)m_source.size();
+            auto triples = size / 3;
+            auto push = [&](char b64) {
+                if (m_packed.size() == count)
+                    m_packed.append_char('\n');
+
+                m_packed.append_char(b64);
+            };
+
+            for (auto i = 0; i < triples; ++i) {
+                auto first = next();
+                auto second = next();
+                auto third = next();
+
+                auto base64_chars = encode_triplet(first, second, third);
+
+                push(base64_chars[0]);
+                push(base64_chars[1]);
+                push(base64_chars[2]);
+                push(base64_chars[3]);
+            }
+
+            auto const remaining = size - (triples * 3);
+            if (! at_end() && remaining == 2) {
+                auto base64_chars = encode_triplet(next(), next(), 0x00);
+
+                push(base64_chars[0]);
+                push(base64_chars[1]);
+                push(base64_chars[2]);
+                push('=');
+            } else {
+                auto base64_chars = encode_triplet(next(), 0x00, 0x00);
+
+                push(base64_chars[0]);
+                push(base64_chars[1]);
+                push('=');
+                push('=');
+            }
+
+            m_packed.append_char('\n');
         }
 
         void pack_u() {

--- a/include/natalie/array_packer/string_handler.hpp
+++ b/include/natalie/array_packer/string_handler.hpp
@@ -189,10 +189,10 @@ namespace ArrayPacker {
             auto size = (int)m_source.size();
             auto triples = size / 3;
             auto push = [&](char b64) {
+                m_packed.append_char(b64);
+
                 if (m_packed.size() == count)
                     m_packed.append_char('\n');
-
-                m_packed.append_char(b64);
             };
 
             for (auto i = 0; i < triples; ++i) {
@@ -225,7 +225,8 @@ namespace ArrayPacker {
                 push('=');
             }
 
-            m_packed.append_char('\n');
+            if (count > 0)
+                m_packed.append_char('\n');
         }
 
         void pack_u() {

--- a/lib/base64.rb
+++ b/lib/base64.rb
@@ -6,4 +6,9 @@ module Base64
   def self.strict_encode64(str)
     [str].pack("m0")
   end
+
+  # NATFIXME: Make this spec-compliant.
+  def self.urlsafe_encode64(bin, padding: true)
+    strict_encode64(bin)
+  end
 end

--- a/lib/base64.rb
+++ b/lib/base64.rb
@@ -1,5 +1,9 @@
 module Base64
-  def self.encode64(bin)
-    [bin].pack("m")
+  def self.encode64(str)
+    [str].pack("m")
+  end
+
+  def self.strict_encode64(str)
+    [str].pack("m0")
   end
 end

--- a/lib/base64.rb
+++ b/lib/base64.rb
@@ -1,0 +1,5 @@
+module Base64
+  def self.encode64(bin)
+    [bin].pack("m")
+  end
+end

--- a/spec/library/base64/decode64_spec.rb
+++ b/spec/library/base64/decode64_spec.rb
@@ -1,0 +1,29 @@
+require_relative '../../spec_helper'
+
+require 'base64'
+
+describe "Base64#decode64" do
+  it "returns the Base64-decoded version of the given string" do
+    Base64.decode64("U2VuZCByZWluZm9yY2VtZW50cw==\n").should == "Send reinforcements"
+  end
+
+  it "returns the Base64-decoded version of the given shared string" do
+    Base64.decode64("base64: U2VuZCByZWluZm9yY2VtZW50cw==\n".split(" ").last).should == "Send reinforcements"
+  end
+
+  it "returns the Base64-decoded version of the given string with wrong padding" do
+    Base64.decode64("XU2VuZCByZWluZm9yY2VtZW50cw===").should == "]M\x95\xB9\x90\x81\xC9\x95\xA5\xB9\x99\xBD\xC9\x8D\x95\xB5\x95\xB9\xD1\xCC".b
+  end
+
+  it "returns the Base64-decoded version of the given string that contains an invalid character" do
+    Base64.decode64("%3D").should == "\xDC".b
+  end
+
+  it "returns a binary encoded string" do
+    Base64.decode64("SEk=").encoding.should == Encoding::BINARY
+  end
+
+  it "decodes without padding suffix ==" do
+    Base64.decode64("eyJrZXkiOnsibiI6InR0dCJ9fQ").should == "{\"key\":{\"n\":\"ttt\"}}"
+  end
+end

--- a/spec/library/base64/decode64_spec.rb
+++ b/spec/library/base64/decode64_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../spec_helper'
 
 require 'base64'
 
-describe "Base64#decode64" do
+xdescribe "Base64#decode64" do
   it "returns the Base64-decoded version of the given string" do
     Base64.decode64("U2VuZCByZWluZm9yY2VtZW50cw==\n").should == "Send reinforcements"
   end

--- a/spec/library/base64/encode64_spec.rb
+++ b/spec/library/base64/encode64_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../spec_helper'
+
+require 'base64'
+
+describe "Base64#encode64" do
+  it "returns the Base64-encoded version of the given string" do
+    Base64.encode64("Now is the time for all good coders\nto learn Ruby").should ==
+      "Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4g\nUnVieQ==\n"
+  end
+
+  it "returns the Base64-encoded version of the given string" do
+    Base64.encode64('Send reinforcements').should == "U2VuZCByZWluZm9yY2VtZW50cw==\n"
+  end
+
+  it "returns the Base64-encoded version of the given shared string" do
+    Base64.encode64("Now is the time for all good coders\nto learn Ruby".split("\n").last).should ==
+      "dG8gbGVhcm4gUnVieQ==\n"
+  end
+
+  # NATFIXME: Add back once we have the ASCII encoding.
+  xit "returns a US_ASCII encoded string" do
+    Base64.encode64("HI").encoding.should == Encoding::US_ASCII
+  end
+end

--- a/spec/library/base64/strict_decode64_spec.rb
+++ b/spec/library/base64/strict_decode64_spec.rb
@@ -1,0 +1,41 @@
+require_relative '../../spec_helper'
+
+require 'base64'
+
+describe "Base64#strict_decode64" do
+  it "returns the Base64-decoded version of the given string" do
+    Base64.strict_decode64("U2VuZCByZWluZm9yY2VtZW50cw==").should == "Send reinforcements"
+  end
+
+  it "returns the Base64-decoded version of the given shared string" do
+    Base64.strict_decode64("base64: U2VuZCByZWluZm9yY2VtZW50cw==".split(" ").last).should == "Send reinforcements"
+  end
+
+  it "raises ArgumentError when the given string contains CR" do
+    -> do
+      Base64.strict_decode64("U2VuZCByZWluZm9yY2VtZW50cw==\r")
+    end.should raise_error(ArgumentError)
+  end
+
+  it "raises ArgumentError when the given string contains LF" do
+    -> do
+      Base64.strict_decode64("U2VuZCByZWluZm9yY2VtZW50cw==\n")
+    end.should raise_error(ArgumentError)
+  end
+
+  it "raises ArgumentError when the given string has wrong padding" do
+    -> do
+      Base64.strict_decode64("=U2VuZCByZWluZm9yY2VtZW50cw==")
+    end.should raise_error(ArgumentError)
+  end
+
+  it "raises ArgumentError when the given string contains an invalid character" do
+    -> do
+      Base64.strict_decode64("%3D")
+    end.should raise_error(ArgumentError)
+  end
+
+  it "returns a binary encoded string" do
+    Base64.strict_decode64("SEk=").encoding.should == Encoding::BINARY
+  end
+end

--- a/spec/library/base64/strict_decode64_spec.rb
+++ b/spec/library/base64/strict_decode64_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../spec_helper'
 
 require 'base64'
 
-describe "Base64#strict_decode64" do
+xdescribe "Base64#strict_decode64" do
   it "returns the Base64-decoded version of the given string" do
     Base64.strict_decode64("U2VuZCByZWluZm9yY2VtZW50cw==").should == "Send reinforcements"
   end

--- a/spec/library/base64/strict_encode64_spec.rb
+++ b/spec/library/base64/strict_encode64_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../../spec_helper'
+
+require 'base64'
+
+describe "Base64#strict_encode64" do
+  it "returns the Base64-encoded version of the given string" do
+    Base64.strict_encode64("Now is the time for all good coders\nto learn Ruby").should ==
+      "Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4gUnVieQ=="
+  end
+
+  it "returns the Base64-encoded version of the given shared string" do
+    Base64.strict_encode64("Now is the time for all good coders\nto learn Ruby".split("\n").last).should ==
+      "dG8gbGVhcm4gUnVieQ=="
+  end
+
+  it "returns a US_ASCII encoded string" do
+    Base64.strict_encode64("HI").encoding.should == Encoding::US_ASCII
+  end
+end

--- a/spec/library/base64/strict_encode64_spec.rb
+++ b/spec/library/base64/strict_encode64_spec.rb
@@ -13,7 +13,8 @@ describe "Base64#strict_encode64" do
       "dG8gbGVhcm4gUnVieQ=="
   end
 
-  it "returns a US_ASCII encoded string" do
+  # NATFIXME: Add back once we have the ASCII encoding.
+  xit "returns a US_ASCII encoded string" do
     Base64.strict_encode64("HI").encoding.should == Encoding::US_ASCII
   end
 end

--- a/spec/library/base64/urlsafe_decode64_spec.rb
+++ b/spec/library/base64/urlsafe_decode64_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../../spec_helper'
+
+require 'base64'
+
+describe "Base64#urlsafe_decode64" do
+  it "uses '_' instead of '/'" do
+    decoded = Base64.urlsafe_decode64("V2hlcmUgYW0gST8gV2hvIGFtIEk_IEFtIEk_IEk_")
+    decoded.should == 'Where am I? Who am I? Am I? I?'
+  end
+
+  it "uses '-' instead of '+'" do
+    decoded = Base64.urlsafe_decode64('IkJlaW5nIGRpc2ludGVncmF0ZWQgbWFrZXMgbWUgdmUtcnkgYW4tZ3J5ISIgPGh1ZmYsIGh1ZmY-')
+    decoded.should == '"Being disintegrated makes me ve-ry an-gry!" <huff, huff>'
+  end
+
+  it "does not require padding" do
+    Base64.urlsafe_decode64("MQ").should == "1"
+  end
+end

--- a/spec/library/base64/urlsafe_decode64_spec.rb
+++ b/spec/library/base64/urlsafe_decode64_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../spec_helper'
 
 require 'base64'
 
-describe "Base64#urlsafe_decode64" do
+xdescribe "Base64#urlsafe_decode64" do
   it "uses '_' instead of '/'" do
     decoded = Base64.urlsafe_decode64("V2hlcmUgYW0gST8gV2hvIGFtIEk_IEFtIEk_IEk_")
     decoded.should == 'Where am I? Who am I? Am I? I?'

--- a/spec/library/base64/urlsafe_encode64_spec.rb
+++ b/spec/library/base64/urlsafe_encode64_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../../spec_helper'
+
+require 'base64'
+
+describe "Base64#urlsafe_encode64" do
+  it "uses '_' instead of '/'" do
+    encoded = Base64.urlsafe_encode64('Where am I? Who am I? Am I? I?')
+    encoded.should == "V2hlcmUgYW0gST8gV2hvIGFtIEk_IEFtIEk_IEk_"
+  end
+
+  it "uses '-' instead of '+'" do
+    encoded = Base64.urlsafe_encode64('"Being disintegrated makes me ve-ry an-gry!" <huff, huff>')
+    encoded.should == 'IkJlaW5nIGRpc2ludGVncmF0ZWQgbWFrZXMgbWUgdmUtcnkgYW4tZ3J5ISIgPGh1ZmYsIGh1ZmY-'
+  end
+
+  it "makes padding optional" do
+    Base64.urlsafe_encode64("1", padding: false).should == "MQ"
+    Base64.urlsafe_encode64("1").should == "MQ=="
+  end
+end

--- a/spec/library/base64/urlsafe_encode64_spec.rb
+++ b/spec/library/base64/urlsafe_encode64_spec.rb
@@ -3,17 +3,17 @@ require_relative '../../spec_helper'
 require 'base64'
 
 describe "Base64#urlsafe_encode64" do
-  it "uses '_' instead of '/'" do
+  xit "uses '_' instead of '/'" do
     encoded = Base64.urlsafe_encode64('Where am I? Who am I? Am I? I?')
     encoded.should == "V2hlcmUgYW0gST8gV2hvIGFtIEk_IEFtIEk_IEk_"
   end
 
-  it "uses '-' instead of '+'" do
+  xit "uses '-' instead of '+'" do
     encoded = Base64.urlsafe_encode64('"Being disintegrated makes me ve-ry an-gry!" <huff, huff>')
     encoded.should == 'IkJlaW5nIGRpc2ludGVncmF0ZWQgbWFrZXMgbWUgdmUtcnkgYW4tZ3J5ISIgPGh1ZmYsIGh1ZmY-'
   end
 
-  it "makes padding optional" do
+  xit "makes padding optional" do
     Base64.urlsafe_encode64("1", padding: false).should == "MQ"
     Base64.urlsafe_encode64("1").should == "MQ=="
   end


### PR DESCRIPTION
This pull requests lays the groundwork for the Base64 module.

Both the Base64#encode_64 and Base64#strict_encode64 methods are spec-compliant (minus encoding tests). The Base64#urlsafe_encode64 method needs some work still.

NOTE: This code could definitely be optimised a little too, i.e. global arrays etc.

I've also started work on Array.pack("m") which made implementing this module very simple. At the time of writing this PR description, 11 tests in the m_spec.rb file are now passing!

**TODO:**
* [ ] Implement `urlsafe_encode64`
* [ ] Implement `decode64`
* [ ] Implement `strict_decode64`
* [ ] Implement `urlsafe_decode64`

Implementing the `decode*` methods will also mark the beginnings of `String.unpack`!

(Re-open of #513)