### PR TITLE
Make `String#clear` spec-compliant

### DIFF
--- a/include/natalie/string_object.hpp
+++ b/include/natalie/string_object.hpp
@@ -158,6 +158,7 @@ public:
     Value bytes(Env *, Block *);
     Value center(Env *, Value, Value);
     Value chr(Env *);
+    Value clear(Env *);
     Value cmp(Env *, Value) const;
     Value concat(Env *env, size_t argc, Value *args);
     Value downcase(Env *);

--- a/lib/natalie/compiler/binding_gen.rb
+++ b/lib/natalie/compiler/binding_gen.rb
@@ -841,6 +841,7 @@ gen.binding('String', 'bytesize', 'StringObject', 'bytesize', argc: 0, pass_env:
 gen.binding('String', 'center', 'StringObject', 'center', argc: 1..2, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('String', 'chars', 'StringObject', 'chars', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('String', 'chr', 'StringObject', 'chr', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
+gen.binding('String', 'clear', 'StringObject', 'clear', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('String', 'concat', 'StringObject', 'concat', argc: :any, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('String', 'downcase', 'StringObject', 'downcase', argc: 0, pass_env: true, pass_block: false, return_type: :Object)
 gen.binding('String', 'each_byte', 'StringObject', 'each_byte', argc: 0, pass_env: true, pass_block: true, return_type: :Object)

--- a/spec/core/string/clear_spec.rb
+++ b/spec/core/string/clear_spec.rb
@@ -1,0 +1,37 @@
+require_relative '../../spec_helper'
+
+describe "String#clear" do
+  before :each do
+    @s = "Jolene"
+  end
+
+  it "sets self equal to the empty String" do
+    @s.clear
+    @s.should == ""
+  end
+
+  it "returns self after emptying it" do
+    cleared = @s.clear
+    cleared.should == ""
+    cleared.should equal @s
+  end
+
+  it "preserves its encoding" do
+    @s.encode!(Encoding::SHIFT_JIS)
+    @s.encoding.should == Encoding::SHIFT_JIS
+    @s.clear.encoding.should == Encoding::SHIFT_JIS
+    @s.encoding.should == Encoding::SHIFT_JIS
+  end
+
+  it "works with multibyte Strings" do
+    s = "\u{9765}\u{876}"
+    s.clear
+    s.should == ""
+  end
+
+  it "raises a FrozenError if self is frozen" do
+    @s.freeze
+    -> { @s.clear        }.should raise_error(FrozenError)
+    -> { "".freeze.clear }.should raise_error(FrozenError)
+  end
+end

--- a/spec/core/string/clear_spec.rb
+++ b/spec/core/string/clear_spec.rb
@@ -16,7 +16,8 @@ describe "String#clear" do
     cleared.should equal @s
   end
 
-  it "preserves its encoding" do
+  # NATFIXME: Add back once we have encoding.
+  xit "preserves its encoding" do
     @s.encode!(Encoding::SHIFT_JIS)
     @s.encoding.should == Encoding::SHIFT_JIS
     @s.clear.encoding.should == Encoding::SHIFT_JIS

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -286,6 +286,10 @@ Value StringObject::mul(Env *env, Value arg) const {
 }
 
 Value StringObject::clear(Env *env) {
+    assert_not_frozen(env);
+    
+    m_string.clear();
+
     return this;
 }
 

--- a/src/string_object.cpp
+++ b/src/string_object.cpp
@@ -285,6 +285,10 @@ Value StringObject::mul(Env *env, Value arg) const {
     return new_string;
 }
 
+Value StringObject::clear(Env *env) {
+    return this;
+}
+
 Value StringObject::cmp(Env *env, Value other) const {
     if (other->type() != Object::Type::String) return NilObject::the();
     auto *str = c_str();


### PR DESCRIPTION
Encoding problems skipped for now.

#217.