### PR TITLE
Parser: fix multi-assign that includes splat attr assignment

### DIFF
--- a/include/natalie_parser/node.hpp
+++ b/include/natalie_parser/node.hpp
@@ -69,7 +69,6 @@ public:
         Self,
         Shell,
         Splat,
-        SplatAssignment,
         SplatValue,
         StabbyProc,
         String,
@@ -1336,29 +1335,6 @@ public:
 
 protected:
     SharedPtr<String> m_string {};
-};
-
-class SplatAssignmentNode : public Node {
-public:
-    SplatAssignmentNode(const Token &token)
-        : Node { token } { }
-
-    SplatAssignmentNode(const Token &token, IdentifierNode *node)
-        : Node { token }
-        , m_node { node } {
-        assert(m_node);
-    }
-
-    ~SplatAssignmentNode() {
-        delete m_node;
-    }
-
-    virtual Type type() override { return Type::SplatAssignment; }
-
-    IdentifierNode *node() const { return m_node; }
-
-protected:
-    IdentifierNode *m_node { nullptr };
 };
 
 class SplatNode : public Node {

--- a/src/natalie_parser/node.cpp
+++ b/src/natalie_parser/node.cpp
@@ -55,12 +55,13 @@ void MultipleAssignmentNode::add_locals(TM::Hashmap<const char *> &locals) {
         case Node::Type::Call:
         case Node::Type::Colon2:
         case Node::Type::Colon3:
-        case Node::Type::Splat:
             break;
-        case Node::Type::SplatAssignment: {
-            auto splat = static_cast<SplatAssignmentNode *>(node);
-            if (splat->node())
-                splat->node()->add_to_locals(locals);
+        case Node::Type::Splat: {
+            auto splat = static_cast<SplatNode *>(node);
+            if (splat->node() && splat->node()->type() == Node::Type::Identifier) {
+                auto identifier = static_cast<IdentifierNode *>(splat->node());
+                identifier->add_to_locals(locals);
+            }
             break;
         }
         case Node::Type::MultipleAssignment:

--- a/src/natalie_parser/parser.cpp
+++ b/src/natalie_parser/parser.cpp
@@ -708,12 +708,9 @@ Node *Parser::parse_multiple_assignment_expression(Node *left, LocalsHashmap &lo
         case Token::Type::Multiply: {
             auto splat_token = current_token();
             advance();
-            ArgNode *n;
             if (current_token().is_assignable()) {
-                auto identifier = static_cast<IdentifierNode *>(parse_identifier(locals));
-                identifier->set_is_lvar(true);
-                list->add_node(new SplatAssignmentNode { splat_token, identifier });
-                identifier->add_to_locals(locals);
+                auto node = parse_expression(Precedence::ASSIGNMENTIDENTIFIER, locals);
+                list->add_node(new SplatNode { splat_token, node });
             } else {
                 list->add_node(new SplatNode { splat_token });
             }

--- a/test/natalie/parser_test.rb
+++ b/test/natalie/parser_test.rb
@@ -221,6 +221,9 @@ describe 'Parser' do
       end
       Parser.parse('a.b, c = 1, 2').should == s(:block, s(:masgn, s(:array, s(:attrasgn, s(:call, nil, :a), :b=), s(:lasgn, :c)), s(:array, s(:lit, 1), s(:lit, 2))))
       Parser.parse('a, b.c = 1, 2').should == s(:block, s(:masgn, s(:array, s(:lasgn, :a), s(:attrasgn, s(:call, nil, :b), :c=)), s(:array, s(:lit, 1), s(:lit, 2))))
+      Parser.parse('*a, b = 1, 2').should == s(:block, s(:masgn, s(:array, s(:splat, s(:lasgn, :a)), s(:lasgn, :b)), s(:array, s(:lit, 1), s(:lit, 2))))
+      Parser.parse('*a.b, c = 1, 2').should == s(:block, s(:masgn, s(:array, s(:splat, s(:attrasgn, s(:call, nil, :a), :b=)), s(:lasgn, :c)), s(:array, s(:lit, 1), s(:lit, 2))))
+      Parser.parse('a, *b.c = 1, 2').should == s(:block, s(:masgn, s(:array, s(:lasgn, :a), s(:splat, s(:attrasgn, s(:call, nil, :b), :c=))), s(:array, s(:lit, 1), s(:lit, 2))))
     end
 
     it 'parses attr assignment' do


### PR DESCRIPTION
For example:

```rb
*a.b, c = 1, 2
```