### PR TITLE
Parser: fix multi-assign that includes attribute assignment

### DIFF
--- a/include/natalie_parser/node.hpp
+++ b/include/natalie_parser/node.hpp
@@ -18,7 +18,6 @@ public:
         Array,
         ArrayPattern,
         Assignment,
-        AttrAssign,
         Begin,
         BeginRescue,
         Block,
@@ -547,17 +546,6 @@ public:
 protected:
     Node *m_condition { nullptr };
     BlockNode *m_body { nullptr };
-};
-
-class AttrAssignNode : public CallNode {
-public:
-    AttrAssignNode(const Token &token, Node *receiver, SharedPtr<String> message)
-        : CallNode { token, receiver, message } { }
-
-    AttrAssignNode(const Token &token, CallNode &node)
-        : CallNode { token, node } { }
-
-    virtual Type type() override { return Type::AttrAssign; }
 };
 
 class SafeCallNode : public CallNode {

--- a/src/natalie_parser/node.cpp
+++ b/src/natalie_parser/node.cpp
@@ -52,6 +52,7 @@ void MultipleAssignmentNode::add_locals(TM::Hashmap<const char *> &locals) {
             identifier->add_to_locals(locals);
             break;
         }
+        case Node::Type::Call:
         case Node::Type::Colon2:
         case Node::Type::Colon3:
         case Node::Type::Splat:

--- a/src/natalie_parser/parser.cpp
+++ b/src/natalie_parser/parser.cpp
@@ -1478,6 +1478,7 @@ Node *Parser::parse_assignment_expression(Node *left, LocalsHashmap &locals, boo
         auto value = parse_assignment_expression_value(false, locals, allow_multiple);
         return new AssignmentNode { token, left, value };
     }
+    case Node::Type::Call:
     case Node::Type::Colon2:
     case Node::Type::Colon3: {
         advance();
@@ -1489,20 +1490,6 @@ Node *Parser::parse_assignment_expression(Node *left, LocalsHashmap &locals, boo
         advance();
         auto value = parse_assignment_expression_value(true, locals, allow_multiple);
         return new AssignmentNode { token, left, value };
-    }
-    case Node::Type::Call: {
-        advance();
-        auto attr_assign_node = new AttrAssignNode { token, *static_cast<CallNode *>(left) };
-        if (*attr_assign_node->message() == "[]") {
-            attr_assign_node->set_message(new String("[]="));
-            attr_assign_node->add_arg(parse_assignment_expression_value(false, locals, allow_multiple));
-        } else {
-            auto message = attr_assign_node->message();
-            message->append_char('=');
-            attr_assign_node->set_message(message);
-            attr_assign_node->add_arg(parse_assignment_expression_value(false, locals, allow_multiple));
-        }
-        return attr_assign_node;
     }
     default:
         throw_unexpected(left->token(), "left side of assignment");

--- a/test/natalie/parser_test.rb
+++ b/test/natalie/parser_test.rb
@@ -219,6 +219,8 @@ describe 'Parser' do
         Parser.parse('A, B::C = 1, 2').should == s(:block, s(:masgn, s(:array, s(:cdecl, :A), s(:const, s(:colon2, s(:const, :B), :C))), s(:array, s(:lit, 1), s(:lit, 2))))
         Parser.parse('A, ::B = 1, 2').should == s(:block, s(:masgn, s(:array, s(:cdecl, :A), s(:const, s(:colon3, :B))), s(:array, s(:lit, 1), s(:lit, 2))))
       end
+      Parser.parse('a.b, c = 1, 2').should == s(:block, s(:masgn, s(:array, s(:attrasgn, s(:call, nil, :a), :b=), s(:lasgn, :c)), s(:array, s(:lit, 1), s(:lit, 2))))
+      Parser.parse('a, b.c = 1, 2').should == s(:block, s(:masgn, s(:array, s(:lasgn, :a), s(:attrasgn, s(:call, nil, :b), :c=)), s(:array, s(:lit, 1), s(:lit, 2))))
     end
 
     it 'parses attr assignment' do


### PR DESCRIPTION
For example:

```rb
a.b, c = 1, 2
```